### PR TITLE
feat: hashline edit mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.1.1"
+version = "0.2.0"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,44 @@ tilth install cursor  # or windsurf, claude-code, vscode, claude-desktop
 
 Five tools over JSON-RPC stdio: `tilth_read`, `tilth_search`, `tilth_files`, `tilth_map`, `tilth_session`. One persistent process, grammars loaded once, shared cache. Server instructions are sent to the LLM automatically during initialization.
 
+### Edit mode
+
+Add `--edit` during install to enable hash-anchored file editing:
+
+```bash
+tilth install claude-code --edit
+tilth install cursor --edit
+```
+
+This registers tilth with `["--mcp", "--edit"]` in your MCP config. It adds a sixth tool (`tilth_edit`) and switches `tilth_read` to hashline output — every line tagged with a content hash:
+
+```
+42:a3f|  let x = compute();
+43:f1b|  return x;
+```
+
+The `line:hash` before the `|` is the anchor. `tilth_edit` uses these to apply verified edits — if the file changed since the last read, the hashes won't match and the edit is rejected with current content shown:
+
+```json
+{
+  "path": "src/auth.ts",
+  "edits": [
+    { "start": "42:a3f", "content": "  let x = recompute();" },
+    { "start": "44:b2c", "end": "46:e1d", "content": "" }
+  ]
+}
+```
+
+For large files, `tilth_read` still returns an outline first. Use `section` to get hashlined content for the lines you need to edit.
+
+To install without edit mode (read-only, no `tilth_edit`):
+
+```bash
+tilth install claude-code
+```
+
+Inspired by [The Harness Problem](https://blog.can.ac/2026/02/12/the-harness-problem/) — the insight that LLM coding performance can be bottlenecked by the edit interface, not model capability.
+
 Or call the CLI from bash — every agent framework has a shell tool. Add this to your agent prompt:
 
 ```

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,0 +1,204 @@
+use std::fs;
+use std::path::Path;
+
+use crate::error::TilthError;
+use crate::format;
+
+/// A single edit operation targeting a line range by hash anchors.
+#[derive(Debug, Clone)]
+pub struct Edit {
+    pub start_line: usize,
+    pub start_hash: u16,
+    pub end_line: usize,
+    pub end_hash: u16,
+    pub content: String,
+}
+
+/// Result of applying edits to a file.
+#[derive(Debug)]
+pub enum EditResult {
+    /// All edits applied. Contains hashlined context around edit sites.
+    Applied(String),
+    /// One or more hashes didn't match current content.
+    HashMismatch(String),
+}
+
+/// Apply a batch of edits to a file.
+///
+/// 1. Read file into lines
+/// 2. Verify ALL hashes before applying ANY edit (fail-fast)
+/// 3. Sort edits by `start_line` descending (reverse preserves line numbers)
+/// 4. Splice replacements
+/// 5. Write file
+/// 6. Return hashlined context around edit sites
+pub fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
+    if edits.is_empty() {
+        return Ok(EditResult::Applied(String::new()));
+    }
+
+    // Read file
+    let content = fs::read_to_string(path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => TilthError::NotFound {
+            path: path.to_path_buf(),
+            suggestion: None,
+        },
+        std::io::ErrorKind::PermissionDenied => TilthError::PermissionDenied {
+            path: path.to_path_buf(),
+        },
+        _ => TilthError::IoError {
+            path: path.to_path_buf(),
+            source: e,
+        },
+    })?;
+
+    let lines: Vec<&str> = content.lines().collect();
+    let total = lines.len();
+
+    // Phase 1: Verify all hashes
+    let mut mismatches: Vec<String> = Vec::new();
+
+    for edit in edits {
+        // Bounds check
+        if edit.start_line < 1 || edit.start_line > total {
+            mismatches.push(format!(
+                "Line {} out of bounds (file has {} lines)",
+                edit.start_line, total
+            ));
+            continue;
+        }
+        if edit.end_line < 1 || edit.end_line > total {
+            mismatches.push(format!(
+                "Line {} out of bounds (file has {} lines)",
+                edit.end_line, total
+            ));
+            continue;
+        }
+        if edit.end_line < edit.start_line {
+            mismatches.push(format!(
+                "Invalid range: {}-{} (end < start)",
+                edit.start_line, edit.end_line
+            ));
+            continue;
+        }
+
+        // Verify start hash
+        let start_idx = edit.start_line - 1;
+        let start_actual_hash = format::line_hash(lines[start_idx].as_bytes());
+        if start_actual_hash != edit.start_hash {
+            let context_start = start_idx.saturating_sub(2);
+            let context_end = (start_idx + 3).min(total);
+            let context_lines: String = lines[context_start..context_end].join("\n");
+            let hashlined = format::hashlines(&context_lines, (context_start + 1) as u32);
+            mismatches.push(format!(
+                "Hash mismatch at line {} (expected {:03x}, got {:03x}):\n{}",
+                edit.start_line, edit.start_hash, start_actual_hash, hashlined
+            ));
+            continue;
+        }
+
+        // Verify end hash if different line
+        if edit.end_line != edit.start_line {
+            let end_idx = edit.end_line - 1;
+            let end_actual_hash = format::line_hash(lines[end_idx].as_bytes());
+            if end_actual_hash != edit.end_hash {
+                let context_start = end_idx.saturating_sub(2);
+                let context_end = (end_idx + 3).min(total);
+                let context_lines: String = lines[context_start..context_end].join("\n");
+                let hashlined = format::hashlines(&context_lines, (context_start + 1) as u32);
+                mismatches.push(format!(
+                    "Hash mismatch at line {} (expected {:03x}, got {:03x}):\n{}",
+                    edit.end_line, edit.end_hash, end_actual_hash, hashlined
+                ));
+            }
+        }
+    }
+
+    if !mismatches.is_empty() {
+        return Ok(EditResult::HashMismatch(mismatches.join("\n\n")));
+    }
+
+    // Check for overlapping ranges
+    let mut range_check: Vec<(usize, usize)> =
+        edits.iter().map(|e| (e.start_line, e.end_line)).collect();
+    range_check.sort_by_key(|&(s, _)| s);
+    for pair in range_check.windows(2) {
+        if pair[0].1 >= pair[1].0 {
+            return Err(TilthError::InvalidQuery {
+                query: format!(
+                    "lines {}-{} and {}-{}",
+                    pair[0].0, pair[0].1, pair[1].0, pair[1].1
+                ),
+                reason: "overlapping edit ranges in batch".into(),
+            });
+        }
+    }
+
+    // Phase 2: Apply edits in reverse order
+    let mut indices: Vec<usize> = (0..edits.len()).collect();
+    indices.sort_by_key(|&i| std::cmp::Reverse(edits[i].start_line));
+
+    let mut owned: Vec<String> = lines.iter().map(|&s| s.to_string()).collect();
+
+    for &idx in &indices {
+        let edit = &edits[idx];
+        let start_idx = edit.start_line - 1;
+        let end_idx = edit.end_line; // exclusive end for inclusive range
+
+        let replacement: Vec<String> = if edit.content.is_empty() {
+            vec![]
+        } else {
+            edit.content.lines().map(String::from).collect()
+        };
+
+        owned.splice(start_idx..end_idx, replacement);
+    }
+
+    // Phase 3: Write file, preserving original line ending style
+    let line_sep = if content.contains("\r\n") {
+        "\r\n"
+    } else {
+        "\n"
+    };
+    let has_trailing_newline = content.ends_with('\n');
+    let mut output = owned.join(line_sep);
+    if has_trailing_newline {
+        output.push_str(line_sep);
+    }
+
+    fs::write(path, &output).map_err(|e| TilthError::IoError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+
+    // Phase 4: Build response with context around each edit site.
+    // Edits were applied in reverse order, so lower-numbered edits shift
+    // the positions of higher-numbered ones. Track cumulative offset.
+    let mut ctx_order: Vec<usize> = (0..edits.len()).collect();
+    ctx_order.sort_by_key(|&i| edits[i].start_line);
+
+    let mut offset: isize = 0;
+    let mut contexts: Vec<String> = Vec::new();
+
+    for &idx in &ctx_order {
+        let edit = &edits[idx];
+        let adjusted = ((edit.start_line as isize - 1) + offset).max(0) as usize;
+        let old_count = edit.end_line - edit.start_line + 1;
+        let new_count = if edit.content.is_empty() {
+            0
+        } else {
+            edit.content.lines().count()
+        };
+
+        let context_start = adjusted.saturating_sub(5);
+        let context_end = (adjusted + new_count + 5).min(owned.len());
+        if context_start < context_end {
+            let context_lines: String = owned[context_start..context_end].join("\n");
+            let hashlined = format::hashlines(&context_lines, (context_start + 1) as u32);
+            contexts.push(hashlined);
+        }
+
+        offset += new_count as isize - old_count as isize;
+    }
+
+    Ok(EditResult::Applied(contexts.join("\n---\n")))
+}

--- a/src/format.rs
+++ b/src/format.rs
@@ -67,3 +67,43 @@ pub fn number_lines(content: &str, start: u32) -> String {
     }
     out
 }
+
+// ---------------------------------------------------------------------------
+// Hashline support (edit mode)
+// ---------------------------------------------------------------------------
+
+/// FNV-1a hash of a line, truncated to 12 bits (3 hex chars).
+/// Used as a per-line content checksum for edit-mode anchors.
+pub(crate) fn line_hash(bytes: &[u8]) -> u16 {
+    let mut h: u32 = 0x811c_9dc5;
+    for &b in bytes {
+        h ^= u32::from(b);
+        h = h.wrapping_mul(0x0100_0193);
+    }
+    (h & 0xFFF) as u16
+}
+
+/// Format lines with hashline anchors: `{line}:{hash}|{content}`
+/// Used in edit mode so the agent can reference lines by content hash.
+pub fn hashlines(content: &str, start: u32) -> String {
+    let lines: Vec<&str> = content.lines().collect();
+    let mut out = String::with_capacity(content.len() + lines.len() * 8);
+    for (i, line) in lines.iter().enumerate() {
+        let num = start as usize + i;
+        let hash = line_hash(line.as_bytes());
+        let _ = writeln!(out, "{num}:{hash:03x}|{line}");
+    }
+    out
+}
+
+/// Parse a hashline anchor `"42:a3f"` into `(line_number, hash)`.
+/// Inverse of the format produced by [`hashlines`].
+pub(crate) fn parse_anchor(s: &str) -> Option<(usize, u16)> {
+    let (line_str, hash_str) = s.split_once(':')?;
+    let line: usize = line_str.trim().parse().ok()?;
+    if line == 0 {
+        return None; // 1-indexed
+    }
+    let hash = u16::from_str_radix(hash_str.trim(), 16).ok()?;
+    Some((line, hash))
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@
 pub(crate) mod budget;
 pub mod cache;
 pub(crate) mod classify;
+pub(crate) mod edit;
 pub mod error;
 pub(crate) mod format;
 pub mod install;
@@ -67,7 +68,7 @@ fn run_inner(
     let query_type = classify(query, scope);
 
     let output = match query_type {
-        QueryType::FilePath(path) => read::read_file(&path, section, full, cache)?,
+        QueryType::FilePath(path) => read::read_file(&path, section, full, cache, false)?,
 
         QueryType::Glob(pattern) => search::search_glob(&pattern, scope, cache)?,
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,6 +40,10 @@ struct Cli {
     #[arg(long)]
     mcp: bool,
 
+    /// Enable edit mode: hashline output + tilth_edit tool.
+    #[arg(long)]
+    edit: bool,
+
     /// Generate a structural codebase map.
     #[arg(long)]
     map: bool,
@@ -56,6 +60,10 @@ enum Command {
     Install {
         /// MCP host to configure.
         host: String,
+
+        /// Enable edit mode (hashline output + tilth_edit tool).
+        #[arg(long)]
+        edit: bool,
     },
 }
 
@@ -71,8 +79,8 @@ fn main() {
     // Subcommands
     if let Some(cmd) = cli.command {
         match cmd {
-            Command::Install { ref host } => {
-                if let Err(e) = tilth::install::run(host) {
+            Command::Install { ref host, edit } => {
+                if let Err(e) = tilth::install::run(host, edit) {
                     eprintln!("install error: {e}");
                     process::exit(1);
                 }
@@ -83,7 +91,7 @@ fn main() {
 
     // MCP mode: JSON-RPC server
     if cli.mcp {
-        if let Err(e) = tilth::mcp::run() {
+        if let Err(e) = tilth::mcp::run(cli.edit) {
             eprintln!("mcp error: {e}");
             process::exit(1);
         }


### PR DESCRIPTION
## Summary

- Adds `--edit` flag to the MCP server that enables hash-anchored file editing
- When active, `tilth_read` tags every line with a 3-char FNV-1a content hash: `42:a3f|code here`
- New `tilth_edit` tool accepts edits referencing these hash anchors, verifying the file hasn't changed since last read
- Server instructions tell the model to prefer tilth tools for the full read→edit workflow
- Version bump to 0.2.0

## How it works

```
# Read (edit mode)
tilth_read → "42:a3f|  let x = 1;"

# Edit (references the hash)
tilth_edit(path, edits: [{ start: "42:a3f", content: "  let x = 2;" }])

# Stale hash? Rejected with current content shown.
```

## Design decisions

- **Opt-in via `--edit` flag** — set once in MCP config, no per-call ceremony
- **Conditional tool registration** — `tilth_edit` only appears when edit mode is on
- **All-or-nothing hash verification** — reject entire batch if any hash mismatches
- **Reverse-order application** — edits sorted descending so line numbers stay valid
- **Zero new dependencies** — FNV-1a is 5 lines inline

## Files changed

| File | What |
|---|---|
| `src/format.rs` | `line_hash()`, `hashlines()`, `parse_anchor()` |
| `src/edit.rs` | **NEW** — `Edit`, `EditResult`, `apply_edits()` |
| `src/read/mod.rs` | Thread `edit_mode`, conditional hashline output |
| `src/lib.rs` | Register edit module |
| `src/mcp.rs` | `tool_edit()`, conditional tools/instructions |
| `src/main.rs` | `--edit` CLI flag |
| `Cargo.toml` | Version 0.2.0 |
| `npm/package.json` | Version 0.2.0 |

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — all pass
- [x] Edit mode: `tilth_edit` appears in tools/list, instructions mention edit workflow
- [x] Normal mode: 5 tools, original instructions unchanged
- [x] Hashline read: `42:a3f|content` format
- [x] Single-line edit with correct hash — applied
- [x] Multi-line range replacement — applied
- [x] Stale hash — rejected with `isError: true` and current content

## Release

After merge: tag `v0.2.0` on main → triggers release workflow → builds + crates.io publish → then npm publish.

Inspired by [The Harness Problem](https://blog.can.ac/2026/02/12/the-harness-problem/).

🤖 Generated with [Claude Code](https://claude.com/claude-code)