### PR TITLE
feat: add Nix flake for building and running tilth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 # Build artifacts
 /target
+/result
+/result-*
 
 # Internal docs (reviews, feedback, specs)
 /docs

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1770843696,
+        "narHash": "sha256-LovWTGDwXhkfCOmbgLVA10bvsi/P8eDDpRudgk68HA8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2343bbb58f99267223bc2aac4fc9ea301a155a16",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,55 @@
+{
+  description = "tilth — tree-sitter indexed lookups — smart code reading for AI agents";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems =
+        f:
+        lib.genAttrs [
+          "aarch64-darwin"
+          "aarch64-linux"
+          "x86_64-darwin"
+          "x86_64-linux"
+        ] (system: f system nixpkgs.legacyPackages.${system});
+      cargoToml = lib.importTOML ./Cargo.toml;
+    in
+    {
+      packages = forAllSystems (
+        system: pkgs: {
+          default = pkgs.rustPlatform.buildRustPackage {
+            pname = cargoToml.package.name;
+            inherit (cargoToml.package) version;
+            src = ./.;
+            cargoLock.lockFile = ./Cargo.lock;
+            meta = {
+              description = "Tree-sitter indexed lookups — smart code reading for AI agents";
+              homepage = "https://github.com/jahala/tilth";
+              license = lib.licenses.mit;
+              mainProgram = "tilth";
+            };
+          };
+        }
+      );
+
+      apps = forAllSystems (
+        system: _: {
+          default = {
+            type = "app";
+            program = lib.getExe self.packages.${system}.default;
+          };
+        }
+      );
+
+      devShells = forAllSystems (
+        system: pkgs: {
+          default = pkgs.mkShell {
+            inputsFrom = [ self.packages.${system}.default ];
+          };
+        }
+      );
+    };
+}


### PR DESCRIPTION
Add a Nix flake with nixpkgs as the sole input. The version and package name are read from Cargo.toml via lib.importTOML so they stay in sync automatically.

What you can do (check out this PR first obviously)

build `tilth`:
```
nix build
```

Run it directly (no install!)
```
nix run github:philiptaron/tilth -- src/main.rs
```

Enter a shell with it
```
nix shell github:philiptaron/tilth
```

Enter a dev shell with the Rust toolchain (no install needed!)
```
nix develop github:philiptaron/tilth
```