### PR TITLE
Read meta.description from Cargo.toml

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
             src = ./.;
             cargoLock.lockFile = ./Cargo.lock;
             meta = {
-              description = "Tree-sitter indexed lookups — smart code reading for AI agents";
+              inherit (cargoToml.package) description;
               homepage = "https://github.com/jahala/tilth";
               license = lib.licenses.mit;
               mainProgram = "tilth";


### PR DESCRIPTION
## Summary
- Use `inherit (cargoToml.package) description` in the flake's meta block instead of a hardcoded string
- Keeps the Nix package description in sync with Cargo.toml, matching how `pname` and `version` are already handled

## Verify

```
nix eval github:philiptaron/tilth/philiptaron/flake-meta-from-cargo#packages.x86_64-linux.default.meta.description
```