### PR TITLE
feat: add OpenCode as supported MCP host

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ tilth install cursor           # ~/.cursor/mcp.json
 tilth install windsurf         # ~/.codeium/windsurf/mcp_config.json
 tilth install vscode           # .vscode/mcp.json (project scope)
 tilth install claude-desktop
+tilth install opencode         # ~/.opencode.json
 ```
 
 Add `--edit` to enable hash-anchored file editing (see [Edit mode](#edit-mode)):

--- a/src/install.rs
+++ b/src/install.rs
@@ -11,12 +11,14 @@ use serde_json::{json, Value};
 //   windsurf:       ~/.codeium/windsurf/mcp_config.json       (global)
 //   vscode:         .vscode/mcp.json                          (project scope)
 //   claude-desktop: ~/Library/Application Support/Claude/...  (global)
+//   opencode:       ~/.opencode.json                          (user scope)
 const SUPPORTED_HOSTS: &[&str] = &[
     "claude-code",
     "cursor",
     "windsurf",
     "vscode",
     "claude-desktop",
+    "opencode",
 ];
 
 /// The tilth server entry injected into each host config.
@@ -148,6 +150,14 @@ fn resolve_host(host: &str) -> Result<HostInfo, String> {
             path: claude_desktop_path()?,
             servers_key: "mcpServers",
             note: None,
+        }),
+
+        // OpenCode user scope: ~/.opencode.json → mcpServers
+        // Verified from opencode source: internal/config/config.go (viper config name ".opencode")
+        "opencode" => Ok(HostInfo {
+            path: home.join(".opencode.json"),
+            servers_key: "mcpServers",
+            note: Some("User scope — available in all projects."),
         }),
 
         _ => Err(format!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,7 +56,7 @@ struct Cli {
 #[derive(clap::Subcommand)]
 enum Command {
     /// Install tilth into an MCP host's config.
-    /// Supported hosts: claude-code, cursor, windsurf, vscode, claude-desktop
+    /// Supported hosts: claude-code, cursor, windsurf, vscode, claude-desktop, opencode
     Install {
         /// MCP host to configure.
         host: String,


### PR DESCRIPTION
## Summary
- Adds `tilth install opencode` — writes MCP config to `~/.opencode.json`
- Uses the standard `mcpServers` key with `command`/`args` format (same as claude-code, cursor, etc.)
- Config path and schema verified against [opencode source](https://github.com/opencode-ai/opencode/blob/main/internal/config/config.go) (`viper config name ".opencode"`) and [opencode-schema.json](https://github.com/opencode-ai/opencode/blob/main/opencode-schema.json)

Closes #11

## Changes
- `src/install.rs` — added `"opencode"` to `SUPPORTED_HOSTS` + match arm in `resolve_host()`
- `src/main.rs` — updated help text
- `README.md` — added `tilth install opencode` to install examples

## Test plan
- [ ] `cargo check` passes
- [ ] `tilth install --help` lists opencode
- [ ] `tilth install opencode` writes correct JSON to `~/.opencode.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)