### PR TITLE
fix: correct GitHub org in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-REPO="flysikring/tilth"
+REPO="jahala/tilth"
 OS=$(uname -s | tr '[:upper:]' '[:lower:]')
 ARCH=$(uname -m)
 case "$ARCH" in


### PR DESCRIPTION
## Summary

- Fix `REPO="flysikring/tilth"` → `REPO="jahala/tilth"` in install.sh
- Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)