### PR TITLE
feat: add glob filter to tilth_search

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,7 @@ Comma-separated symbols for multi-symbol lookup (max 5).
 kind: "symbol" (default) | "content" (strings/comments) | "callers" (call sites)
 expand (default 2): inline full source for top matches.
 context: path to file being edited — boosts nearby results.
+glob: file pattern filter — "*.rs" (whitelist), "!*.test.ts" (exclude), "*.{go,rs}" (multi).
 Output per match:
 ## <path>:<start>-<end> [definition|usage|impl]
 <outline context>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,9 +51,10 @@ pub fn run(
     scope: &Path,
     section: Option<&str>,
     budget_tokens: Option<u64>,
+    glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    run_inner(query, scope, section, budget_tokens, false, 0, cache)
+    run_inner(query, scope, section, budget_tokens, false, 0, glob, cache)
 }
 
 /// Full variant — forces full file output, bypassing smart views.
@@ -62,9 +63,10 @@ pub fn run_full(
     scope: &Path,
     section: Option<&str>,
     budget_tokens: Option<u64>,
+    glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    run_inner(query, scope, section, budget_tokens, true, 0, cache)
+    run_inner(query, scope, section, budget_tokens, true, 0, glob, cache)
 }
 
 /// Run with expanded search — inline source for top N matches.
@@ -75,9 +77,19 @@ pub fn run_expanded(
     budget_tokens: Option<u64>,
     full: bool,
     expand: usize,
+    glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    run_inner(query, scope, section, budget_tokens, full, expand, cache)
+    run_inner(
+        query,
+        scope,
+        section,
+        budget_tokens,
+        full,
+        expand,
+        glob,
+        cache,
+    )
 }
 
 /// Find all callers of a symbol.
@@ -86,13 +98,14 @@ pub fn run_callers(
     scope: &Path,
     expand: usize,
     budget_tokens: Option<u64>,
+    glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
     let session = session::Session::new();
     let bloom = index::bloom::BloomFilterCache::new();
     let expand = if expand > 0 { expand } else { 2 };
     let output = search::callers::search_callers_expanded(
-        target, scope, cache, &session, &bloom, expand, None,
+        target, scope, cache, &session, &bloom, expand, None, glob,
     )?;
     match budget_tokens {
         Some(b) => Ok(budget::apply(&output, b)),
@@ -120,6 +133,7 @@ fn run_inner(
     budget_tokens: Option<u64>,
     full: bool,
     expand: usize,
+    glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
     let query_type = classify(query, scope);
@@ -154,7 +168,7 @@ fn run_inner(
             let bloom = index::bloom::BloomFilterCache::new();
             let expand = if expand > 0 { expand } else { 2 };
             let output = search::search_multi_symbol_expanded(
-                &parts, scope, cache, &session, &sym_index, &bloom, expand, None,
+                &parts, scope, cache, &session, &sym_index, &bloom, expand, None, glob,
             )?;
             return match budget_tokens {
                 Some(b) => Ok(budget::apply(&output, b)),
@@ -189,9 +203,9 @@ fn run_inner(
                 bloom: index::bloom::BloomFilterCache::new(),
                 expand,
             };
-            run_query_expanded(&query_type, scope, cache, &ctx)?
+            run_query_expanded(&query_type, scope, cache, &ctx, glob)?
         }
-        _ => run_query_basic(&query_type, scope, cache)?,
+        _ => run_query_basic(&query_type, scope, cache, glob)?,
     };
 
     match budget_tokens {
@@ -207,6 +221,7 @@ fn run_query_expanded(
     scope: &Path,
     cache: &OutlineCache,
     ctx: &ExpandedCtx,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     match query_type {
         QueryType::Symbol(name) => search::search_symbol_expanded(
@@ -218,10 +233,17 @@ fn run_query_expanded(
             &ctx.bloom,
             ctx.expand,
             None,
+            glob,
         ),
-        QueryType::Concept(text) if text.contains(' ') => {
-            search::search_content_expanded(text, scope, cache, &ctx.session, ctx.expand, None)
-        }
+        QueryType::Concept(text) if text.contains(' ') => search::search_content_expanded(
+            text,
+            scope,
+            cache,
+            &ctx.session,
+            ctx.expand,
+            None,
+            glob,
+        ),
         // Single-word Concept and Fallthrough share the same expanded path:
         // both go straight to symbol_expanded, intentionally bypassing the
         // definitions>0 / content fallback cascade in single_query_search.
@@ -235,13 +257,26 @@ fn run_query_expanded(
             &ctx.bloom,
             ctx.expand,
             None,
+            glob,
         ),
-        QueryType::Content(text) => {
-            search::search_content_expanded(text, scope, cache, &ctx.session, ctx.expand, None)
-        }
-        QueryType::Regex(pattern) => {
-            search::search_regex_expanded(pattern, scope, cache, &ctx.session, ctx.expand, None)
-        }
+        QueryType::Content(text) => search::search_content_expanded(
+            text,
+            scope,
+            cache,
+            &ctx.session,
+            ctx.expand,
+            None,
+            glob,
+        ),
+        QueryType::Regex(pattern) => search::search_regex_expanded(
+            pattern,
+            scope,
+            cache,
+            &ctx.session,
+            ctx.expand,
+            None,
+            glob,
+        ),
         // FilePath/Glob never reach here (gated by use_expanded)
         QueryType::FilePath(_) | QueryType::Glob(_) => {
             unreachable!("non-search query type in expanded path")
@@ -255,21 +290,22 @@ fn run_query_basic(
     query_type: &QueryType,
     scope: &Path,
     cache: &OutlineCache,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     match query_type {
-        QueryType::Symbol(name) => search::search_symbol(name, scope, cache),
+        QueryType::Symbol(name) => search::search_symbol(name, scope, cache, glob),
         QueryType::Concept(text) if text.contains(' ') => {
-            multi_word_concept_search(text, scope, cache)
+            multi_word_concept_search(text, scope, cache, glob)
         }
         QueryType::Concept(text) => {
             // Single-word concept: prefer definitions, then content, then any match.
-            single_query_search(text, scope, cache, true)
+            single_query_search(text, scope, cache, true, glob)
         }
-        QueryType::Content(text) => search::search_content(text, scope, cache),
-        QueryType::Regex(pattern) => search::search_regex(pattern, scope, cache),
+        QueryType::Content(text) => search::search_content(text, scope, cache, glob),
+        QueryType::Regex(pattern) => search::search_regex(pattern, scope, cache, glob),
         QueryType::Fallthrough(text) => {
             // Accept any symbol match immediately (no definitions preference).
-            single_query_search(text, scope, cache, false)
+            single_query_search(text, scope, cache, false, glob)
         }
         // FilePath/Glob never reach here
         QueryType::FilePath(_) | QueryType::Glob(_) => {
@@ -288,8 +324,9 @@ fn single_query_search(
     scope: &Path,
     cache: &cache::OutlineCache,
     prefer_definitions: bool,
+    glob: Option<&str>,
 ) -> Result<String, error::TilthError> {
-    let sym_result = search::search_symbol_raw(text, scope)?;
+    let sym_result = search::search_symbol_raw(text, scope, glob)?;
     let accept_sym = if prefer_definitions {
         sym_result.definitions > 0
     } else {
@@ -300,7 +337,7 @@ fn single_query_search(
         return search::format_raw_result(&sym_result, cache);
     }
 
-    let content_result = search::search_content_raw(text, scope)?;
+    let content_result = search::search_content_raw(text, scope, glob)?;
     if content_result.total_found > 0 {
         return search::format_raw_result(&content_result, cache);
     }
@@ -321,9 +358,10 @@ fn multi_word_concept_search(
     text: &str,
     scope: &Path,
     cache: &cache::OutlineCache,
+    glob: Option<&str>,
 ) -> Result<String, error::TilthError> {
     // Try exact phrase match first
-    let mut content_result = search::search_content_raw(text, scope)?;
+    let mut content_result = search::search_content_raw(text, scope, glob)?;
     content_result.query = text.to_string();
     if content_result.total_found > 0 {
         return search::format_raw_result(&content_result, cache);
@@ -348,7 +386,7 @@ fn multi_word_concept_search(
             .join("|")
     };
 
-    let mut relaxed_result = search::search_regex_raw(&relaxed, scope)?;
+    let mut relaxed_result = search::search_regex_raw(&relaxed, scope, glob)?;
     relaxed_result.query = text.to_string();
     if relaxed_result.total_found > 0 {
         return search::format_raw_result(&relaxed_result, cache);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ struct Cli {
     #[arg(long, num_args = 0..=1, default_missing_value = "2", require_equals = true)]
     expand: Option<usize>,
 
+    /// File pattern filter (e.g. "*.rs", "!*.test.ts", "*.{go,rs}").
+    #[arg(long)]
+    glob: Option<String>,
+
     /// Find all callers of a symbol.
     #[arg(long, conflicts_with_all = ["deps", "map", "edit"])]
     callers: bool,
@@ -139,7 +143,14 @@ fn main() {
 
     // Callers mode
     if cli.callers {
-        let result = tilth::run_callers(&query, &scope, expand, cli.budget, &cache);
+        let result = tilth::run_callers(
+            &query,
+            &scope,
+            expand,
+            cli.budget,
+            cli.glob.as_deref(),
+            &cache,
+        );
         emit_result(result, &query, cli.json, is_tty);
         return;
     }
@@ -174,12 +185,27 @@ fn main() {
             cli.budget,
             full,
             expand,
+            cli.glob.as_deref(),
             &cache,
         )
     } else if full {
-        tilth::run_full(&query, &scope, cli.section.as_deref(), cli.budget, &cache)
+        tilth::run_full(
+            &query,
+            &scope,
+            cli.section.as_deref(),
+            cli.budget,
+            cli.glob.as_deref(),
+            &cache,
+        )
     } else {
-        tilth::run(&query, &scope, cli.section.as_deref(), cli.budget, &cache)
+        tilth::run(
+            &query,
+            &scope,
+            cli.section.as_deref(),
+            cli.budget,
+            cli.glob.as_deref(),
+            &cache,
+        )
     };
 
     emit_result(result, &query, cli.json, is_tty);

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -46,6 +46,7 @@ tilth_search: Search code — finds definitions, usages, and text. Replaces grep
   kind: \"symbol\" (default) | \"content\" (strings/comments) | \"callers\" (call sites)\n\
   expand (default 2): inline full source for top matches.\n\
   context: path to file being edited — boosts nearby results.\n\
+  glob: file pattern filter — \"*.rs\" (whitelist), \"!*.test.ts\" (exclude).\n\
   Output per match:\n\
     ## <path>:<start>-<end> [definition|usage|impl]\n\
     <outline context>\n\
@@ -359,6 +360,7 @@ fn tool_search(
         .and_then(|v| v.as_str())
         .map(PathBuf::from);
     let context = context_path.as_deref();
+    let glob = args.get("glob").and_then(|v| v.as_str());
     let budget = args.get("budget").and_then(serde_json::Value::as_u64);
 
     let output = match kind {
@@ -373,7 +375,7 @@ fn tool_search(
                 1 => {
                     session.record_search(queries[0]);
                     crate::search::search_symbol_expanded(
-                        queries[0], &scope, cache, session, index, bloom, expand, context,
+                        queries[0], &scope, cache, session, index, bloom, expand, context, glob,
                     )
                 }
                 2..=5 => {
@@ -381,7 +383,7 @@ fn tool_search(
                         session.record_search(q);
                     }
                     crate::search::search_multi_symbol_expanded(
-                        &queries, &scope, cache, session, index, bloom, expand, context,
+                        &queries, &scope, cache, session, index, bloom, expand, context, glob,
                     )
                 }
                 _ => {
@@ -394,18 +396,20 @@ fn tool_search(
         }
         "content" => {
             session.record_search(query);
-            crate::search::search_content_expanded(query, &scope, cache, session, expand, context)
+            crate::search::search_content_expanded(
+                query, &scope, cache, session, expand, context, glob,
+            )
         }
         "regex" => {
             session.record_search(query);
-            let result = crate::search::content::search(query, &scope, true, context)
+            let result = crate::search::content::search(query, &scope, true, context, glob)
                 .map_err(|e| e.to_string())?;
             crate::search::format_raw_result(&result, cache)
         }
         "callers" => {
             session.record_search(query);
             crate::search::callers::search_callers_expanded(
-                query, &scope, cache, session, bloom, expand, context,
+                query, &scope, cache, session, bloom, expand, context, glob,
             )
         }
         _ => {
@@ -744,6 +748,10 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "budget": {
                         "type": "number",
                         "description": "Max tokens in response."
+                    },
+                    "glob": {
+                        "type": "string",
+                        "description": "File pattern filter. Whitelist: \"*.rs\" (only Rust files). Exclude: \"!*.test.ts\" (skip test files). Brace expansion: \"*.{go,rs}\" (Go and Rust). Path patterns: \"src/**/*.ts\"."
                     }
                 }
             }

--- a/src/search/blast.rs
+++ b/src/search/blast.rs
@@ -82,7 +82,7 @@ pub(crate) fn blast_radius(
 
     let symbol_names: HashSet<String> = touched.iter().map(|t| t.name.clone()).collect();
 
-    let callers = find_callers_batch(&symbol_names, scope, bloom).ok()?;
+    let callers = find_callers_batch(&symbol_names, scope, bloom, None).ok()?;
 
     let canonical = path.canonicalize().ok()?;
     let callers: Vec<(String, CallerMatch)> = callers

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -45,12 +45,13 @@ pub fn find_callers(
     target: &str,
     scope: &Path,
     bloom: &crate::index::bloom::BloomFilterCache,
+    glob: Option<&str>,
 ) -> Result<Vec<CallerMatch>, TilthError> {
     let matches: Mutex<Vec<CallerMatch>> = Mutex::new(Vec::new());
     let found_count = AtomicUsize::new(0);
     let needle = target.as_bytes();
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, glob)?;
 
     walker.run(|| {
         let matches = &matches;
@@ -225,11 +226,12 @@ pub(crate) fn find_callers_batch(
     targets: &HashSet<String>,
     scope: &Path,
     bloom: &crate::index::bloom::BloomFilterCache,
+    glob: Option<&str>,
 ) -> Result<Vec<(String, CallerMatch)>, TilthError> {
     let matches: Mutex<Vec<(String, CallerMatch)>> = Mutex::new(Vec::new());
     let found_count = AtomicUsize::new(0);
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, glob)?;
 
     walker.run(|| {
         let matches = &matches;
@@ -478,8 +480,9 @@ pub fn search_callers_expanded(
     bloom: &crate::index::bloom::BloomFilterCache,
     expand: usize,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let callers = find_callers(target, scope, bloom)?;
+    let callers = find_callers(target, scope, bloom, glob)?;
 
     if callers.is_empty() {
         return Ok(format!(
@@ -562,7 +565,7 @@ pub fn search_callers_expanded(
     // Use all_caller_names (pre-truncation) for the fan-out threshold check,
     // but search for callers of the full set to capture transitive impact.
     if !all_caller_names.is_empty() && all_caller_names.len() <= IMPACT_FANOUT_THRESHOLD {
-        if let Ok(hop2) = find_callers_batch(&all_caller_names, scope, bloom) {
+        if let Ok(hop2) = find_callers_batch(&all_caller_names, scope, bloom, glob) {
             // Filter out hop-1 matches (same file+line = same call site)
             let hop1_locations: HashSet<(PathBuf, u32)> = sorted_callers
                 .iter()

--- a/src/search/content.rs
+++ b/src/search/content.rs
@@ -21,6 +21,7 @@ pub fn search(
     scope: &Path,
     is_regex: bool,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<SearchResult, TilthError> {
     let matcher = if is_regex {
         RegexMatcher::new(pattern)
@@ -37,7 +38,7 @@ pub fn search(
     // Early-quit checks are approximate by design — one extra iteration is harmless.
     let total_found = AtomicUsize::new(0);
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, glob)?;
 
     walker.run(|| {
         let matcher = &matcher;

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -175,7 +175,7 @@ pub fn analyze_deps(
 
     let mut used_by = if searched_count > 0 {
         let symbols_set: HashSet<String> = all_names.iter().cloned().collect();
-        let raw_matches = find_callers_batch(&symbols_set, scope, bloom)?;
+        let raw_matches = find_callers_batch(&symbols_set, scope, bloom, None)?;
 
         // Group by file path
         let mut by_file: HashMap<PathBuf, Vec<(String, String, u32)>> = HashMap::new();

--- a/src/search/glob.rs
+++ b/src/search/glob.rs
@@ -32,7 +32,7 @@ pub fn search(pattern: &str, scope: &Path) -> Result<GlobResult, TilthError> {
     let total_found = std::sync::atomic::AtomicUsize::new(0);
     let extensions: std::sync::Mutex<HashSet<String>> = std::sync::Mutex::new(HashSet::new());
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, None)?;
 
     walker.run(|| {
         let matcher = &matcher;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -100,7 +100,8 @@ pub(crate) fn package_root(path: &Path) -> Option<&Path> {
 
 /// Build a parallel directory walker that searches ALL files except known junk directories.
 /// Does NOT respect .gitignore — ensures gitignored but locally-relevant files are found.
-pub(crate) fn walker(scope: &Path) -> ignore::WalkParallel {
+/// When `glob` is Some, applies a file-pattern override (whitelist or negation).
+pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkParallel, TilthError> {
     let threads = std::env::var("TILTH_THREADS")
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
@@ -108,7 +109,8 @@ pub(crate) fn walker(scope: &Path) -> ignore::WalkParallel {
             std::thread::available_parallelism().map_or(4, |n| (n.get() / 2).clamp(2, 6))
         });
 
-    WalkBuilder::new(scope)
+    let mut builder = WalkBuilder::new(scope);
+    builder
         .hidden(false)
         .git_ignore(false)
         .git_global(false)
@@ -123,8 +125,25 @@ pub(crate) fn walker(scope: &Path) -> ignore::WalkParallel {
                 }
             }
             true
-        })
-        .build_parallel()
+        });
+
+    if let Some(pattern) = glob {
+        if !pattern.is_empty() {
+            let mut overrides = ignore::overrides::OverrideBuilder::new(scope);
+            overrides
+                .add(pattern)
+                .map_err(|e| TilthError::InvalidQuery {
+                    query: pattern.to_string(),
+                    reason: format!("invalid glob: {e}"),
+                })?;
+            builder.overrides(overrides.build().map_err(|e| TilthError::InvalidQuery {
+                query: pattern.to_string(),
+                reason: format!("invalid glob: {e}"),
+            })?);
+        }
+    }
+
+    Ok(builder.build_parallel())
 }
 
 /// Parse `/pattern/` regex syntax. Returns (pattern, `is_regex`).
@@ -153,8 +172,9 @@ pub fn search_symbol(
     query: &str,
     scope: &Path,
     cache: &OutlineCache,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let result = symbol::search(query, scope, None)?;
+    let result = symbol::search(query, scope, None, glob)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -168,12 +188,13 @@ pub fn search_symbol_expanded(
     bloom: &crate::index::bloom::BloomFilterCache,
     expand: usize,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     // Index is available but not yet used for search fast-path.
     // Build will be triggered when the lookup path is wired in.
     let _ = index;
 
-    let result = symbol::search(query, scope, context)?;
+    let result = symbol::search(query, scope, context, glob)?;
     format_search_result(&result, cache, Some(session), bloom, expand)
 }
 
@@ -186,6 +207,7 @@ pub fn search_multi_symbol_expanded(
     bloom: &crate::index::bloom::BloomFilterCache,
     expand: usize,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     let _ = index; // Available but not yet used for search fast-path
 
@@ -200,7 +222,7 @@ pub fn search_multi_symbol_expanded(
     let mut sections = Vec::with_capacity(queries.len());
 
     for query in queries {
-        let result = symbol::search(query, scope, context)?;
+        let result = symbol::search(query, scope, context, glob)?;
         let mut out = format::search_header(
             &result.query,
             &result.scope,
@@ -235,9 +257,10 @@ pub fn search_content(
     query: &str,
     scope: &Path,
     cache: &OutlineCache,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    let result = content::search(pattern, scope, is_regex, None)?;
+    let result = content::search(pattern, scope, is_regex, None, glob)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -246,8 +269,9 @@ pub fn search_regex(
     pattern: &str,
     scope: &Path,
     cache: &OutlineCache,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let result = content::search(pattern, scope, true, None)?;
+    let result = content::search(pattern, scope, true, None, glob)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -259,9 +283,10 @@ pub fn search_content_expanded(
     session: &Session,
     expand: usize,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    let result = content::search(pattern, scope, is_regex, context)?;
+    let result = content::search(pattern, scope, is_regex, context, glob)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, Some(session), &bloom, expand)
 }
@@ -274,26 +299,39 @@ pub fn search_regex_expanded(
     session: &Session,
     expand: usize,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let result = content::search(pattern, scope, true, context)?;
+    let result = content::search(pattern, scope, true, context, glob)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, Some(session), &bloom, expand)
 }
 
 /// Raw symbol search — returns structured result for programmatic inspection.
-pub fn search_symbol_raw(query: &str, scope: &Path) -> Result<SearchResult, TilthError> {
-    symbol::search(query, scope, None)
+pub fn search_symbol_raw(
+    query: &str,
+    scope: &Path,
+    glob: Option<&str>,
+) -> Result<SearchResult, TilthError> {
+    symbol::search(query, scope, None, glob)
 }
 
 /// Raw content search — returns structured result for programmatic inspection.
-pub fn search_content_raw(query: &str, scope: &Path) -> Result<SearchResult, TilthError> {
+pub fn search_content_raw(
+    query: &str,
+    scope: &Path,
+    glob: Option<&str>,
+) -> Result<SearchResult, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    content::search(pattern, scope, is_regex, None)
+    content::search(pattern, scope, is_regex, None, glob)
 }
 
 /// Raw regex search — returns structured result for programmatic inspection.
-pub fn search_regex_raw(pattern: &str, scope: &Path) -> Result<SearchResult, TilthError> {
-    content::search(pattern, scope, true, None)
+pub fn search_regex_raw(
+    pattern: &str,
+    scope: &Path,
+    glob: Option<&str>,
+) -> Result<SearchResult, TilthError> {
+    content::search(pattern, scope, true, None, glob)
 }
 
 /// Format a raw search result (symbol or content — both use the same pipeline).
@@ -1209,4 +1247,230 @@ fn format_glob_result(result: &glob::GlobResult, scope: &Path) -> Result<String,
     }
 
     Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::sync::Mutex;
+
+    /// Collect all file paths from a walker into a sorted Vec.
+    fn walk_paths(scope: &Path, glob: Option<&str>) -> Vec<PathBuf> {
+        let w = walker(scope, glob).expect("walker failed");
+        let paths: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
+        w.run(|| {
+            let paths = &paths;
+            Box::new(move |entry| {
+                if let Ok(e) = entry {
+                    if e.file_type().is_some_and(|ft| ft.is_file()) {
+                        paths.lock().unwrap().push(e.into_path());
+                    }
+                }
+                ignore::WalkState::Continue
+            })
+        });
+        let mut v = paths.into_inner().unwrap();
+        v.sort();
+        v
+    }
+
+    fn extensions(paths: &[PathBuf]) -> HashSet<String> {
+        paths
+            .iter()
+            .filter_map(|p| p.extension())
+            .map(|e| e.to_string_lossy().to_string())
+            .collect()
+    }
+
+    // ── walker unit tests ──
+
+    #[test]
+    fn walker_none_returns_all_file_types() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let all = walk_paths(&scope, None);
+        let exts = extensions(&all);
+        assert!(exts.contains("rs"), "expected .rs files, got {exts:?}");
+        assert!(!all.is_empty());
+    }
+
+    #[test]
+    fn walker_whitelist_filters_to_matching_extension() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let filtered = walk_paths(&scope, Some("*.rs"));
+        assert!(!filtered.is_empty(), "whitelist should find .rs files");
+        for p in &filtered {
+            assert_eq!(
+                p.extension().and_then(|e| e.to_str()),
+                Some("rs"),
+                "non-.rs file leaked through whitelist: {}",
+                p.display()
+            );
+        }
+    }
+
+    #[test]
+    fn walker_negation_excludes_matching_extension() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let without_rs = walk_paths(&scope, Some("!*.rs"));
+        for p in &without_rs {
+            assert_ne!(
+                p.extension().and_then(|e| e.to_str()),
+                Some("rs"),
+                ".rs file leaked through negation: {}",
+                p.display()
+            );
+        }
+    }
+
+    #[test]
+    fn walker_empty_string_equals_none() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let all = walk_paths(&scope, None);
+        let empty = walk_paths(&scope, Some(""));
+        assert_eq!(all.len(), empty.len(), "empty glob should behave like None");
+    }
+
+    #[test]
+    fn walker_invalid_glob_returns_error() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let result = walker(&scope, Some("[unclosed"));
+        match result {
+            Err(TilthError::InvalidQuery { query, reason }) => {
+                assert_eq!(query, "[unclosed");
+                assert!(
+                    reason.contains("invalid glob"),
+                    "reason should mention 'invalid glob': {reason}"
+                );
+            }
+            Err(other) => panic!("expected InvalidQuery, got {other}"),
+            Ok(_) => panic!("expected Err for invalid glob, got Ok"),
+        }
+    }
+
+    #[test]
+    fn walker_brace_expansion_matches_multiple_extensions() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let filtered = walk_paths(&scope, Some("*.{rs,toml}"));
+        let exts = extensions(&filtered);
+        assert!(
+            exts.contains("rs"),
+            "brace expansion should include .rs: {exts:?}"
+        );
+        assert!(
+            exts.contains("toml"),
+            "brace expansion should include .toml: {exts:?}"
+        );
+        for ext in &exts {
+            assert!(
+                ext == "rs" || ext == "toml",
+                "unexpected extension leaked: {ext}"
+            );
+        }
+    }
+
+    #[test]
+    fn walker_whitelist_fewer_than_unfiltered() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let all = walk_paths(&scope, None);
+        let rs_only = walk_paths(&scope, Some("*.rs"));
+        assert!(
+            rs_only.len() < all.len(),
+            "whitelist ({}) should find fewer files than unfiltered ({})",
+            rs_only.len(),
+            all.len()
+        );
+    }
+
+    #[test]
+    fn walker_path_pattern_restricts_directory() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR"));
+        let filtered = walk_paths(&scope, Some("src/**/*.rs"));
+        assert!(!filtered.is_empty(), "path pattern should find files");
+        let src_dir = scope.join("src");
+        for p in &filtered {
+            assert!(
+                p.starts_with(&src_dir),
+                "file outside src/ leaked: {}",
+                p.display()
+            );
+        }
+    }
+
+    // ── end-to-end through search functions ──
+
+    #[test]
+    fn content_search_glob_restricts_results() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let all = content::search("TilthError", &scope, false, None, None).expect("search failed");
+        let rs_only = content::search("TilthError", &scope, false, None, Some("*.rs"))
+            .expect("search with glob failed");
+        let toml_only = content::search("TilthError", &scope, false, None, Some("*.toml"))
+            .expect("search with toml glob failed");
+
+        assert!(all.total_found > 0, "unfiltered should find TilthError");
+        assert!(rs_only.total_found > 0, "*.rs should find TilthError");
+        assert_eq!(
+            toml_only.total_found, 0,
+            "*.toml should not find TilthError in Rust source"
+        );
+        for m in &rs_only.matches {
+            assert_eq!(
+                m.path.extension().and_then(|e| e.to_str()),
+                Some("rs"),
+                "non-.rs match leaked: {}",
+                m.path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn symbol_search_glob_restricts_results() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let rs_result =
+            symbol::search("walker", &scope, None, Some("*.rs")).expect("symbol search failed");
+        let toml_result = symbol::search("walker", &scope, None, Some("*.toml"))
+            .expect("symbol search with toml failed");
+
+        assert!(rs_result.total_found > 0, "*.rs should find 'walker'");
+        assert_eq!(
+            toml_result.total_found, 0,
+            "*.toml should not find 'walker'"
+        );
+        for m in &rs_result.matches {
+            assert_eq!(
+                m.path.extension().and_then(|e| e.to_str()),
+                Some("rs"),
+                "non-.rs match in symbol search: {}",
+                m.path.display()
+            );
+        }
+    }
+
+    #[test]
+    fn callers_search_glob_restricts_results() {
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let rs_callers =
+            callers::find_callers("walker", &scope, &bloom, Some("*.rs")).expect("callers failed");
+        let toml_callers = callers::find_callers("walker", &scope, &bloom, Some("*.toml"))
+            .expect("callers toml failed");
+
+        assert!(
+            !rs_callers.is_empty(),
+            "*.rs should find callers of 'walker'"
+        );
+        assert!(
+            toml_callers.is_empty(),
+            "*.toml should not find callers of 'walker'"
+        );
+        for c in &rs_callers {
+            assert_eq!(
+                c.path.extension().and_then(|e| e.to_str()),
+                Some("rs"),
+                "non-.rs caller leaked: {}",
+                c.path.display()
+            );
+        }
+    }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1371,7 +1371,9 @@ mod tests {
 
     #[test]
     fn walker_whitelist_fewer_than_unfiltered() {
-        let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+        // Use project root (not src/) — project root has .toml, .md, .lock etc.
+        // alongside .rs files, so *.rs is guaranteed to be a strict subset.
+        let scope = Path::new(env!("CARGO_MANIFEST_DIR"));
         let all = walk_paths(&scope, None);
         let rs_only = walk_paths(&scope, Some("*.rs"));
         assert!(

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -31,6 +31,7 @@ pub fn search(
     query: &str,
     scope: &Path,
     context: Option<&Path>,
+    glob: Option<&str>,
 ) -> Result<SearchResult, TilthError> {
     // Compile regex once, share across both arms
     let word_pattern = format!(r"\b{}\b", regex_syntax::escape(query));
@@ -40,8 +41,8 @@ pub fn search(
     })?;
 
     let (defs, usages) = rayon::join(
-        || find_definitions(query, scope),
-        || find_usages(query, &matcher, scope),
+        || find_definitions(query, scope, glob),
+        || find_usages(query, &matcher, scope, glob),
     );
 
     let defs = defs?;
@@ -85,14 +86,18 @@ pub fn search(
 /// Single-read design: reads each file once, checks for symbol via
 /// `memchr::memmem` (SIMD), then reuses the buffer for tree-sitter parsing.
 /// Early termination: quits the parallel walker once enough defs are found.
-fn find_definitions(query: &str, scope: &Path) -> Result<Vec<Match>, TilthError> {
+fn find_definitions(
+    query: &str,
+    scope: &Path,
+    glob: Option<&str>,
+) -> Result<Vec<Match>, TilthError> {
     let matches: Mutex<Vec<Match>> = Mutex::new(Vec::new());
     // Relaxed is correct: walker.run() joins all threads before we read the final value.
     // Early-quit checks are approximate by design — one extra iteration is harmless.
     let found_count = AtomicUsize::new(0);
     let needle = query.as_bytes();
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, glob)?;
 
     walker.run(|| {
         let matches = &matches;
@@ -359,12 +364,13 @@ fn find_usages(
     query: &str,
     matcher: &RegexMatcher,
     scope: &Path,
+    glob: Option<&str>,
 ) -> Result<Vec<Match>, TilthError> {
     let matches: Mutex<Vec<Match>> = Mutex::new(Vec::new());
     // Relaxed: same reasoning as find_definitions — approximate early-quit, joined before read
     let found_count = AtomicUsize::new(0);
 
-    let walker = super::walker(scope);
+    let walker = super::walker(scope, glob)?;
 
     walker.run(|| {
         let matches = &matches;


### PR DESCRIPTION
Closes #47

## Summary

- Adds `glob` parameter to `tilth_search` (MCP tool + CLI `--glob`) so agents can restrict search results by file pattern
- Uses `ignore` crate's `OverrideBuilder` — zero new dependencies
- Threads `glob: Option<&str>` through `walker()` → all search functions → MCP dispatch + CLI
- Internal callers (`blast_radius`, `analyze_deps`) always pass `None` — full codebase view preserved where correctness requires it

## Semantics

| Pattern | Effect |
|---------|--------|
| `*.rs` | Whitelist — only `.rs` files searched |
| `!*.test.ts` | Negation — exclude test files |
| `*.{go,rs}` | Brace expansion — multiple extensions |
| `src/**/*.ts` | Path patterns |
| (omitted) | No filtering — current behavior unchanged |

## What changed

| File | Change |
|------|--------|
| `search/mod.rs` | `walker()` accepts `glob`, builds `Override` when present. 11 tests added. |
| `search/symbol.rs` | `search()`, `find_definitions()`, `find_usages()` thread `glob` to walker |
| `search/content.rs` | `search()` threads `glob` to walker |
| `search/callers.rs` | `find_callers()`, `find_callers_batch()`, `search_callers_expanded()` thread `glob` |
| `search/glob.rs` | Passes `None` (glob search IS the file pattern search) |
| `search/blast.rs` | Passes `None` (needs full codebase view) |
| `search/deps.rs` | Passes `None` (needs full codebase view) |
| `lib.rs` | All public + internal functions thread `glob` |
| `main.rs` | `--glob` CLI flag via clap |
| `mcp.rs` | `glob` in tool schema + extraction in `tool_search()` |
| `AGENTS.md` | Documents `glob` parameter |

## Test plan

- [x] `cargo fmt --check` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo test` — 146 tests pass (11 new glob tests)
- [ ] Manual: `tilth "handleAuth" --glob "*.rs"` — only Rust results
- [ ] Manual: `tilth_search(query: "Lang", glob: "*.rs")` via MCP — only Rust results
- [ ] Manual: `tilth_search(query: "Lang", glob: "[invalid")` — returns error

### New tests

**Walker unit tests (8):** whitelist filtering, negation exclusion, empty string = None, invalid glob error, brace expansion, whitelist < unfiltered, path pattern restricts directory

**End-to-end (3):** content search, symbol search, callers search — each verifies glob restricts results to matching file extensions using the project's own source tree (no mocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)