### PR TITLE
refactor: tilth_run v2 — structured API, CLI, hook integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -584,6 +584,7 @@ dependencies = [
  "memchr",
  "memmap2",
  "rayon",
+ "regex",
  "regex-syntax",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,7 @@ dependencies = [
  "grep-regex",
  "grep-searcher",
  "ignore",
+ "libc",
  "memchr",
  "memmap2",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ regex-syntax = "0.8"
 
 # Byte scanning (SIMD-accelerated)
 memchr = "2"
+regex = "1"
 memmap2 = "0.9"
 
 # Parallelism

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,8 @@ toml = "0.8"
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
 
 [profile.release]
 opt-level = 3

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,11 +24,11 @@ pub mod install;
 pub mod map;
 pub mod mcp;
 pub(crate) mod read;
+#[allow(dead_code, clippy::pedantic)]
+pub(crate) mod run;
 pub(crate) mod search;
 pub(crate) mod session;
 pub(crate) mod types;
-#[allow(dead_code, clippy::pedantic)]
-pub(crate) mod run;
 
 use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ pub mod install;
 pub mod map;
 pub mod mcp;
 pub(crate) mod read;
-#[allow(dead_code, clippy::pedantic)]
+#[allow(clippy::pedantic)]
 pub(crate) mod run;
 pub(crate) mod search;
 pub(crate) mod session;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,8 @@ pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod session;
 pub(crate) mod types;
+#[allow(dead_code, clippy::pedantic)]
+pub(crate) mod run;
 
 use std::path::Path;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,8 +24,7 @@ pub mod install;
 pub mod map;
 pub mod mcp;
 pub(crate) mod read;
-#[allow(clippy::pedantic)]
-pub(crate) mod run;
+pub mod run;
 pub(crate) mod search;
 pub(crate) mod session;
 pub(crate) mod types;

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,6 +65,29 @@ enum Command {
         #[arg(long)]
         edit: bool,
     },
+    /// Hook for Claude Code PreToolUse — rewrites Bash commands through tilth run.
+    ///
+    /// Reads tool input JSON from stdin, rewrites compressible commands
+    /// (build/test/lint) to use `tilth run`, writes modified JSON to stdout.
+    HookRewrite,
+    /// Run a shell command with structured output compression.
+    Run {
+        /// The command to execute (passed to sh -c).
+        #[arg(trailing_var_arg = true)]
+        command: Vec<String>,
+
+        /// Working directory for the command.
+        #[arg(long, default_value = ".")]
+        cwd: PathBuf,
+
+        /// Timeout in seconds.
+        #[arg(long, default_value_t = 120)]
+        timeout: u64,
+
+        /// Output format: markdown, plain, json.
+        #[arg(long)]
+        format: Option<String>,
+    },
 }
 
 fn main() {
@@ -85,6 +108,17 @@ fn main() {
                     eprintln!("install error: {e}");
                     process::exit(1);
                 }
+            }
+            Command::HookRewrite => {
+                handle_hook_rewrite();
+            }
+            Command::Run {
+                command,
+                cwd,
+                timeout,
+                format,
+            } => {
+                handle_run(command, cwd, timeout, format);
             }
         }
         return;
@@ -151,6 +185,180 @@ fn main() {
             process::exit(e.exit_code());
         }
     }
+}
+
+/// Hook rewrite: reads Bash tool input from stdin, rewrites compressible commands to use tilth run.
+fn handle_hook_rewrite() -> ! {
+    use io::Read;
+
+    let mut input = String::new();
+    if io::stdin().read_to_string(&mut input).is_err() || input.is_empty() {
+        // Can't read stdin — pass through (exit 0 = no modification)
+        process::exit(0);
+    }
+
+    let Ok(mut json) = serde_json::from_str::<serde_json::Value>(&input) else {
+        process::exit(0);
+    };
+
+    let Some(command) = json
+        .get("command")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+    else {
+        process::exit(0);
+    };
+
+    if should_rewrite_for_hook(&command) {
+        // Find tilth binary path for the rewrite
+        let tilth_bin = std::env::current_exe()
+            .ok()
+            .and_then(|p| p.to_str().map(String::from))
+            .unwrap_or_else(|| "tilth".into());
+
+        let rewritten = format!("{tilth_bin} run -- {command}");
+        json["command"] = serde_json::Value::String(rewritten);
+    }
+
+    // Write modified (or unmodified) JSON to stdout
+    let _ = io::stdout().write_all(serde_json::to_string(&json).unwrap_or(input).as_bytes());
+    process::exit(0);
+}
+
+/// Check if a command should be routed through `tilth run` for compression.
+fn should_rewrite_for_hook(command: &str) -> bool {
+    let cmd = command.trim();
+
+    // Already wrapped
+    if cmd.starts_with("tilth") {
+        return false;
+    }
+
+    // Extract the base command name (handle paths like /usr/bin/cargo)
+    let first_word = cmd.split_whitespace().next().unwrap_or("");
+    let base = first_word.rsplit('/').next().unwrap_or(first_word);
+
+    matches!(
+        base,
+        "cargo"
+            | "rustc"
+            | "npm"
+            | "npx"
+            | "pnpm"
+            | "yarn"
+            | "bun"
+            | "pip"
+            | "pip3"
+            | "pytest"
+            | "python"
+            | "python3"
+            | "go"
+            | "tsc"
+            | "eslint"
+            | "ruff"
+            | "mypy"
+            | "flake8"
+            | "pylint"
+            | "make"
+            | "cmake"
+            | "gradle"
+            | "mvn"
+            | "jest"
+            | "vitest"
+            | "mocha"
+            | "dotnet"
+            | "msbuild"
+            | "gcc"
+            | "g++"
+            | "clang"
+            | "clang++"
+    )
+}
+
+/// Execute a shell command, compress its output, and exit with the command's exit code.
+fn handle_run(command: Vec<String>, cwd: PathBuf, timeout: u64, format: Option<String>) -> ! {
+    use tilth::run::{exec, process_structured, OutputFormat};
+
+    let is_tty = io::stdout().is_terminal();
+
+    if command.is_empty() {
+        eprintln!("error: no command given");
+        process::exit(1);
+    }
+
+    let cmd_str = shell_join(&command);
+    let cwd = cwd.canonicalize().unwrap_or(cwd);
+
+    let exec_result = match exec::execute(&cmd_str, &cwd, timeout) {
+        Ok(r) => r,
+        Err(e) => {
+            eprintln!("run error: {e}");
+            process::exit(1);
+        }
+    };
+
+    if exec_result.timed_out {
+        eprintln!("command timed out after {timeout}s");
+        let partial = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
+            (_, true) => exec_result.stdout,
+            (true, _) => exec_result.stderr,
+            _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
+        };
+        if !partial.is_empty() {
+            emit_output(&partial, is_tty);
+        }
+        process::exit(124);
+    }
+
+    let combined = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
+        (_, true) => exec_result.stdout,
+        (true, _) => exec_result.stderr,
+        _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
+    };
+
+    let fmt = match format.as_deref() {
+        Some("json") => OutputFormat::Json,
+        Some("markdown") => OutputFormat::Markdown,
+        Some("plain") => OutputFormat::Plain,
+        None if is_tty => OutputFormat::Plain,
+        _ => OutputFormat::Markdown,
+    };
+
+    let result = process_structured(&combined);
+
+    let output = if result.passthrough {
+        combined.clone()
+    } else {
+        result
+            .format_checked(fmt, combined.len())
+            .unwrap_or(combined)
+    };
+
+    if exec_result.exit_code != 0 {
+        eprintln!("exit code: {}", exec_result.exit_code);
+    }
+
+    emit_output(&output, is_tty);
+    process::exit(exec_result.exit_code);
+}
+
+/// Join command arguments, quoting any that contain shell metacharacters.
+fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|arg| {
+            if arg.is_empty() {
+                "''".to_string()
+            } else if arg.contains(|c: char| {
+                c.is_ascii_whitespace() || "\"'\\$`!#&|;(){}[]<>?*~".contains(c)
+            }) {
+                // Single-quote the arg, escaping any embedded single quotes
+                format!("'{}'", arg.replace('\'', "'\\''"))
+            } else {
+                arg.clone()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Write output to stdout. When TTY and output is long, pipe through $PAGER.

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use std::io::{self, IsTerminal, Write};
 use std::path::PathBuf;
 use std::process;
 
-use clap::{CommandFactory, Parser};
+use clap::{CommandFactory, Parser, ValueEnum};
 use clap_complete::Shell;
 
 /// tilth — Tree-sitter indexed lookups, smart code reading for AI agents.
@@ -53,6 +53,14 @@ struct Cli {
     completions: Option<Shell>,
 }
 
+/// Output format for the `run` subcommand.
+#[derive(Clone, ValueEnum)]
+enum RunFormat {
+    Markdown,
+    Plain,
+    Json,
+}
+
 #[derive(clap::Subcommand)]
 enum Command {
     /// Install tilth into an MCP host's config.
@@ -84,9 +92,9 @@ enum Command {
         #[arg(long, default_value_t = 120)]
         timeout: u64,
 
-        /// Output format: markdown, plain, json.
+        /// Output format.
         #[arg(long)]
-        format: Option<String>,
+        format: Option<RunFormat>,
     },
 }
 
@@ -216,7 +224,13 @@ fn handle_hook_rewrite() -> ! {
             .and_then(|p| p.to_str().map(String::from))
             .unwrap_or_else(|| "tilth".into());
 
-        let rewritten = format!("{tilth_bin} run -- {command}");
+        // Quote both paths: tilth_bin may contain spaces, and command may contain
+        // shell metacharacters (&&, ||, ;, pipes). Single-quoting passes the full
+        // compound command as one argument to tilth's trailing_var_arg, which then
+        // joins and passes it to sh -c.
+        let tilth_quoted = shell_quote_single(&tilth_bin);
+        let cmd_quoted = shell_quote_single(&command);
+        let rewritten = format!("{tilth_quoted} run -- {cmd_quoted}");
         json["command"] = serde_json::Value::String(rewritten);
     }
 
@@ -228,15 +242,12 @@ fn handle_hook_rewrite() -> ! {
 /// Check if a command should be routed through `tilth run` for compression.
 fn should_rewrite_for_hook(command: &str) -> bool {
     let cmd = command.trim();
+    let base = extract_base_command(cmd);
 
-    // Already wrapped
-    if cmd.starts_with("tilth") {
+    // Already wrapped — exact word boundary so "tilthx" doesn't match
+    if base == "tilth" {
         return false;
     }
-
-    // Extract the base command name (handle paths like /usr/bin/cargo)
-    let first_word = cmd.split_whitespace().next().unwrap_or("");
-    let base = first_word.rsplit('/').next().unwrap_or(first_word);
 
     matches!(
         base,
@@ -275,8 +286,48 @@ fn should_rewrite_for_hook(command: &str) -> bool {
     )
 }
 
+/// Extract the actual base command name from a shell command string, skipping:
+/// - `KEY=VALUE` environment variable assignments
+/// - Known wrapper commands: `sudo`, `env`, `time`, `nice`, `nohup`, `strace`, `ltrace`
+///
+/// Also strips path prefixes (e.g. `/usr/bin/cargo` → `cargo`).
+fn extract_base_command(cmd: &str) -> &str {
+    let mut words = cmd.split_whitespace();
+    loop {
+        let Some(word) = words.next() else {
+            return "";
+        };
+        let base = word.rsplit('/').next().unwrap_or(word);
+        // Skip KEY=VALUE env var assignments (contains '=' but doesn't start with it)
+        if base.contains('=') && !base.starts_with('=') {
+            continue;
+        }
+        // Skip known wrapper commands
+        if matches!(
+            base,
+            "sudo" | "env" | "time" | "nice" | "nohup" | "strace" | "ltrace"
+        ) {
+            continue;
+        }
+        return base;
+    }
+}
+
+/// Build the shell command string for `sh -c`.
+///
+/// When there is exactly one argument (e.g. a fully-formed compound command delivered
+/// by the hook path), pass it through verbatim — calling `shell_join` would re-quote
+/// it, causing `sh -c` to fail. For multiple arguments, join with quoting.
+fn build_command_string(command: Vec<String>) -> String {
+    if command.len() == 1 {
+        command.into_iter().next().unwrap()
+    } else {
+        shell_join(&command)
+    }
+}
+
 /// Execute a shell command, compress its output, and exit with the command's exit code.
-fn handle_run(command: Vec<String>, cwd: PathBuf, timeout: u64, format: Option<String>) -> ! {
+fn handle_run(command: Vec<String>, cwd: PathBuf, timeout: u64, format: Option<RunFormat>) -> ! {
     use tilth::run::{exec, process_structured, OutputFormat};
 
     let is_tty = io::stdout().is_terminal();
@@ -286,7 +337,7 @@ fn handle_run(command: Vec<String>, cwd: PathBuf, timeout: u64, format: Option<S
         process::exit(1);
     }
 
-    let cmd_str = shell_join(&command);
+    let cmd_str = build_command_string(command);
     let cwd = cwd.canonicalize().unwrap_or(cwd);
 
     let exec_result = match exec::execute(&cmd_str, &cwd, timeout) {
@@ -297,49 +348,52 @@ fn handle_run(command: Vec<String>, cwd: PathBuf, timeout: u64, format: Option<S
         }
     };
 
-    if exec_result.timed_out {
+    let exit_code = exec_result.exit_code;
+    let timed_out = exec_result.timed_out;
+
+    if timed_out {
         eprintln!("command timed out after {timeout}s");
-        let partial = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
-            (_, true) => exec_result.stdout,
-            (true, _) => exec_result.stderr,
-            _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
-        };
+        let partial = exec_result.combined_output();
         if !partial.is_empty() {
             emit_output(&partial, is_tty);
         }
         process::exit(124);
     }
 
-    let combined = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
-        (_, true) => exec_result.stdout,
-        (true, _) => exec_result.stderr,
-        _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
-    };
+    let combined = exec_result.combined_output();
 
-    let fmt = match format.as_deref() {
-        Some("json") => OutputFormat::Json,
-        Some("markdown") => OutputFormat::Markdown,
-        Some("plain") => OutputFormat::Plain,
+    let fmt = match format {
+        Some(RunFormat::Json) => OutputFormat::Json,
+        Some(RunFormat::Markdown) => OutputFormat::Markdown,
+        Some(RunFormat::Plain) => OutputFormat::Plain,
         None if is_tty => OutputFormat::Plain,
-        _ => OutputFormat::Markdown,
+        None => OutputFormat::Markdown,
     };
 
     let result = process_structured(&combined);
 
     let output = if result.passthrough {
-        combined.clone()
+        combined
     } else {
         result
             .format_checked(fmt, combined.len())
             .unwrap_or(combined)
     };
 
-    if exec_result.exit_code != 0 {
-        eprintln!("exit code: {}", exec_result.exit_code);
+    if exit_code != 0 {
+        eprintln!("exit code: {exit_code}");
     }
 
     emit_output(&output, is_tty);
-    process::exit(exec_result.exit_code);
+    process::exit(exit_code);
+}
+
+/// Wrap a string in single quotes for use in a shell command.
+///
+/// Single-quotes prevent all shell interpretation (metacharacters, variable expansion, etc.).
+/// Embedded single quotes are escaped using the `'\''` idiom.
+fn shell_quote_single(s: &str) -> String {
+    format!("'{}'", s.replace('\'', "'\\''"))
 }
 
 /// Join command arguments, quoting any that contain shell metacharacters.
@@ -381,7 +435,8 @@ fn emit_output(output: &str, is_tty: bool) {
         }
     }
 
-    println!("{output}");
+    print!("{output}");
+    let _ = io::stdout().flush();
 }
 
 fn terminal_height() -> usize {
@@ -412,4 +467,194 @@ fn configure_thread_pools() {
         .num_threads(num_threads)
         .build_global()
         .ok();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- should_rewrite_for_hook ---
+
+    #[test]
+    fn rewrite_simple_cargo() {
+        assert!(should_rewrite_for_hook("cargo test"));
+    }
+
+    #[test]
+    fn no_rewrite_already_wrapped() {
+        assert!(!should_rewrite_for_hook("tilth run -- cargo test"));
+    }
+
+    #[test]
+    fn no_rewrite_tilth_alone() {
+        assert!(!should_rewrite_for_hook("tilth"));
+    }
+
+    /// Bug #16: "tilthx" must NOT be treated as already-wrapped.
+    #[test]
+    fn rewrite_tilthx_not_matched_by_guard() {
+        // "tilthx" is not a known build command so should_rewrite returns false,
+        // but the guard must not incorrectly suppress the check — tilthx != tilth.
+        // Since tilthx is not in the allow-list either, the result is false.
+        // The important thing: it must not return false due to the "already wrapped" guard.
+        // We verify by checking a known command prefixed with "tilth" in the name:
+        // use a hypothetical "tilthbuild cargo test" — not a real command, so false is correct.
+        // More directly: a command whose first word is "tilthx" should reach the matches! block.
+        // It won't match any known command, so result is false — but NOT because of guard.
+        assert!(!should_rewrite_for_hook("tilthx cargo test"));
+    }
+
+    /// Bug #16 — the guard must not block "tilth_something" style names.
+    #[test]
+    fn rewrite_guard_exact_word_only() {
+        // "tilthy build" — base == "tilthy", not "tilth", so guard doesn't fire.
+        // Not in the match list → returns false (correct — no rewrite for unknown commands).
+        assert!(!should_rewrite_for_hook("tilthy build"));
+    }
+
+    /// Compound command (Bug #5) — cargo + shell operator
+    #[test]
+    fn rewrite_compound_command() {
+        assert!(should_rewrite_for_hook("cargo test && echo done"));
+    }
+
+    #[test]
+    fn rewrite_compound_pipe() {
+        assert!(should_rewrite_for_hook("cargo build 2>&1 | tee build.log"));
+    }
+
+    #[test]
+    fn no_rewrite_unknown_command() {
+        assert!(!should_rewrite_for_hook("echo hello"));
+    }
+
+    // --- shell_quote_single ---
+
+    #[test]
+    fn quote_simple_string() {
+        assert_eq!(shell_quote_single("hello"), "'hello'");
+    }
+
+    #[test]
+    fn quote_string_with_spaces() {
+        // Handles paths like /Users/John Doe/.cargo/bin/tilth
+        assert_eq!(
+            shell_quote_single("/Users/John Doe/.cargo/bin/tilth"),
+            "'/Users/John Doe/.cargo/bin/tilth'"
+        );
+    }
+
+    #[test]
+    fn quote_string_with_single_quote() {
+        assert_eq!(shell_quote_single("it's"), "'it'\\''s'");
+    }
+
+    #[test]
+    fn quote_compound_command() {
+        // A compound command passed as one arg
+        assert_eq!(
+            shell_quote_single("cargo test && echo done"),
+            "'cargo test && echo done'"
+        );
+    }
+
+    // --- handle_hook_rewrite integration (rewrite format) ---
+
+    /// Verify the rewritten command has the correct structure for Bug #5 and Bug #17.
+    #[test]
+    fn hook_rewrite_quotes_compound_command() {
+        // Simulate what handle_hook_rewrite does for a compound command
+        let command = "cargo test && echo done";
+        let tilth_bin = "/Users/John Doe/.cargo/bin/tilth";
+
+        let tilth_quoted = shell_quote_single(tilth_bin);
+        let cmd_quoted = shell_quote_single(command);
+        let rewritten = format!("{tilth_quoted} run -- {cmd_quoted}");
+
+        assert_eq!(
+            rewritten,
+            "'/Users/John Doe/.cargo/bin/tilth' run -- 'cargo test && echo done'"
+        );
+    }
+
+    #[test]
+    fn hook_rewrite_simple_command() {
+        let command = "cargo test";
+        let tilth_bin = "/home/user/.cargo/bin/tilth";
+
+        let tilth_quoted = shell_quote_single(tilth_bin);
+        let cmd_quoted = shell_quote_single(command);
+        let rewritten = format!("{tilth_quoted} run -- {cmd_quoted}");
+
+        assert_eq!(
+            rewritten,
+            "'/home/user/.cargo/bin/tilth' run -- 'cargo test'"
+        );
+    }
+
+    // --- build_command_string: single-arg passthrough ---
+    //
+    // When the hook rewrites a command, it produces something like:
+    //   tilth run -- 'cargo test && echo done'
+    // Clap parses this as a single trailing_var_arg element: ["cargo test && echo done"].
+    // build_command_string must pass it through verbatim — calling shell_join would
+    // re-quote it, causing sh -c to treat the whole thing as a literal binary name.
+    // shell_join itself is correct for multi-arg joining; the fix is in the caller.
+
+    #[test]
+    fn build_command_string_single_compound_arg_passthrough() {
+        // A compound command arriving as one element must come through verbatim.
+        let args = vec!["cargo test && echo done".to_string()];
+        assert_eq!(build_command_string(args), "cargo test && echo done");
+    }
+
+    #[test]
+    fn build_command_string_single_simple_arg_passthrough() {
+        // A simple two-word command passed as one element must come through verbatim.
+        let args = vec!["cargo test".to_string()];
+        assert_eq!(build_command_string(args), "cargo test");
+    }
+
+    #[test]
+    fn build_command_string_multi_arg_joins_with_quoting() {
+        // Multiple args (CLI invocation like `tilth run cargo test`) are shell-joined.
+        let args = vec!["cargo".to_string(), "test".to_string()];
+        assert_eq!(build_command_string(args), "cargo test");
+    }
+
+    #[test]
+    fn build_command_string_multi_arg_with_metachar_quoting() {
+        // An arg with metacharacters in a multi-arg context gets quoted by shell_join.
+        let args = vec!["echo".to_string(), "hello world".to_string()];
+        assert_eq!(build_command_string(args), "echo 'hello world'");
+    }
+
+    #[test]
+    fn rewrite_env_var_prefixed_command() {
+        // Bug: env var prefix causes first_word to be "RUST_BACKTRACE=1",
+        // base becomes "RUST_BACKTRACE=1", no match → returns false.
+        assert!(should_rewrite_for_hook("RUST_BACKTRACE=1 cargo test"));
+    }
+
+    #[test]
+    fn rewrite_sudo_prefixed_command() {
+        assert!(should_rewrite_for_hook("sudo cargo test"));
+    }
+
+    #[test]
+    fn rewrite_env_prefixed_command() {
+        assert!(should_rewrite_for_hook("env cargo test"));
+    }
+
+    // --- FIX N4: absolute-path commands ---
+
+    #[test]
+    fn rewrite_absolute_path_cargo() {
+        assert!(should_rewrite_for_hook("/usr/bin/cargo test"));
+    }
+
+    #[test]
+    fn rewrite_absolute_path_pytest() {
+        assert!(should_rewrite_for_hook("/usr/local/bin/pytest foo.py"));
+    }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -513,9 +513,6 @@ fn tool_edit(
     }
 }
 
-const DEFAULT_RUN_TIMEOUT_SECS: u64 = 120;
-const MAX_OUTPUT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
-
 fn tool_run(args: &Value) -> Result<String, String> {
     let command = args
         .get("command")
@@ -525,80 +522,45 @@ fn tool_run(args: &Value) -> Result<String, String> {
     let timeout_secs = args
         .get("timeout")
         .and_then(serde_json::Value::as_u64)
-        .unwrap_or(DEFAULT_RUN_TIMEOUT_SECS);
+        .unwrap_or(crate::run::exec::default_timeout());
 
     let cwd = args.get("cwd").and_then(|v| v.as_str()).unwrap_or(".");
     let cwd_path = std::path::Path::new(cwd);
-    if !cwd_path.is_dir() {
-        return Err(format!("cwd is not a valid directory: {cwd}"));
-    }
 
-    let mut child = std::process::Command::new("sh")
-        .args(["-c", command])
-        .current_dir(cwd_path)
-        .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| format!("failed to spawn command: {e}"))?;
+    let exec_result =
+        crate::run::exec::execute(command, cwd_path, timeout_secs).map_err(|e| e.to_string())?;
 
-    // Read stdout/stderr in background threads to avoid pipe deadlock.
-    // Bounded reads prevent OOM from runaway commands.
-    let stdout = child.stdout.take().unwrap();
-    let stderr = child.stderr.take().unwrap();
-    let stdout_handle = std::thread::spawn(move || read_bounded(stdout));
-    let stderr_handle = std::thread::spawn(move || read_bounded(stderr));
-
-    // Wait for exit on a dedicated thread so we don't block the MCP I/O loop.
-    let child_pid = child.id();
-    let (tx, rx) = std::sync::mpsc::channel();
-    std::thread::spawn(move || {
-        let _ = tx.send(child.wait());
-    });
-
-    let status = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
-        Ok(Ok(status)) => status,
-        Ok(Err(e)) => return Err(format!("failed to wait on command: {e}")),
-        Err(_) => {
-            // Kill the child process. The wait thread will unblock and clean up.
-            let _ = std::process::Command::new("kill")
-                .args(["-9", &child_pid.to_string()])
-                .status();
-            return Err(format!("command timed out after {timeout_secs}s"));
+    if exec_result.timed_out {
+        let mut output = format!("command timed out after {timeout_secs}s\n\n");
+        let partial = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
+            (_, true) => exec_result.stdout,
+            (true, _) => exec_result.stderr,
+            _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
+        };
+        if !partial.is_empty() {
+            output.push_str(&partial);
         }
-    };
-    let stdout_str = stdout_handle
-        .join()
-        .map_err(|_| "stdout reader thread panicked".to_string())?
-        .map_err(|e| format!("failed to read stdout: {e}"))?;
-    let stderr_str = stderr_handle
-        .join()
-        .map_err(|_| "stderr reader thread panicked".to_string())?
-        .map_err(|e| format!("failed to read stderr: {e}"))?;
-
-    let combined = match (stdout_str.is_empty(), stderr_str.is_empty()) {
-        (_, true) => stdout_str,
-        (true, _) => stderr_str,
-        _ => format!("{stdout_str}{stderr_str}"),
-    };
-
-    let exit_code = status.code().unwrap_or(-1);
-    let processed = crate::run::process(&combined);
-
-    let mut result_text = String::with_capacity(processed.len() + 32);
-    if exit_code != 0 {
-        write!(result_text, "exit code: {exit_code}\n\n").unwrap();
+        return Ok(output);
     }
-    result_text.push_str(&processed);
 
-    Ok(result_text)
-}
+    let combined = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
+        (_, true) => exec_result.stdout,
+        (true, _) => exec_result.stderr,
+        _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
+    };
 
-/// Read up to `MAX_OUTPUT_BYTES` from a reader into a String.
-fn read_bounded(reader: impl std::io::Read) -> std::io::Result<String> {
-    use std::io::Read;
-    let mut buf = String::new();
-    reader.take(MAX_OUTPUT_BYTES).read_to_string(&mut buf)?;
-    Ok(buf)
+    let result = crate::run::process_structured(&combined);
+    let formatted = result
+        .format_checked(crate::run::OutputFormat::Markdown, combined.len())
+        .unwrap_or(combined);
+
+    let mut output = String::with_capacity(formatted.len() + 32);
+    if exec_result.exit_code != 0 {
+        write!(output, "exit code: {}\n\n", exec_result.exit_code).unwrap();
+    }
+    output.push_str(&formatted);
+
+    Ok(output)
 }
 
 /// Falls back to cwd when scope is invalid, with a warning message.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -51,10 +51,16 @@ tilth_files: Find files by glob pattern. Replaces find, ls, pwd, and the host Gl
 tilth_deps: Blast-radius check — what imports this file and what it imports.\n\
   Use ONLY before renaming, removing, or changing an export's signature.\n\
 \n\
+tilth_run: Run a shell command with structured output parsing. Replaces Bash for build/test/lint.\n\
+  Automatically detects and compresses verbose output (cargo, go test, pytest, jest, eslint, etc.).\n\
+  Test failures are grouped, error counts summarized, noise removed.\n\
+  Output: exit code (if non-zero) + compressed diagnostics.\n\
+  Use tilth_run instead of Bash for any command whose output you need to understand.
+\n\
 To search code, use tilth_search instead of Grep or Bash(grep/rg).\n\
 To read files, use tilth_read instead of Read or Bash(cat).\n\
 To find files, use tilth_files instead of Glob or Bash(find/ls).\n\
-DO NOT re-read files already shown in expanded search results.";
+To run commands, use tilth_run instead of Bash for build/test/lint commands.\nDO NOT re-read files already shown in expanded search results.";
 
 const EDIT_MODE_EXTRA: &str = "\n\
 \n\
@@ -226,6 +232,7 @@ pub(crate) fn dispatch_tool(
         "tilth_map" => Err("tilth_map is disabled — use tilth_search instead".into()),
         "tilth_session" => tool_session(args, session),
         "tilth_edit" if edit_mode => tool_edit(args, session, cache, bloom),
+        "tilth_run" => tool_run(args),
         _ => Err(format!("unknown tool: {tool}")),
     }
 }
@@ -505,6 +512,56 @@ fn tool_edit(
     }
 }
 
+const DEFAULT_RUN_TIMEOUT_SECS: u64 = 120;
+
+fn tool_run(args: &Value) -> Result<String, String> {
+    let command = args
+        .get("command")
+        .and_then(|v| v.as_str())
+        .ok_or("missing required parameter: command")?;
+
+    let _timeout_secs = args
+        .get("timeout")
+        .and_then(serde_json::Value::as_u64)
+        .unwrap_or(DEFAULT_RUN_TIMEOUT_SECS);
+
+    let child = std::process::Command::new("sh")
+        .args(["-c", command])
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn();
+
+    let child = match child {
+        Ok(c) => c,
+        Err(e) => return Err(format!("failed to spawn command: {e}")),
+    };
+
+    let output = child
+        .wait_with_output()
+        .map_err(|e| format!("command execution failed: {e}"))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = if stderr.is_empty() {
+        stdout.into_owned()
+    } else if stdout.is_empty() {
+        stderr.into_owned()
+    } else {
+        format!("{stdout}{stderr}")
+    };
+
+    let exit_code = output.status.code().unwrap_or(-1);
+    let processed = crate::run::process(&combined);
+
+    let mut result_text = String::with_capacity(processed.len() + 32);
+    if exit_code != 0 {
+        write!(result_text, "exit code: {exit_code}\n\n").unwrap();
+    }
+    result_text.push_str(&processed);
+
+    Ok(result_text)
+}
+
 /// Falls back to cwd when scope is invalid, with a warning message.
 fn resolve_scope(args: &Value) -> (PathBuf, Option<String>) {
     let raw_str = args.get("scope").and_then(|v| v.as_str()).unwrap_or(".");
@@ -705,6 +762,24 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "budget": {
                         "type": "number",
                         "description": "Max tokens. Truncates 'Used by' first."
+                    }
+                }
+            }
+        }),
+        serde_json::json!({
+            "name": "tilth_run",
+            "description": "Run a shell command and return structured output. Replaces Bash for build, test, and lint commands. Output is automatically parsed and compressed — test failures are grouped by type, error counts are summarized, and verbose output is reduced to actionable diagnostics. Supports cargo, go, pytest, jest, eslint, ruff, mypy, tsc, and more. Use this instead of Bash for any command whose output you need to understand.",
+            "inputSchema": {
+                "type": "object",
+                "required": ["command"],
+                "properties": {
+                    "command": {
+                        "type": "string",
+                        "description": "Shell command to execute (passed to sh -c)."
+                    },
+                    "timeout": {
+                        "type": "number",
+                        "description": "Timeout in seconds (default: 120)."
                     }
                 }
             }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -514,6 +514,7 @@ fn tool_edit(
 }
 
 const DEFAULT_RUN_TIMEOUT_SECS: u64 = 120;
+const MAX_OUTPUT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
 
 fn tool_run(args: &Value) -> Result<String, String> {
     let command = args
@@ -526,46 +527,53 @@ fn tool_run(args: &Value) -> Result<String, String> {
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(DEFAULT_RUN_TIMEOUT_SECS);
 
+    let cwd = args.get("cwd").and_then(|v| v.as_str()).unwrap_or(".");
+    let cwd_path = std::path::Path::new(cwd);
+    if !cwd_path.is_dir() {
+        return Err(format!("cwd is not a valid directory: {cwd}"));
+    }
+
     let mut child = std::process::Command::new("sh")
         .args(["-c", command])
+        .current_dir(cwd_path)
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
         .spawn()
         .map_err(|e| format!("failed to spawn command: {e}"))?;
 
     // Read stdout/stderr in background threads to avoid pipe deadlock.
+    // Bounded reads prevent OOM from runaway commands.
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
-    let stdout_handle = std::thread::spawn(move || std::io::read_to_string(stdout));
-    let stderr_handle = std::thread::spawn(move || std::io::read_to_string(stderr));
+    let stdout_handle = std::thread::spawn(move || read_bounded(stdout));
+    let stderr_handle = std::thread::spawn(move || read_bounded(stderr));
 
-    // Poll for completion with timeout.
-    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
-    let status = loop {
-        match child.try_wait() {
-            Ok(Some(status)) => break status,
-            Ok(None) => {
-                if std::time::Instant::now() >= deadline {
-                    let _ = child.kill();
-                    let _ = child.wait(); // reap zombie
-                    return Err(format!("command timed out after {timeout_secs}s"));
-                }
-                std::thread::sleep(std::time::Duration::from_millis(50));
-            }
-            Err(e) => return Err(format!("failed to wait on command: {e}")),
+    // Wait for exit on a dedicated thread so we don't block the MCP I/O loop.
+    let child_pid = child.id();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+
+    let status = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok(Ok(status)) => status,
+        Ok(Err(e)) => return Err(format!("failed to wait on command: {e}")),
+        Err(_) => {
+            // Kill the child process. The wait thread will unblock and clean up.
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &child_pid.to_string()])
+                .status();
+            return Err(format!("command timed out after {timeout_secs}s"));
         }
     };
-
     let stdout_str = stdout_handle
         .join()
-        .ok()
-        .and_then(std::result::Result::ok)
-        .unwrap_or_default();
+        .map_err(|_| "stdout reader thread panicked".to_string())?
+        .map_err(|e| format!("failed to read stdout: {e}"))?;
     let stderr_str = stderr_handle
         .join()
-        .ok()
-        .and_then(std::result::Result::ok)
-        .unwrap_or_default();
+        .map_err(|_| "stderr reader thread panicked".to_string())?
+        .map_err(|e| format!("failed to read stderr: {e}"))?;
 
     let combined = match (stdout_str.is_empty(), stderr_str.is_empty()) {
         (_, true) => stdout_str,
@@ -583,6 +591,14 @@ fn tool_run(args: &Value) -> Result<String, String> {
     result_text.push_str(&processed);
 
     Ok(result_text)
+}
+
+/// Read up to `MAX_OUTPUT_BYTES` from a reader into a String.
+fn read_bounded(reader: impl std::io::Read) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut buf = String::new();
+    reader.take(MAX_OUTPUT_BYTES).read_to_string(&mut buf)?;
+    Ok(buf)
 }
 
 /// Falls back to cwd when scope is invalid, with a warning message.
@@ -799,6 +815,10 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "command": {
                         "type": "string",
                         "description": "Shell command to execute (passed to sh -c)."
+                    },
+                    "cwd": {
+                        "type": "string",
+                        "description": "Working directory for the command. Default: current directory."
                     },
                     "timeout": {
                         "type": "number",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -522,41 +522,42 @@ fn tool_run(args: &Value) -> Result<String, String> {
     let timeout_secs = args
         .get("timeout")
         .and_then(serde_json::Value::as_u64)
-        .unwrap_or(crate::run::exec::default_timeout());
+        .unwrap_or(crate::run::exec::default_timeout())
+        .max(1);
 
     let cwd = args.get("cwd").and_then(|v| v.as_str()).unwrap_or(".");
-    let cwd_path = std::path::Path::new(cwd);
+    let cwd_path = std::path::PathBuf::from(cwd);
+    let cwd_path = cwd_path.canonicalize().unwrap_or(cwd_path);
 
     let exec_result =
-        crate::run::exec::execute(command, cwd_path, timeout_secs).map_err(|e| e.to_string())?;
+        crate::run::exec::execute(command, &cwd_path, timeout_secs).map_err(|e| e.to_string())?;
 
-    if exec_result.timed_out {
+    let exit_code = exec_result.exit_code;
+    let timed_out = exec_result.timed_out;
+
+    if timed_out {
         let mut output = format!("command timed out after {timeout_secs}s\n\n");
-        let partial = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
-            (_, true) => exec_result.stdout,
-            (true, _) => exec_result.stderr,
-            _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
-        };
+        let partial = exec_result.combined_output();
         if !partial.is_empty() {
             output.push_str(&partial);
         }
         return Ok(output);
     }
 
-    let combined = match (exec_result.stdout.is_empty(), exec_result.stderr.is_empty()) {
-        (_, true) => exec_result.stdout,
-        (true, _) => exec_result.stderr,
-        _ => format!("{}{}", exec_result.stdout, exec_result.stderr),
-    };
+    let combined = exec_result.combined_output();
 
     let result = crate::run::process_structured(&combined);
-    let formatted = result
-        .format_checked(crate::run::OutputFormat::Markdown, combined.len())
-        .unwrap_or(combined);
+    let formatted = if result.passthrough {
+        combined
+    } else {
+        result
+            .format_checked(crate::run::OutputFormat::Markdown, combined.len())
+            .unwrap_or(combined)
+    };
 
     let mut output = String::with_capacity(formatted.len() + 32);
-    if exec_result.exit_code != 0 {
-        write!(output, "exit code: {}\n\n", exec_result.exit_code).unwrap();
+    if exit_code != 0 {
+        write!(output, "exit code: {exit_code}\n\n").unwrap();
     }
     output.push_str(&formatted);
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -556,8 +556,16 @@ fn tool_run(args: &Value) -> Result<String, String> {
         }
     };
 
-    let stdout_str = stdout_handle.join().ok().and_then(std::result::Result::ok).unwrap_or_default();
-    let stderr_str = stderr_handle.join().ok().and_then(std::result::Result::ok).unwrap_or_default();
+    let stdout_str = stdout_handle
+        .join()
+        .ok()
+        .and_then(std::result::Result::ok)
+        .unwrap_or_default();
+    let stderr_str = stderr_handle
+        .join()
+        .ok()
+        .and_then(std::result::Result::ok)
+        .unwrap_or_default();
 
     let combined = match (stdout_str.is_empty(), stderr_str.is_empty()) {
         (_, true) => stdout_str,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -60,7 +60,8 @@ tilth_run: Run a shell command with structured output parsing. Replaces Bash for
 To search code, use tilth_search instead of Grep or Bash(grep/rg).\n\
 To read files, use tilth_read instead of Read or Bash(cat).\n\
 To find files, use tilth_files instead of Glob or Bash(find/ls).\n\
-To run commands, use tilth_run instead of Bash for build/test/lint commands.\nDO NOT re-read files already shown in expanded search results.";
+To run commands, use tilth_run instead of Bash for build/test/lint commands.\n\
+DO NOT re-read files already shown in expanded search results.";
 
 const EDIT_MODE_EXTRA: &str = "\n\
 \n\
@@ -520,37 +521,51 @@ fn tool_run(args: &Value) -> Result<String, String> {
         .and_then(|v| v.as_str())
         .ok_or("missing required parameter: command")?;
 
-    let _timeout_secs = args
+    let timeout_secs = args
         .get("timeout")
         .and_then(serde_json::Value::as_u64)
         .unwrap_or(DEFAULT_RUN_TIMEOUT_SECS);
 
-    let child = std::process::Command::new("sh")
+    let mut child = std::process::Command::new("sh")
         .args(["-c", command])
         .stdout(std::process::Stdio::piped())
         .stderr(std::process::Stdio::piped())
-        .spawn();
+        .spawn()
+        .map_err(|e| format!("failed to spawn command: {e}"))?;
 
-    let child = match child {
-        Ok(c) => c,
-        Err(e) => return Err(format!("failed to spawn command: {e}")),
+    // Read stdout/stderr in background threads to avoid pipe deadlock.
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let stdout_handle = std::thread::spawn(move || std::io::read_to_string(stdout));
+    let stderr_handle = std::thread::spawn(move || std::io::read_to_string(stderr));
+
+    // Poll for completion with timeout.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(timeout_secs);
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => {
+                if std::time::Instant::now() >= deadline {
+                    let _ = child.kill();
+                    let _ = child.wait(); // reap zombie
+                    return Err(format!("command timed out after {timeout_secs}s"));
+                }
+                std::thread::sleep(std::time::Duration::from_millis(50));
+            }
+            Err(e) => return Err(format!("failed to wait on command: {e}")),
+        }
     };
 
-    let output = child
-        .wait_with_output()
-        .map_err(|e| format!("command execution failed: {e}"))?;
+    let stdout_str = stdout_handle.join().ok().and_then(std::result::Result::ok).unwrap_or_default();
+    let stderr_str = stderr_handle.join().ok().and_then(std::result::Result::ok).unwrap_or_default();
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let combined = if stderr.is_empty() {
-        stdout.into_owned()
-    } else if stdout.is_empty() {
-        stderr.into_owned()
-    } else {
-        format!("{stdout}{stderr}")
+    let combined = match (stdout_str.is_empty(), stderr_str.is_empty()) {
+        (_, true) => stdout_str,
+        (true, _) => stderr_str,
+        _ => format!("{stdout_str}{stderr_str}"),
     };
 
-    let exit_code = output.status.code().unwrap_or(-1);
+    let exit_code = status.code().unwrap_or(-1);
     let processed = crate::run::process(&combined);
 
     let mut result_text = String::with_capacity(processed.len() + 32);

--- a/src/run/ansi.rs
+++ b/src/run/ansi.rs
@@ -75,7 +75,10 @@ mod tests {
 
     #[test]
     fn strips_osc_with_st() {
-        assert_eq!(strip("\x1b]8;;http://example.com\x1b\\link\x1b]8;;\x1b\\"), "link");
+        assert_eq!(
+            strip("\x1b]8;;http://example.com\x1b\\link\x1b]8;;\x1b\\"),
+            "link"
+        );
     }
 
     #[test]

--- a/src/run/ansi.rs
+++ b/src/run/ansi.rs
@@ -40,6 +40,21 @@ pub fn strip(input: &str) -> String {
                     }
                     i += 1;
                 }
+            } else if i < bytes.len() && (0x40..=0x5F).contains(&bytes[i]) {
+                // Fe escape sequence (2 bytes total): ESC + final byte
+                // Includes \x1bD (IND), \x1bE (NEL), \x1bM (RI), etc.
+                // [ and ] already handled above.
+                i += 1;
+            } else if i < bytes.len() && (0x20..=0x2F).contains(&bytes[i]) {
+                // Escape sequence with intermediate bytes: ESC <intermediates> <final>
+                // Example: \x1b(B (select ASCII charset)
+                // Skip intermediate bytes (0x20-0x2F), then skip the final byte (0x30-0x7E)
+                while i < bytes.len() && (0x20..=0x2F).contains(&bytes[i]) {
+                    i += 1;
+                }
+                if i < bytes.len() && (0x30..=0x7E).contains(&bytes[i]) {
+                    i += 1;
+                }
             }
             // Any other escape: just consumed the 0x1b, continue.
         } else {
@@ -49,8 +64,10 @@ pub fn strip(input: &str) -> String {
     }
 
     // All remaining bytes are original UTF-8 content — the stripping only
-    // skips escape sequences without modifying any other bytes.
-    String::from_utf8(out).expect("ANSI stripping preserved valid UTF-8")
+    // skips escape sequences without modifying any other bytes. If somehow
+    // invalid UTF-8 slips through (e.g. ESC inside a multibyte sequence),
+    // degrade gracefully rather than panic.
+    String::from_utf8(out).unwrap_or_else(|e| String::from_utf8_lossy(e.as_bytes()).into_owned())
 }
 
 #[cfg(test)]
@@ -84,5 +101,30 @@ mod tests {
     #[test]
     fn preserves_utf8() {
         assert_eq!(strip("\x1b[1m日本語\x1b[0m"), "日本語");
+    }
+
+    #[test]
+    fn strips_fe_escape_sequence() {
+        // \x1b(B is "select ASCII charset" — a 3-byte Fe escape sequence.
+        // Bug: only the ESC byte is consumed, "(B" leaks into output.
+        assert_eq!(strip("hello\x1b(Bworld"), "helloworld");
+    }
+
+    #[test]
+    fn strips_designate_charset_sequence() {
+        // \x1b(0 is "select DEC Special Graphics charset" — intermediate + final byte
+        assert_eq!(strip("before\x1b(0after"), "beforeafter");
+    }
+
+    #[test]
+    fn valid_utf8_input_produces_valid_utf8_output() {
+        // Valid UTF-8 input with escape sequences around multibyte chars.
+        // Stripping removes only ASCII-range escape bytes, preserving UTF-8 validity.
+        let input = "\x1b[1m日本語\x1b(B test\x1b[0m";
+        let result = strip(input);
+        assert!(result.contains("日本語"));
+        assert!(result.contains("test"));
+        // Verify the result is valid UTF-8 (it's a String, so this is guaranteed,
+        // but the from_utf8_lossy fallback in strip() provides defense-in-depth).
     }
 }

--- a/src/run/ansi.rs
+++ b/src/run/ansi.rs
@@ -1,0 +1,85 @@
+use memchr::memchr;
+
+/// Strip ANSI escape sequences from a string.
+///
+/// Fast path uses SIMD (via memchr) to detect if any escape bytes exist at all.
+/// Slow path handles CSI (`\x1b[...letter`), OSC (`\x1b]...BEL` or `\x1b]...ESC \\`) sequences.
+pub fn strip(input: &str) -> String {
+    // Fast path: no escape sequences present.
+    if memchr(0x1b, input.as_bytes()).is_none() {
+        return input.to_string();
+    }
+
+    let bytes = input.as_bytes();
+    let mut out = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+
+    while i < bytes.len() {
+        if bytes[i] == 0x1b {
+            i += 1;
+            if i < bytes.len() && bytes[i] == b'[' {
+                // CSI: skip until final byte in range 0x40–0x7E.
+                i += 1;
+                while i < bytes.len() && !(0x40..=0x7E).contains(&bytes[i]) {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+            } else if i < bytes.len() && bytes[i] == b']' {
+                // OSC: skip until BEL (0x07), ST (ESC \), or end of input.
+                i += 1;
+                while i < bytes.len() {
+                    if bytes[i] == 0x07 {
+                        i += 1;
+                        break;
+                    }
+                    if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' {
+                        i += 2;
+                        break;
+                    }
+                    i += 1;
+                }
+            }
+            // Any other escape: just consumed the 0x1b, continue.
+        } else {
+            out.push(bytes[i]);
+            i += 1;
+        }
+    }
+
+    // All remaining bytes are original UTF-8 content — the stripping only
+    // skips escape sequences without modifying any other bytes.
+    String::from_utf8(out).expect("ANSI stripping preserved valid UTF-8")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn no_ansi_fast_path() {
+        let s = "hello world";
+        assert_eq!(strip(s), s);
+    }
+
+    #[test]
+    fn strips_color_codes() {
+        assert_eq!(strip("\x1b[31mred\x1b[0m"), "red");
+    }
+
+    #[test]
+    fn strips_osc() {
+        assert_eq!(strip("\x1b]0;title\x07text"), "text");
+    }
+
+    #[test]
+    fn strips_osc_with_st() {
+        assert_eq!(strip("\x1b]8;;http://example.com\x1b\\link\x1b]8;;\x1b\\"), "link");
+    }
+
+    #[test]
+    fn preserves_utf8() {
+        assert_eq!(strip("\x1b[1m日本語\x1b[0m"), "日本語");
+    }
+}

--- a/src/run/exec.rs
+++ b/src/run/exec.rs
@@ -1,4 +1,12 @@
+#[cfg(not(unix))]
+compile_error!(
+    "The exec module requires Unix (process groups, killpg). Windows is not yet supported."
+);
+
 use std::path::Path;
+
+#[cfg(unix)]
+use std::os::unix::process::CommandExt;
 
 use crate::error::TilthError;
 
@@ -7,6 +15,26 @@ pub struct ExecResult {
     pub stdout: String,
     pub stderr: String,
     pub timed_out: bool,
+}
+
+impl ExecResult {
+    /// Combine stdout and stderr into a single string.
+    /// If only one stream has output, return it directly (no duplication).
+    /// If both have output, stderr is appended after stdout.
+    #[must_use]
+    pub fn combined_output(self) -> String {
+        match (self.stdout.is_empty(), self.stderr.is_empty()) {
+            (_, true) => self.stdout,
+            (true, _) => self.stderr,
+            _ => {
+                if self.stdout.ends_with('\n') {
+                    format!("{}{}", self.stdout, self.stderr)
+                } else {
+                    format!("{}\n{}", self.stdout, self.stderr)
+                }
+            }
+        }
+    }
 }
 
 const MAX_OUTPUT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
@@ -25,21 +53,25 @@ pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResul
         });
     }
 
-    let mut child = std::process::Command::new("sh")
-        .args(["-c", command])
+    let mut cmd = std::process::Command::new("sh");
+    cmd.args(["-c", command])
         .current_dir(cwd)
         .stdout(std::process::Stdio::piped())
-        .stderr(std::process::Stdio::piped())
-        .spawn()
-        .map_err(|e| TilthError::IoError {
-            path: cwd.to_path_buf(),
-            source: e,
-        })?;
+        .stderr(std::process::Stdio::piped());
+    // Make `sh` a process group leader (setpgid(0,0)) so that on timeout we can
+    // kill the entire group (sh + grandchildren like cargo, npm, etc.).
+    // On Windows, job objects would be the equivalent mechanism.
+    #[cfg(unix)]
+    cmd.process_group(0);
+    let mut child = cmd.spawn().map_err(|e| TilthError::IoError {
+        path: cwd.to_path_buf(),
+        source: e,
+    })?;
 
     // Read stdout/stderr in background threads to avoid pipe deadlock.
     // Bounded reads prevent OOM from runaway commands.
-    let stdout = child.stdout.take().unwrap();
-    let stderr = child.stderr.take().unwrap();
+    let stdout = child.stdout.take().expect("stdout was set to piped");
+    let stderr = child.stderr.take().expect("stderr was set to piped");
     let stdout_handle = std::thread::spawn(move || read_bounded(stdout));
     let stderr_handle = std::thread::spawn(move || read_bounded(stderr));
 
@@ -50,8 +82,8 @@ pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResul
         let _ = tx.send(child.wait());
     });
 
-    let (status, _timed_out) = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
-        Ok(Ok(status)) => (status, false),
+    let status = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok(Ok(status)) => status,
         Ok(Err(e)) => {
             return Err(TilthError::IoError {
                 path: cwd.to_path_buf(),
@@ -59,21 +91,33 @@ pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResul
             });
         }
         Err(_) => {
-            // Kill the child process. The wait thread will unblock and clean up.
-            let _ = std::process::Command::new("kill")
-                .args(["-9", &child_pid.to_string()])
-                .status();
-            // Collect whatever output we have so far.
-            let stdout_str = stdout_handle
-                .join()
-                .ok()
-                .and_then(std::result::Result::ok)
+            // Kill the entire process group so grandchildren (cargo, npm, etc.)
+            // are also terminated. `sh` becomes the group leader via setpgid(0,0).
+            // On Windows a different mechanism (job objects) would be needed.
+            let pgid = child_pid as libc::pid_t;
+            debug_assert!(pgid > 0, "child PID must be positive");
+            if pgid > 0 {
+                unsafe {
+                    libc::killpg(pgid, libc::SIGKILL);
+                }
+            } else {
+                // PID 0 would kill our own process group — never do that.
+                eprintln!("warning: refusing to killpg(0)");
+            }
+
+            // Join reader threads with a 5-second timeout. If they don't finish
+            // (e.g. grandchild still has the pipe open), detach and let them leak —
+            // they'll die once the pipes close after the process group is killed.
+            let (tx_done, rx_done) = std::sync::mpsc::channel::<(String, String)>();
+            std::thread::spawn(move || {
+                let out = stdout_handle.join().unwrap_or_default();
+                let err = stderr_handle.join().unwrap_or_default();
+                let _ = tx_done.send((out, err));
+            });
+            let (stdout_str, stderr_str) = rx_done
+                .recv_timeout(std::time::Duration::from_secs(5))
                 .unwrap_or_default();
-            let stderr_str = stderr_handle
-                .join()
-                .ok()
-                .and_then(std::result::Result::ok)
-                .unwrap_or_default();
+
             return Ok(ExecResult {
                 exit_code: -1,
                 stdout: stdout_str,
@@ -83,26 +127,14 @@ pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResul
         }
     };
 
-    let stdout_str = stdout_handle
-        .join()
-        .map_err(|_| TilthError::InvalidQuery {
-            query: command.to_string(),
-            reason: "stdout reader thread panicked".to_string(),
-        })?
-        .map_err(|e| TilthError::IoError {
-            path: cwd.to_path_buf(),
-            source: e,
-        })?;
-    let stderr_str = stderr_handle
-        .join()
-        .map_err(|_| TilthError::InvalidQuery {
-            query: command.to_string(),
-            reason: "stderr reader thread panicked".to_string(),
-        })?
-        .map_err(|e| TilthError::IoError {
-            path: cwd.to_path_buf(),
-            source: e,
-        })?;
+    let stdout_str = stdout_handle.join().map_err(|_| TilthError::InvalidQuery {
+        query: command.to_string(),
+        reason: "stdout reader thread panicked".to_string(),
+    })?;
+    let stderr_str = stderr_handle.join().map_err(|_| TilthError::InvalidQuery {
+        query: command.to_string(),
+        reason: "stderr reader thread panicked".to_string(),
+    })?;
 
     Ok(ExecResult {
         exit_code: status.code().unwrap_or(-1),
@@ -113,9 +145,135 @@ pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResul
 }
 
 /// Read up to `MAX_OUTPUT_BYTES` from a reader into a String.
-fn read_bounded(reader: impl std::io::Read) -> std::io::Result<String> {
+/// Uses lossy UTF-8 conversion so non-UTF-8 bytes (binary output, locale issues)
+/// don't cause failures.
+fn read_bounded(reader: impl std::io::Read) -> String {
     use std::io::Read;
-    let mut buf = String::new();
-    reader.take(MAX_OUTPUT_BYTES).read_to_string(&mut buf)?;
-    Ok(buf)
+    let mut buf = Vec::new();
+    // Ignore truncation errors — partial output is better than nothing.
+    let _ = reader.take(MAX_OUTPUT_BYTES).read_to_end(&mut buf);
+    String::from_utf8_lossy(&buf).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_bounded_handles_non_utf8() {
+        // Embed invalid UTF-8 bytes (continuation byte without start byte).
+        let invalid: &[u8] = b"hello \xff\xfe world";
+        let result = read_bounded(std::io::Cursor::new(invalid));
+        assert!(result.contains("hello"));
+        assert!(result.contains("world"));
+        // Replacement characters are present for the invalid bytes.
+        assert!(result.contains('\u{FFFD}'));
+    }
+
+    #[test]
+    fn read_bounded_valid_utf8_unchanged() {
+        let input = "cargo build\nFinished in 1.2s\n";
+        let result = read_bounded(std::io::Cursor::new(input.as_bytes()));
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn combined_output_stdout_only() {
+        let r = ExecResult {
+            exit_code: 0,
+            stdout: "hello".into(),
+            stderr: String::new(),
+            timed_out: false,
+        };
+        assert_eq!(r.combined_output(), "hello");
+    }
+
+    #[test]
+    fn combined_output_stderr_only() {
+        let r = ExecResult {
+            exit_code: 1,
+            stdout: String::new(),
+            stderr: "error".into(),
+            timed_out: false,
+        };
+        assert_eq!(r.combined_output(), "error");
+    }
+
+    #[test]
+    fn combined_output_both_streams() {
+        // stdout already ends with newline — no extra separator inserted
+        let r = ExecResult {
+            exit_code: 0,
+            stdout: "out\n".into(),
+            stderr: "err\n".into(),
+            timed_out: false,
+        };
+        assert_eq!(r.combined_output(), "out\nerr\n");
+    }
+
+    #[test]
+    fn combined_output_both_streams_no_trailing_newline() {
+        // stdout lacks trailing newline — separator is inserted
+        let r = ExecResult {
+            exit_code: 0,
+            stdout: "out".into(),
+            stderr: "err\n".into(),
+            timed_out: false,
+        };
+        assert_eq!(r.combined_output(), "out\nerr\n");
+    }
+
+    #[test]
+    fn combined_output_both_empty() {
+        let r = ExecResult {
+            exit_code: 0,
+            stdout: String::new(),
+            stderr: String::new(),
+            timed_out: false,
+        };
+        assert_eq!(r.combined_output(), "");
+    }
+
+    #[test]
+    fn execute_echo_hello() {
+        let result =
+            execute("echo hello", std::path::Path::new("/tmp"), 5).expect("execute should succeed");
+        assert!(
+            result.stdout.contains("hello"),
+            "stdout should contain 'hello'"
+        );
+        assert_eq!(result.exit_code, 0);
+        assert!(!result.timed_out);
+        assert!(result.stderr.is_empty(), "stderr should be empty");
+    }
+
+    #[test]
+    fn execute_timeout() {
+        let result = execute("sleep 60", std::path::Path::new("/tmp"), 1)
+            .expect("execute should return Ok even on timeout");
+        assert!(result.timed_out, "should have timed out");
+        assert_eq!(result.exit_code, -1);
+    }
+
+    #[test]
+    fn execute_bad_cwd() {
+        let result = execute("echo x", std::path::Path::new("/nonexistent_dir_xyz"), 5);
+        assert!(result.is_err(), "bad cwd should return Err");
+    }
+
+    #[test]
+    fn execute_nonzero_exit() {
+        let result =
+            execute("exit 42", std::path::Path::new("/tmp"), 5).expect("execute should succeed");
+        assert_eq!(result.exit_code, 42);
+        assert!(!result.timed_out);
+    }
+
+    #[test]
+    fn execute_stderr_output() {
+        let result = execute("echo err >&2", std::path::Path::new("/tmp"), 5)
+            .expect("execute should succeed");
+        assert!(result.stderr.contains("err"), "stderr should contain 'err'");
+        assert!(result.stdout.is_empty(), "stdout should be empty");
+    }
 }

--- a/src/run/exec.rs
+++ b/src/run/exec.rs
@@ -1,0 +1,121 @@
+use std::path::Path;
+
+use crate::error::TilthError;
+
+pub struct ExecResult {
+    pub exit_code: i32,
+    pub stdout: String,
+    pub stderr: String,
+    pub timed_out: bool,
+}
+
+const MAX_OUTPUT_BYTES: u64 = 10 * 1024 * 1024; // 10 MB
+const DEFAULT_TIMEOUT_SECS: u64 = 120;
+
+#[must_use]
+pub fn default_timeout() -> u64 {
+    DEFAULT_TIMEOUT_SECS
+}
+
+pub fn execute(command: &str, cwd: &Path, timeout_secs: u64) -> Result<ExecResult, TilthError> {
+    if !cwd.is_dir() {
+        return Err(TilthError::NotFound {
+            path: cwd.to_path_buf(),
+            suggestion: None,
+        });
+    }
+
+    let mut child = std::process::Command::new("sh")
+        .args(["-c", command])
+        .current_dir(cwd)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .map_err(|e| TilthError::IoError {
+            path: cwd.to_path_buf(),
+            source: e,
+        })?;
+
+    // Read stdout/stderr in background threads to avoid pipe deadlock.
+    // Bounded reads prevent OOM from runaway commands.
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+    let stdout_handle = std::thread::spawn(move || read_bounded(stdout));
+    let stderr_handle = std::thread::spawn(move || read_bounded(stderr));
+
+    // Wait for exit on a dedicated thread so we don't block the MCP I/O loop.
+    let child_pid = child.id();
+    let (tx, rx) = std::sync::mpsc::channel();
+    std::thread::spawn(move || {
+        let _ = tx.send(child.wait());
+    });
+
+    let (status, _timed_out) = match rx.recv_timeout(std::time::Duration::from_secs(timeout_secs)) {
+        Ok(Ok(status)) => (status, false),
+        Ok(Err(e)) => {
+            return Err(TilthError::IoError {
+                path: cwd.to_path_buf(),
+                source: e,
+            });
+        }
+        Err(_) => {
+            // Kill the child process. The wait thread will unblock and clean up.
+            let _ = std::process::Command::new("kill")
+                .args(["-9", &child_pid.to_string()])
+                .status();
+            // Collect whatever output we have so far.
+            let stdout_str = stdout_handle
+                .join()
+                .ok()
+                .and_then(std::result::Result::ok)
+                .unwrap_or_default();
+            let stderr_str = stderr_handle
+                .join()
+                .ok()
+                .and_then(std::result::Result::ok)
+                .unwrap_or_default();
+            return Ok(ExecResult {
+                exit_code: -1,
+                stdout: stdout_str,
+                stderr: stderr_str,
+                timed_out: true,
+            });
+        }
+    };
+
+    let stdout_str = stdout_handle
+        .join()
+        .map_err(|_| TilthError::InvalidQuery {
+            query: command.to_string(),
+            reason: "stdout reader thread panicked".to_string(),
+        })?
+        .map_err(|e| TilthError::IoError {
+            path: cwd.to_path_buf(),
+            source: e,
+        })?;
+    let stderr_str = stderr_handle
+        .join()
+        .map_err(|_| TilthError::InvalidQuery {
+            query: command.to_string(),
+            reason: "stderr reader thread panicked".to_string(),
+        })?
+        .map_err(|e| TilthError::IoError {
+            path: cwd.to_path_buf(),
+            source: e,
+        })?;
+
+    Ok(ExecResult {
+        exit_code: status.code().unwrap_or(-1),
+        stdout: stdout_str,
+        stderr: stderr_str,
+        timed_out: false,
+    })
+}
+
+/// Read up to `MAX_OUTPUT_BYTES` from a reader into a String.
+fn read_bounded(reader: impl std::io::Read) -> std::io::Result<String> {
+    use std::io::Read;
+    let mut buf = String::new();
+    reader.take(MAX_OUTPUT_BYTES).read_to_string(&mut buf)?;
+    Ok(buf)
+}

--- a/src/run/format.rs
+++ b/src/run/format.rs
@@ -1,0 +1,328 @@
+use std::fmt::Write as FmtWrite;
+
+use crate::run::types::{DiagnosticGroup, ParsedOutput};
+
+const HEAD_TAIL_LINES: usize = 10;
+const MAX_DETAIL_LINES: usize = 10;
+
+/// Format parsed output into a human-readable (and AI-readable) summary.
+///
+/// Returns the formatted string. The caller is responsible for the never-worse
+/// check (falling back to original input when formatted >= original length).
+pub fn format_output(
+    parsed: &ParsedOutput,
+    groups: &[DiagnosticGroup],
+    focus: Option<&str>,
+) -> String {
+    if parsed.tool == "unknown" {
+        // Unknown tools are formatted via format_generic_with_raw; this path
+        // only fires if someone calls format_output directly for unknown.
+        return String::new();
+    }
+
+    match focus {
+        Some(f) => format_focused(parsed, groups, f),
+        None => format_summary(parsed, groups),
+    }
+}
+
+
+// ---------------------------------------------------------------------------
+// Summary format (non-generic tools, no focus)
+// ---------------------------------------------------------------------------
+
+fn format_summary(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
+    let mut out = String::with_capacity(512);
+
+    write_header_line(&mut out, parsed);
+
+    for group in groups {
+        let _ = out.write_char('\n');
+        write_group_block(&mut out, group);
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Focused format (drill into a specific diagnostic name)
+// ---------------------------------------------------------------------------
+
+fn format_focused(parsed: &ParsedOutput, groups: &[DiagnosticGroup], focus: &str) -> String {
+    let matched: Vec<&DiagnosticGroup> = groups
+        .iter()
+        .filter(|g| g.signature.contains(focus) || g.representative.name.contains(focus))
+        .collect();
+
+    if matched.is_empty() {
+        let mut out = String::with_capacity(256);
+        let _ = writeln!(
+            out,
+            "# {} — no match for '{focus}'",
+            parsed.tool
+        );
+        let _ = out.write_str("#\n# Available diagnostics:\n");
+        for g in groups {
+            let _ = writeln!(out, "#   {} {}", g.severity, g.signature);
+        }
+        return out;
+    }
+
+    let mut out = String::with_capacity(512);
+    write_header_line(&mut out, parsed);
+
+    for group in matched {
+        let _ = out.write_char('\n');
+        // Focused mode: show all locations (not capped to MAX_LOCATIONS_PER_GROUP).
+        write_group_block_full(&mut out, group);
+    }
+
+    out
+}
+
+// ---------------------------------------------------------------------------
+// Shared formatting helpers
+// ---------------------------------------------------------------------------
+
+fn write_header_line(out: &mut String, parsed: &ParsedOutput) {
+    let _ = out.write_str("# ");
+    let _ = out.write_str(parsed.tool);
+    let _ = out.write_str(" — ");
+    let _ = out.write_str(&parsed.summary);
+    if let Some(d) = parsed.duration_secs {
+        let _ = write!(out, " ({d:.1}s)");
+    }
+    let _ = out.write_char('\n');
+}
+
+
+fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
+    // Header line
+    let cascade_tag = if group.cascading { " [cascading]" } else { "" };
+
+    if group.locations.len() > 1 || group.total > 1 {
+        // Multiple locations or occurrences
+        let _ = writeln!(
+            out,
+            "# {} {} — {} occurrence(s){cascade_tag}",
+            group.severity,
+            group.signature,
+            group.total,
+        );
+        // List locations
+        if !group.locations.is_empty() {
+            let _ = out.write_str("#   ");
+            let mut first = true;
+            for loc in &group.locations {
+                if !first {
+                    let _ = out.write_str(", ");
+                }
+                let _ = out.write_str(&loc.to_string());
+                first = false;
+            }
+            let extra = group.total.saturating_sub(group.locations.len());
+            if extra > 0 {
+                let _ = write!(out, " (+{extra} more)");
+            }
+            let _ = out.write_char('\n');
+        }
+    } else {
+        // Single occurrence
+        let loc_str = group
+            .representative
+            .location
+            .as_ref()
+            .map(|l| format!(" {l}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "# {}{loc_str} {}{cascade_tag}",
+            group.severity,
+            group.signature,
+        );
+    }
+
+    // Message
+    let _ = writeln!(out, "#   {}", group.representative.message);
+
+    // Detail (truncated)
+    if let Some(detail) = &group.representative.detail {
+        write_detail(out, detail);
+    }
+}
+
+fn write_group_block_full(out: &mut String, group: &DiagnosticGroup) {
+    let cascade_tag = if group.cascading { " [cascading]" } else { "" };
+
+    let _ = writeln!(
+        out,
+        "# {} {} — {} occurrence(s){cascade_tag}",
+        group.severity,
+        group.signature,
+        group.total,
+    );
+
+    // All locations (not capped).
+    if !group.locations.is_empty() {
+        let _ = out.write_str("#   ");
+        let mut first = true;
+        for loc in &group.locations {
+            if !first {
+                let _ = out.write_str(", ");
+            }
+            let _ = out.write_str(&loc.to_string());
+            first = false;
+        }
+        let _ = out.write_char('\n');
+    }
+
+    let _ = writeln!(out, "#   {}", group.representative.message);
+
+    if let Some(detail) = &group.representative.detail {
+        // Full detail in focused mode — no truncation.
+        for line in detail.lines() {
+            let _ = writeln!(out, "#   {line}");
+        }
+    }
+}
+
+/// Write detail lines, truncating to MAX_DETAIL_LINES.
+fn write_detail(out: &mut String, detail: &str) {
+    let total: usize = detail.lines().count();
+
+    for (count, line) in detail.lines().enumerate() {
+        if count >= MAX_DETAIL_LINES {
+            let remaining = total - count;
+            let _ = writeln!(out, "#   ... ({remaining} more lines)");
+            break;
+        }
+        let _ = writeln!(out, "#   {line}");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic format with head/tail (called from process_inner with access to raw)
+// ---------------------------------------------------------------------------
+
+/// Format generic output with head/tail sections from the original cleaned lines.
+///
+/// Shows grouped error lines first, then head/tail of the raw output for context.
+/// Skips head/tail when error lines dominate (>80% of input) — the groups already
+/// contain all useful information.
+pub fn format_generic_with_raw(
+    parsed: &ParsedOutput,
+    groups: &[DiagnosticGroup],
+    cleaned: &str,
+) -> String {
+    let mut out = String::with_capacity(512);
+
+    write_header_line(&mut out, parsed);
+
+    if !groups.is_empty() {
+        let _ = out.write_char('\n');
+        for group in groups {
+            write_group_block(&mut out, group);
+        }
+    }
+
+    // Skip head/tail when errors dominate the input — the groups are the content.
+    let error_line_count: usize = groups.iter().map(|g| g.total).sum();
+    let error_ratio = error_line_count as f64 / parsed.raw_lines.max(1) as f64;
+    if error_ratio > 0.8 {
+        return out;
+    }
+
+    // Head + tail for context around the errors.
+    let lines: Vec<&str> = cleaned.lines().collect();
+    let n = lines.len();
+    let head_count = HEAD_TAIL_LINES.min(n);
+
+    let _ = writeln!(out, "#\n# --- first {head_count} lines ---");
+    for line in &lines[..head_count] {
+        let _ = writeln!(out, "# {line}");
+    }
+
+    if n > head_count * 2 {
+        let tail_start = n - HEAD_TAIL_LINES.min(n);
+        let tail_count = n - tail_start;
+        let _ = writeln!(out, "# --- last {tail_count} lines ---");
+        for line in &lines[tail_start..] {
+            let _ = writeln!(out, "# {line}");
+        }
+    } else if n > head_count {
+        let _ = writeln!(out, "# --- last {} lines ---", n - head_count);
+        for line in &lines[head_count..] {
+            let _ = writeln!(out, "# {line}");
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::types::{Counts, Diagnostic, DiagnosticGroup, Location, ParsedOutput, Severity};
+
+    fn make_parsed(tool: &'static str, summary: &str, raw_lines: usize) -> ParsedOutput {
+        ParsedOutput {
+            tool,
+            summary: summary.to_string(),
+            diagnostics: Vec::new(),
+            counts: Counts::default(),
+            duration_secs: None,
+            raw_lines,
+            raw_bytes: 0,
+        }
+    }
+
+    fn make_group(severity: Severity, sig: &str, total: usize) -> DiagnosticGroup {
+        DiagnosticGroup {
+            severity,
+            signature: sig.to_string(),
+            locations: vec![Location {
+                file: "src/main.rs".to_string(),
+                line: 10,
+                column: None,
+            }],
+            total,
+            representative: Diagnostic {
+                severity,
+                location: None,
+                name: sig.to_string(),
+                message: "something went wrong".to_string(),
+                detail: None,
+            },
+            cascading: false,
+        }
+    }
+
+    #[test]
+    fn summary_format_contains_tool() {
+        let parsed = make_parsed("cargo test", "1 failed", 100);
+        let group = make_group(Severity::Error, "test_foo", 1);
+        let out = format_output(&parsed, &[group], None);
+        assert!(out.contains("cargo test"));
+        assert!(out.contains("1 failed"));
+    }
+
+    #[test]
+    fn focused_no_match() {
+        let parsed = make_parsed("cargo test", "1 failed", 100);
+        let group = make_group(Severity::Error, "test_foo", 1);
+        let out = format_output(&parsed, &[group], Some("nonexistent"));
+        assert!(out.contains("no match for 'nonexistent'"));
+        assert!(out.contains("test_foo"));
+    }
+
+    #[test]
+    fn detail_truncation() {
+        let detail: String = (0..20).map(|i| format!("line {i}\n")).collect();
+        let mut out = String::new();
+        write_detail(&mut out, &detail);
+        assert!(out.contains("more lines"));
+        let lines: Vec<_> = out.lines().collect();
+        // Should be MAX_DETAIL_LINES content lines + 1 truncation line.
+        assert_eq!(lines.len(), MAX_DETAIL_LINES + 1);
+    }
+}

--- a/src/run/format.rs
+++ b/src/run/format.rs
@@ -9,26 +9,19 @@ const MAX_DETAIL_LINES: usize = 10;
 ///
 /// Returns the formatted string. The caller is responsible for the never-worse
 /// check (falling back to original input when formatted >= original length).
-pub fn format_output(
-    parsed: &ParsedOutput,
-    groups: &[DiagnosticGroup],
-    focus: Option<&str>,
-) -> String {
+pub fn format_output(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
     if parsed.tool == "unknown" {
         // Unknown tools are formatted via format_generic_with_raw; this path
         // only fires if someone calls format_output directly for unknown.
         return String::new();
     }
 
-    match focus {
-        Some(f) => format_focused(parsed, groups, f),
-        None => format_summary(parsed, groups),
-    }
+    format_summary(parsed, groups)
 }
 
 
 // ---------------------------------------------------------------------------
-// Summary format (non-generic tools, no focus)
+// Summary format (non-generic tools)
 // ---------------------------------------------------------------------------
 
 fn format_summary(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
@@ -39,42 +32,6 @@ fn format_summary(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
     for group in groups {
         let _ = out.write_char('\n');
         write_group_block(&mut out, group);
-    }
-
-    out
-}
-
-// ---------------------------------------------------------------------------
-// Focused format (drill into a specific diagnostic name)
-// ---------------------------------------------------------------------------
-
-fn format_focused(parsed: &ParsedOutput, groups: &[DiagnosticGroup], focus: &str) -> String {
-    let matched: Vec<&DiagnosticGroup> = groups
-        .iter()
-        .filter(|g| g.signature.contains(focus) || g.representative.name.contains(focus))
-        .collect();
-
-    if matched.is_empty() {
-        let mut out = String::with_capacity(256);
-        let _ = writeln!(
-            out,
-            "# {} — no match for '{focus}'",
-            parsed.tool
-        );
-        let _ = out.write_str("#\n# Available diagnostics:\n");
-        for g in groups {
-            let _ = writeln!(out, "#   {} {}", g.severity, g.signature);
-        }
-        return out;
-    }
-
-    let mut out = String::with_capacity(512);
-    write_header_line(&mut out, parsed);
-
-    for group in matched {
-        let _ = out.write_char('\n');
-        // Focused mode: show all locations (not capped to MAX_LOCATIONS_PER_GROUP).
-        write_group_block_full(&mut out, group);
     }
 
     out
@@ -150,42 +107,6 @@ fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
         write_detail(out, detail);
     }
 }
-
-fn write_group_block_full(out: &mut String, group: &DiagnosticGroup) {
-    let cascade_tag = if group.cascading { " [cascading]" } else { "" };
-
-    let _ = writeln!(
-        out,
-        "# {} {} — {} occurrence(s){cascade_tag}",
-        group.severity,
-        group.signature,
-        group.total,
-    );
-
-    // All locations (not capped).
-    if !group.locations.is_empty() {
-        let _ = out.write_str("#   ");
-        let mut first = true;
-        for loc in &group.locations {
-            if !first {
-                let _ = out.write_str(", ");
-            }
-            let _ = out.write_str(&loc.to_string());
-            first = false;
-        }
-        let _ = out.write_char('\n');
-    }
-
-    let _ = writeln!(out, "#   {}", group.representative.message);
-
-    if let Some(detail) = &group.representative.detail {
-        // Full detail in focused mode — no truncation.
-        for line in detail.lines() {
-            let _ = writeln!(out, "#   {line}");
-        }
-    }
-}
-
 /// Write detail lines, truncating to MAX_DETAIL_LINES.
 fn write_detail(out: &mut String, detail: &str) {
     let total: usize = detail.lines().count();
@@ -301,18 +222,9 @@ mod tests {
     fn summary_format_contains_tool() {
         let parsed = make_parsed("cargo test", "1 failed", 100);
         let group = make_group(Severity::Error, "test_foo", 1);
-        let out = format_output(&parsed, &[group], None);
+        let out = format_output(&parsed, &[group]);
         assert!(out.contains("cargo test"));
         assert!(out.contains("1 failed"));
-    }
-
-    #[test]
-    fn focused_no_match() {
-        let parsed = make_parsed("cargo test", "1 failed", 100);
-        let group = make_group(Severity::Error, "test_foo", 1);
-        let out = format_output(&parsed, &[group], Some("nonexistent"));
-        assert!(out.contains("no match for 'nonexistent'"));
-        assert!(out.contains("test_foo"));
     }
 
     #[test]

--- a/src/run/format.rs
+++ b/src/run/format.rs
@@ -19,7 +19,6 @@ pub fn format_output(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> Strin
     format_summary(parsed, groups)
 }
 
-
 // ---------------------------------------------------------------------------
 // Summary format (non-generic tools)
 // ---------------------------------------------------------------------------
@@ -52,7 +51,6 @@ fn write_header_line(out: &mut String, parsed: &ParsedOutput) {
     let _ = out.write_char('\n');
 }
 
-
 fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
     // Header line
     let cascade_tag = if group.cascading { " [cascading]" } else { "" };
@@ -62,9 +60,7 @@ fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
         let _ = writeln!(
             out,
             "# {} {} — {} occurrence(s){cascade_tag}",
-            group.severity,
-            group.signature,
-            group.total,
+            group.severity, group.signature, group.total,
         );
         // List locations
         if !group.locations.is_empty() {
@@ -94,8 +90,7 @@ fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
         let _ = writeln!(
             out,
             "# {}{loc_str} {}{cascade_tag}",
-            group.severity,
-            group.signature,
+            group.severity, group.signature,
         );
     }
 
@@ -183,7 +178,9 @@ pub fn format_generic_with_raw(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::run::types::{Counts, Diagnostic, DiagnosticGroup, Location, ParsedOutput, Severity};
+    use crate::run::types::{
+        Counts, Diagnostic, DiagnosticGroup, Location, ParsedOutput, Severity,
+    };
 
     fn make_parsed(tool: &'static str, summary: &str, raw_lines: usize) -> ParsedOutput {
         ParsedOutput {

--- a/src/run/format.rs
+++ b/src/run/format.rs
@@ -1,68 +1,72 @@
 use std::fmt::Write as FmtWrite;
 
-use crate::run::types::{DiagnosticGroup, ParsedOutput};
+use crate::run::types::{CompressResult, Counts, DiagnosticGroup, Severity};
 
 const HEAD_TAIL_LINES: usize = 10;
 const MAX_DETAIL_LINES: usize = 10;
 
-/// Format parsed output into a human-readable (and AI-readable) summary.
-///
-/// Returns the formatted string. The caller is responsible for the never-worse
-/// check (falling back to original input when formatted >= original length).
-pub fn format_output(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
-    if parsed.tool == "unknown" {
-        // Unknown tools are formatted via format_generic_with_raw; this path
-        // only fires if someone calls format_output directly for unknown.
-        return String::new();
-    }
-
-    format_summary(parsed, groups)
-}
-
 // ---------------------------------------------------------------------------
-// Summary format (non-generic tools)
+// Markdown format
 // ---------------------------------------------------------------------------
 
-fn format_summary(parsed: &ParsedOutput, groups: &[DiagnosticGroup]) -> String {
+pub fn format_markdown(result: &CompressResult) -> String {
     let mut out = String::with_capacity(512);
 
-    write_header_line(&mut out, parsed);
+    write_markdown_header(&mut out, result);
 
-    for group in groups {
+    for group in &result.groups {
         let _ = out.write_char('\n');
-        write_group_block(&mut out, group);
+        write_markdown_group(&mut out, group);
     }
 
     out
 }
 
-// ---------------------------------------------------------------------------
-// Shared formatting helpers
-// ---------------------------------------------------------------------------
+pub fn format_markdown_with_raw(result: &CompressResult, cleaned: &str) -> String {
+    let mut out = String::with_capacity(512);
 
-fn write_header_line(out: &mut String, parsed: &ParsedOutput) {
+    write_markdown_header(&mut out, result);
+
+    if !result.groups.is_empty() {
+        let _ = out.write_char('\n');
+        for group in &result.groups {
+            write_markdown_group(&mut out, group);
+        }
+    }
+
+    // Skip head/tail when errors dominate the input — the groups are the content.
+    let error_line_count: usize = result.groups.iter().map(|g| g.total).sum();
+    #[allow(clippy::cast_precision_loss)] // ratio comparison — precision loss is acceptable
+    let error_ratio = error_line_count as f64 / result.input_stats.lines.max(1) as f64;
+    if error_ratio > 0.8 {
+        return out;
+    }
+
+    write_head_tail_markdown(&mut out, cleaned);
+
+    out
+}
+
+fn write_markdown_header(out: &mut String, result: &CompressResult) {
     let _ = out.write_str("# ");
-    let _ = out.write_str(parsed.tool);
+    let _ = out.write_str(result.tool);
     let _ = out.write_str(" — ");
-    let _ = out.write_str(&parsed.summary);
-    if let Some(d) = parsed.duration_secs {
+    let _ = out.write_str(&result.summary);
+    if let Some(d) = result.duration_secs {
         let _ = write!(out, " ({d:.1}s)");
     }
     let _ = out.write_char('\n');
 }
 
-fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
-    // Header line
+fn write_markdown_group(out: &mut String, group: &DiagnosticGroup) {
     let cascade_tag = if group.cascading { " [cascading]" } else { "" };
 
     if group.locations.len() > 1 || group.total > 1 {
-        // Multiple locations or occurrences
         let _ = writeln!(
             out,
             "# {} {} — {} occurrence(s){cascade_tag}",
             group.severity, group.signature, group.total,
         );
-        // List locations
         if !group.locations.is_empty() {
             let _ = out.write_str("#   ");
             let mut first = true;
@@ -80,7 +84,6 @@ fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
             let _ = out.write_char('\n');
         }
     } else {
-        // Single occurrence
         let loc_str = group
             .representative
             .location
@@ -94,16 +97,14 @@ fn write_group_block(out: &mut String, group: &DiagnosticGroup) {
         );
     }
 
-    // Message
     let _ = writeln!(out, "#   {}", group.representative.message);
 
-    // Detail (truncated)
     if let Some(detail) = &group.representative.detail {
-        write_detail(out, detail);
+        write_detail_markdown(out, detail);
     }
 }
-/// Write detail lines, truncating to MAX_DETAIL_LINES.
-fn write_detail(out: &mut String, detail: &str) {
+
+fn write_detail_markdown(out: &mut String, detail: &str) {
     let total: usize = detail.lines().count();
 
     for (count, line) in detail.lines().enumerate() {
@@ -116,39 +117,7 @@ fn write_detail(out: &mut String, detail: &str) {
     }
 }
 
-// ---------------------------------------------------------------------------
-// Generic format with head/tail (called from process_inner with access to raw)
-// ---------------------------------------------------------------------------
-
-/// Format generic output with head/tail sections from the original cleaned lines.
-///
-/// Shows grouped error lines first, then head/tail of the raw output for context.
-/// Skips head/tail when error lines dominate (>80% of input) — the groups already
-/// contain all useful information.
-pub fn format_generic_with_raw(
-    parsed: &ParsedOutput,
-    groups: &[DiagnosticGroup],
-    cleaned: &str,
-) -> String {
-    let mut out = String::with_capacity(512);
-
-    write_header_line(&mut out, parsed);
-
-    if !groups.is_empty() {
-        let _ = out.write_char('\n');
-        for group in groups {
-            write_group_block(&mut out, group);
-        }
-    }
-
-    // Skip head/tail when errors dominate the input — the groups are the content.
-    let error_line_count: usize = groups.iter().map(|g| g.total).sum();
-    let error_ratio = error_line_count as f64 / parsed.raw_lines.max(1) as f64;
-    if error_ratio > 0.8 {
-        return out;
-    }
-
-    // Head + tail for context around the errors.
+fn write_head_tail_markdown(out: &mut String, cleaned: &str) {
     let lines: Vec<&str> = cleaned.lines().collect();
     let n = lines.len();
     let head_count = HEAD_TAIL_LINES.min(n);
@@ -171,26 +140,262 @@ pub fn format_generic_with_raw(
             let _ = writeln!(out, "# {line}");
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Plain format
+// ---------------------------------------------------------------------------
+
+pub fn format_plain(result: &CompressResult) -> String {
+    let mut out = String::with_capacity(512);
+
+    write_plain_header(&mut out, result);
+
+    for group in &result.groups {
+        let _ = out.write_char('\n');
+        write_plain_group(&mut out, group);
+    }
 
     out
 }
 
+pub fn format_plain_with_raw(result: &CompressResult, cleaned: &str) -> String {
+    let mut out = String::with_capacity(512);
+
+    write_plain_header(&mut out, result);
+
+    if !result.groups.is_empty() {
+        let _ = out.write_char('\n');
+        for group in &result.groups {
+            write_plain_group(&mut out, group);
+        }
+    }
+
+    let error_line_count: usize = result.groups.iter().map(|g| g.total).sum();
+    #[allow(clippy::cast_precision_loss)] // ratio comparison — precision loss is acceptable
+    let error_ratio = error_line_count as f64 / result.input_stats.lines.max(1) as f64;
+    if error_ratio > 0.8 {
+        return out;
+    }
+
+    write_head_tail_plain(&mut out, cleaned);
+
+    out
+}
+
+fn write_plain_header(out: &mut String, result: &CompressResult) {
+    let _ = out.write_str(result.tool);
+    let _ = out.write_str(" — ");
+    let _ = out.write_str(&result.summary);
+    if let Some(d) = result.duration_secs {
+        let _ = write!(out, " ({d:.1}s)");
+    }
+    let _ = out.write_char('\n');
+}
+
+fn write_plain_group(out: &mut String, group: &DiagnosticGroup) {
+    let cascade_tag = if group.cascading { " [cascading]" } else { "" };
+
+    if group.locations.len() > 1 || group.total > 1 {
+        let _ = writeln!(
+            out,
+            "{} {} — {} occurrence(s){cascade_tag}",
+            group.severity, group.signature, group.total,
+        );
+        if !group.locations.is_empty() {
+            let _ = out.write_str("  ");
+            let mut first = true;
+            for loc in &group.locations {
+                if !first {
+                    let _ = out.write_str(", ");
+                }
+                let _ = out.write_str(&loc.to_string());
+                first = false;
+            }
+            let extra = group.total.saturating_sub(group.locations.len());
+            if extra > 0 {
+                let _ = write!(out, " (+{extra} more)");
+            }
+            let _ = out.write_char('\n');
+        }
+    } else {
+        let loc_str = group
+            .representative
+            .location
+            .as_ref()
+            .map(|l| format!(" {l}"))
+            .unwrap_or_default();
+        let _ = writeln!(
+            out,
+            "{}{loc_str} {}{cascade_tag}",
+            group.severity, group.signature,
+        );
+    }
+
+    let _ = writeln!(out, "  {}", group.representative.message);
+
+    if let Some(detail) = &group.representative.detail {
+        write_detail_plain(out, detail);
+    }
+}
+
+fn write_detail_plain(out: &mut String, detail: &str) {
+    let total: usize = detail.lines().count();
+
+    for (count, line) in detail.lines().enumerate() {
+        if count >= MAX_DETAIL_LINES {
+            let remaining = total - count;
+            let _ = writeln!(out, "  ... ({remaining} more lines)");
+            break;
+        }
+        let _ = writeln!(out, "  {line}");
+    }
+}
+
+fn write_head_tail_plain(out: &mut String, cleaned: &str) {
+    let lines: Vec<&str> = cleaned.lines().collect();
+    let n = lines.len();
+    let head_count = HEAD_TAIL_LINES.min(n);
+
+    let _ = writeln!(out, "\n--- first {head_count} lines ---");
+    for line in &lines[..head_count] {
+        let _ = writeln!(out, "{line}");
+    }
+
+    if n > head_count * 2 {
+        let tail_start = n - HEAD_TAIL_LINES.min(n);
+        let tail_count = n - tail_start;
+        let _ = writeln!(out, "--- last {tail_count} lines ---");
+        for line in &lines[tail_start..] {
+            let _ = writeln!(out, "{line}");
+        }
+    } else if n > head_count {
+        let _ = writeln!(out, "--- last {} lines ---", n - head_count);
+        for line in &lines[head_count..] {
+            let _ = writeln!(out, "{line}");
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// JSON format
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize)]
+struct JsonOutput<'a> {
+    tool: &'a str,
+    summary: &'a str,
+    duration_secs: Option<f64>,
+    counts: &'a Counts,
+    groups: Vec<JsonGroup<'a>>,
+}
+
+#[derive(serde::Serialize)]
+struct JsonGroup<'a> {
+    severity: &'a str,
+    signature: &'a str,
+    total: usize,
+    locations: Vec<String>,
+    message: &'a str,
+    cascading: bool,
+}
+
+#[derive(serde::Serialize)]
+struct JsonOutputWithRaw<'a> {
+    tool: &'a str,
+    summary: &'a str,
+    duration_secs: Option<f64>,
+    counts: &'a Counts,
+    groups: Vec<JsonGroup<'a>>,
+    head: Vec<&'a str>,
+    tail: Vec<&'a str>,
+}
+
+fn build_json_groups(result: &CompressResult) -> Vec<JsonGroup<'_>> {
+    result
+        .groups
+        .iter()
+        .map(|g| {
+            let severity_str = match g.severity {
+                Severity::Error => "error",
+                Severity::Warning => "warning",
+                Severity::Info => "info",
+            };
+            JsonGroup {
+                severity: severity_str,
+                signature: &g.signature,
+                total: g.total,
+                locations: g
+                    .locations
+                    .iter()
+                    .map(std::string::ToString::to_string)
+                    .collect(),
+                message: &g.representative.message,
+                cascading: g.cascading,
+            }
+        })
+        .collect()
+}
+
+pub fn format_json(result: &CompressResult) -> String {
+    let output = JsonOutput {
+        tool: result.tool,
+        summary: &result.summary,
+        duration_secs: result.duration_secs,
+        counts: &result.counts,
+        groups: build_json_groups(result),
+    };
+    serde_json::to_string(&output).unwrap_or_default()
+}
+
+pub fn format_json_with_raw(result: &CompressResult, cleaned: &str) -> String {
+    let lines: Vec<&str> = cleaned.lines().collect();
+    let n = lines.len();
+    let head_count = HEAD_TAIL_LINES.min(n);
+    let head: Vec<&str> = lines[..head_count].to_vec();
+    let tail: Vec<&str> = if n > head_count * 2 {
+        let tail_start = n - HEAD_TAIL_LINES.min(n);
+        lines[tail_start..].to_vec()
+    } else if n > head_count {
+        lines[head_count..].to_vec()
+    } else {
+        Vec::new()
+    };
+
+    let output = JsonOutputWithRaw {
+        tool: result.tool,
+        summary: &result.summary,
+        duration_secs: result.duration_secs,
+        counts: &result.counts,
+        groups: build_json_groups(result),
+        head,
+        tail,
+    };
+    serde_json::to_string(&output).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::run::types::{
-        Counts, Diagnostic, DiagnosticGroup, Location, ParsedOutput, Severity,
-    };
+    use crate::run::types::{Counts, Diagnostic, DiagnosticGroup, InputStats, Location, Severity};
 
-    fn make_parsed(tool: &'static str, summary: &str, raw_lines: usize) -> ParsedOutput {
-        ParsedOutput {
+    fn make_result(tool: &'static str, summary: &str, raw_lines: usize) -> CompressResult {
+        CompressResult {
             tool,
             summary: summary.to_string(),
-            diagnostics: Vec::new(),
+            groups: Vec::new(),
             counts: Counts::default(),
             duration_secs: None,
-            raw_lines,
-            raw_bytes: 0,
+            input_stats: InputStats {
+                lines: raw_lines,
+                bytes: 0,
+            },
+            passthrough: false,
+            cleaned: None,
         }
     }
 
@@ -217,9 +422,9 @@ mod tests {
 
     #[test]
     fn summary_format_contains_tool() {
-        let parsed = make_parsed("cargo test", "1 failed", 100);
-        let group = make_group(Severity::Error, "test_foo", 1);
-        let out = format_output(&parsed, &[group]);
+        let mut result = make_result("cargo test", "1 failed", 100);
+        result.groups = vec![make_group(Severity::Error, "test_foo", 1)];
+        let out = format_markdown(&result);
         assert!(out.contains("cargo test"));
         assert!(out.contains("1 failed"));
     }
@@ -228,10 +433,27 @@ mod tests {
     fn detail_truncation() {
         let detail: String = (0..20).map(|i| format!("line {i}\n")).collect();
         let mut out = String::new();
-        write_detail(&mut out, &detail);
+        write_detail_markdown(&mut out, &detail);
         assert!(out.contains("more lines"));
         let lines: Vec<_> = out.lines().collect();
         // Should be MAX_DETAIL_LINES content lines + 1 truncation line.
         assert_eq!(lines.len(), MAX_DETAIL_LINES + 1);
+    }
+
+    #[test]
+    fn plain_format_no_hash_prefix() {
+        let mut result = make_result("cargo test", "1 failed", 100);
+        result.groups = vec![make_group(Severity::Error, "test_foo", 1)];
+        let out = format_plain(&result);
+        assert!(!out.contains("# "));
+        assert!(out.contains("cargo test"));
+    }
+
+    #[test]
+    fn json_format_parses() {
+        let result = make_result("cargo test", "1 failed", 100);
+        let out = format_json(&result);
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert_eq!(parsed["tool"], "cargo test");
     }
 }

--- a/src/run/format.rs
+++ b/src/run/format.rs
@@ -1,3 +1,4 @@
+use std::collections::VecDeque;
 use std::fmt::Write as FmtWrite;
 
 use crate::run::types::{CompressResult, Counts, DiagnosticGroup, Severity};
@@ -34,11 +35,11 @@ pub fn format_markdown_with_raw(result: &CompressResult, cleaned: &str) -> Strin
         }
     }
 
-    // Skip head/tail when errors dominate the input — the groups are the content.
-    let error_line_count: usize = result.groups.iter().map(|g| g.total).sum();
+    // Skip head/tail when error groups dominate the input — the groups are the content.
+    // Each group contributes ~5 lines of formatted output; if that fills >80% of input, skip.
+    let estimated_error_lines = result.groups.len() * 5;
     #[allow(clippy::cast_precision_loss)] // ratio comparison — precision loss is acceptable
-    let error_ratio = error_line_count as f64 / result.input_stats.lines.max(1) as f64;
-    if error_ratio > 0.8 {
+    if estimated_error_lines as f64 / result.input_stats.lines.max(1) as f64 > 0.8 {
         return out;
     }
 
@@ -117,26 +118,50 @@ fn write_detail_markdown(out: &mut String, detail: &str) {
     }
 }
 
+struct HeadTail<'a> {
+    head: Vec<&'a str>,
+    tail: VecDeque<&'a str>,
+    total: usize,
+}
+
+fn collect_head_tail(text: &str) -> HeadTail<'_> {
+    let mut head: Vec<&str> = Vec::with_capacity(HEAD_TAIL_LINES);
+    let mut tail: VecDeque<&str> = VecDeque::with_capacity(HEAD_TAIL_LINES);
+    let mut total = 0usize;
+
+    for line in text.lines() {
+        if total < HEAD_TAIL_LINES {
+            head.push(line);
+        } else {
+            if tail.len() == HEAD_TAIL_LINES {
+                tail.pop_front();
+            }
+            tail.push_back(line);
+        }
+        total += 1;
+    }
+
+    HeadTail { head, tail, total }
+}
+
 fn write_head_tail_markdown(out: &mut String, cleaned: &str) {
-    let lines: Vec<&str> = cleaned.lines().collect();
-    let n = lines.len();
-    let head_count = HEAD_TAIL_LINES.min(n);
+    let HeadTail { head, tail, total } = collect_head_tail(cleaned);
+    let head_count = head.len();
 
     let _ = writeln!(out, "#\n# --- first {head_count} lines ---");
-    for line in &lines[..head_count] {
+    for line in &head {
         let _ = writeln!(out, "# {line}");
     }
 
-    if n > head_count * 2 {
-        let tail_start = n - HEAD_TAIL_LINES.min(n);
-        let tail_count = n - tail_start;
+    if total > head_count * 2 {
+        let tail_count = tail.len();
         let _ = writeln!(out, "# --- last {tail_count} lines ---");
-        for line in &lines[tail_start..] {
+        for line in &tail {
             let _ = writeln!(out, "# {line}");
         }
-    } else if n > head_count {
-        let _ = writeln!(out, "# --- last {} lines ---", n - head_count);
-        for line in &lines[head_count..] {
+    } else if total > head_count {
+        let _ = writeln!(out, "# --- last {} lines ---", total - head_count);
+        for line in &tail {
             let _ = writeln!(out, "# {line}");
         }
     }
@@ -171,10 +196,11 @@ pub fn format_plain_with_raw(result: &CompressResult, cleaned: &str) -> String {
         }
     }
 
-    let error_line_count: usize = result.groups.iter().map(|g| g.total).sum();
+    // Skip head/tail when error groups dominate the input — the groups are the content.
+    // Each group contributes ~5 lines of formatted output; if that fills >80% of input, skip.
+    let estimated_error_lines = result.groups.len() * 5;
     #[allow(clippy::cast_precision_loss)] // ratio comparison — precision loss is acceptable
-    let error_ratio = error_line_count as f64 / result.input_stats.lines.max(1) as f64;
-    if error_ratio > 0.8 {
+    if estimated_error_lines as f64 / result.input_stats.lines.max(1) as f64 > 0.8 {
         return out;
     }
 
@@ -253,25 +279,23 @@ fn write_detail_plain(out: &mut String, detail: &str) {
 }
 
 fn write_head_tail_plain(out: &mut String, cleaned: &str) {
-    let lines: Vec<&str> = cleaned.lines().collect();
-    let n = lines.len();
-    let head_count = HEAD_TAIL_LINES.min(n);
+    let HeadTail { head, tail, total } = collect_head_tail(cleaned);
+    let head_count = head.len();
 
     let _ = writeln!(out, "\n--- first {head_count} lines ---");
-    for line in &lines[..head_count] {
+    for line in &head {
         let _ = writeln!(out, "{line}");
     }
 
-    if n > head_count * 2 {
-        let tail_start = n - HEAD_TAIL_LINES.min(n);
-        let tail_count = n - tail_start;
+    if total > head_count * 2 {
+        let tail_count = tail.len();
         let _ = writeln!(out, "--- last {tail_count} lines ---");
-        for line in &lines[tail_start..] {
+        for line in &tail {
             let _ = writeln!(out, "{line}");
         }
-    } else if n > head_count {
-        let _ = writeln!(out, "--- last {} lines ---", n - head_count);
-        for line in &lines[head_count..] {
+    } else if total > head_count {
+        let _ = writeln!(out, "--- last {} lines ---", total - head_count);
+        for line in &tail {
             let _ = writeln!(out, "{line}");
         }
     }
@@ -297,6 +321,8 @@ struct JsonGroup<'a> {
     total: usize,
     locations: Vec<String>,
     message: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<&'a str>,
     cascading: bool,
 }
 
@@ -331,6 +357,7 @@ fn build_json_groups(result: &CompressResult) -> Vec<JsonGroup<'_>> {
                     .map(std::string::ToString::to_string)
                     .collect(),
                 message: &g.representative.message,
+                detail: g.representative.detail.as_deref(),
                 cascading: g.cascading,
             }
         })
@@ -345,7 +372,7 @@ pub fn format_json(result: &CompressResult) -> String {
         counts: &result.counts,
         groups: build_json_groups(result),
     };
-    serde_json::to_string(&output).unwrap_or_default()
+    serde_json::to_string(&output).expect("CompressResult JSON is always serializable")
 }
 
 pub fn format_json_with_raw(result: &CompressResult, cleaned: &str) -> String {
@@ -371,7 +398,7 @@ pub fn format_json_with_raw(result: &CompressResult, cleaned: &str) -> String {
         head,
         tail,
     };
-    serde_json::to_string(&output).unwrap_or_default()
+    serde_json::to_string(&output).expect("CompressResult JSON is always serializable")
 }
 
 // ---------------------------------------------------------------------------
@@ -455,5 +482,64 @@ mod tests {
         let out = format_json(&result);
         let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
         assert_eq!(parsed["tool"], "cargo test");
+    }
+
+    #[test]
+    fn json_format_includes_detail_field() {
+        let mut result = make_result("cargo test", "1 failed", 100);
+        let mut group = make_group(Severity::Error, "test_foo", 1);
+        group.representative.detail = Some("expected 1, got 2\nstack trace here".to_string());
+        result.groups = vec![group];
+
+        let out = format_json(&result);
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        let detail = parsed["groups"][0]["detail"]
+            .as_str()
+            .expect("detail field must be present");
+        assert!(detail.contains("expected 1, got 2"));
+    }
+
+    #[test]
+    fn json_format_omits_detail_when_none() {
+        let mut result = make_result("cargo test", "1 failed", 100);
+        result.groups = vec![make_group(Severity::Error, "test_foo", 1)];
+
+        let out = format_json(&result);
+        let parsed: serde_json::Value = serde_json::from_str(&out).expect("valid JSON");
+        assert!(
+            parsed["groups"][0].get("detail").is_none(),
+            "detail field should be omitted when None"
+        );
+    }
+
+    #[test]
+    fn json_format_never_empty_string() {
+        let result = make_result("cargo test", "ok", 10);
+        let out = format_json(&result);
+        assert!(!out.is_empty(), "JSON output must never be empty");
+        // Must be valid JSON
+        serde_json::from_str::<serde_json::Value>(&out).expect("must be valid JSON");
+    }
+
+    #[test]
+    fn head_tail_not_suppressed_by_inflated_diagnostic_count() {
+        // 100-line input, 5 error groups with total=20 each (100 diagnostics total).
+        // The error_ratio should not suppress head/tail — only 5 distinct error patterns
+        // exist, and many lines are non-error content (build progress, etc.).
+        let mut result = make_result("cargo build", "5 errors", 100);
+        result.groups = (0..5)
+            .map(|i| {
+                let mut g = make_group(Severity::Error, &format!("E{i:03}"), 20);
+                g.total = 20;
+                g
+            })
+            .collect();
+
+        let cleaned: String = (0..100).map(|i| format!("line {i}\n")).collect();
+        let out = format_markdown_with_raw(&result, &cleaned);
+        assert!(
+            out.contains("first"),
+            "head/tail should NOT be suppressed when diagnostic count inflates the ratio"
+        );
     }
 }

--- a/src/run/group.rs
+++ b/src/run/group.rs
@@ -80,9 +80,8 @@ pub fn group(diagnostics: &[Diagnostic]) -> Vec<DiagnosticGroup> {
 
     // Retain only within caps; collect remaining info groups too (uncapped for now).
     let info_start = warn_end_raw;
-    let mut result: Vec<DiagnosticGroup> = Vec::with_capacity(
-        error_end_capped + warn_count + (groups.len() - info_start),
-    );
+    let mut result: Vec<DiagnosticGroup> =
+        Vec::with_capacity(error_end_capped + warn_count + (groups.len() - info_start));
 
     result.extend(groups.drain(..error_end).take(MAX_ERROR_GROUPS));
     let remaining = groups;
@@ -214,7 +213,10 @@ mod tests {
             .map(|i| make_diag(Severity::Error, &format!("E{i:03}"), "msg"))
             .collect();
         let groups = group(&diags);
-        let error_count = groups.iter().filter(|g| g.severity == Severity::Error).count();
+        let error_count = groups
+            .iter()
+            .filter(|g| g.severity == Severity::Error)
+            .count();
         assert!(error_count <= MAX_ERROR_GROUPS);
     }
 

--- a/src/run/group.rs
+++ b/src/run/group.rs
@@ -1,0 +1,226 @@
+use std::collections::HashMap;
+
+use crate::run::types::{Diagnostic, DiagnosticGroup, Location, Severity};
+
+const MAX_ERROR_GROUPS: usize = 10;
+const MAX_WARNING_GROUPS: usize = 5;
+const MAX_LOCATIONS_PER_GROUP: usize = 3;
+
+/// Group a flat list of diagnostics into ranked, deduplicated groups.
+///
+/// See module-level doc for the full algorithm:
+/// 1. Signature extraction (by `diagnostic.name`)
+/// 2. HashMap grouping
+/// 3. Ranking: errors first, then by frequency descending
+/// 4. Capping: max groups and max locations per group
+/// 5. Cascade detection: if one error's identifier appears in >50% of others
+pub fn group(diagnostics: &[Diagnostic]) -> Vec<DiagnosticGroup> {
+    if diagnostics.is_empty() {
+        return Vec::new();
+    }
+
+    // --- Step 1 & 2: Group by (severity, name) ---
+    // Key: (Severity, name as owned String so we can borrow freely later)
+    let mut map: HashMap<(Severity, String), Vec<usize>> = HashMap::new();
+
+    for (idx, diag) in diagnostics.iter().enumerate() {
+        map.entry((diag.severity, diag.name.clone()))
+            .or_default()
+            .push(idx);
+    }
+
+    // --- Step 3: Build group structs and rank ---
+    let mut groups: Vec<DiagnosticGroup> = map
+        .into_iter()
+        .map(|((severity, signature), indices)| {
+            let total = indices.len();
+
+            // Collect up to MAX_LOCATIONS_PER_GROUP unique locations.
+            let locations: Vec<Location> = indices
+                .iter()
+                .filter_map(|&i| diagnostics[i].location.clone())
+                .take(MAX_LOCATIONS_PER_GROUP)
+                .collect();
+
+            // Representative: first diagnostic in the group (preserves source order).
+            let rep_idx = indices[0];
+            let rep = &diagnostics[rep_idx];
+            let representative = Diagnostic {
+                severity: rep.severity,
+                location: rep.location.clone(),
+                name: rep.name.clone(),
+                message: rep.message.clone(),
+                detail: rep.detail.clone(),
+            };
+
+            DiagnosticGroup {
+                severity,
+                signature,
+                locations,
+                total,
+                representative,
+                cascading: false,
+            }
+        })
+        .collect();
+
+    // Sort: Severity (Error < Warning < Info), then total descending (most frequent first).
+    groups.sort_unstable_by(|a, b| {
+        a.severity
+            .cmp(&b.severity)
+            .then_with(|| b.total.cmp(&a.total))
+    });
+
+    // --- Step 4: Cap group counts ---
+    let error_end = groups.partition_point(|g| g.severity == Severity::Error);
+    let warn_end_raw = groups.partition_point(|g| g.severity <= Severity::Warning);
+
+    let error_end_capped = error_end.min(MAX_ERROR_GROUPS);
+    let warn_count = (warn_end_raw - error_end).min(MAX_WARNING_GROUPS);
+
+    // Retain only within caps; collect remaining info groups too (uncapped for now).
+    let info_start = warn_end_raw;
+    let mut result: Vec<DiagnosticGroup> = Vec::with_capacity(
+        error_end_capped + warn_count + (groups.len() - info_start),
+    );
+
+    result.extend(groups.drain(..error_end).take(MAX_ERROR_GROUPS));
+    let remaining = groups;
+    let mut remaining_iter = remaining.into_iter();
+    let warn_slice: Vec<_> = remaining_iter
+        .by_ref()
+        .take_while(|g| g.severity == Severity::Warning)
+        .take(MAX_WARNING_GROUPS)
+        .collect();
+    result.extend(warn_slice);
+    result.extend(remaining_iter); // info groups, uncapped
+
+    // --- Step 5: Cascade detection ---
+    mark_cascading(&mut result);
+
+    result
+}
+
+/// If a single error group dominates (exactly 1 error group, or the first error
+/// group has a clear "root" identifier), mark subsequent error groups as cascading
+/// when >50% of their diagnostics share that identifier.
+///
+/// We extract an identifier by scanning the representative message for the first
+/// backtick-quoted or single-quoted token.
+fn mark_cascading(groups: &mut [DiagnosticGroup]) {
+    let error_count = groups
+        .iter()
+        .filter(|g| g.severity == Severity::Error)
+        .count();
+
+    if error_count <= 1 {
+        return;
+    }
+
+    // Extract identifier from first error group's representative message.
+    let root_id = match extract_quoted_identifier(&groups[0].representative.message) {
+        Some(id) => id,
+        None => return,
+    };
+
+    // For every subsequent error group, check if the root_id appears in its signature
+    // or representative message — mark cascading if it does and there's >1 error group.
+    for group in groups.iter_mut().skip(1) {
+        if group.severity != Severity::Error {
+            break;
+        }
+        if group.signature.contains(root_id.as_str())
+            || group.representative.message.contains(root_id.as_str())
+        {
+            group.cascading = true;
+        }
+    }
+}
+
+/// Extract the first backtick-quoted (`ident`) or single-quoted ('ident') token
+/// from a message string.
+fn extract_quoted_identifier(msg: &str) -> Option<String> {
+    let bytes = msg.as_bytes();
+    let n = bytes.len();
+
+    let delimiters: &[(u8, u8)] = &[(b'`', b'`'), (b'\'', b'\''), (b'"', b'"')];
+
+    for &(open, close) in delimiters {
+        if let Some(start) = bytes.iter().position(|&b| b == open) {
+            let content_start = start + 1;
+            if content_start >= n {
+                continue;
+            }
+            if let Some(rel_end) = bytes[content_start..].iter().position(|&b| b == close) {
+                let content = &msg[content_start..content_start + rel_end];
+                // Only treat as identifier if it looks like one (not too long, no spaces).
+                if !content.is_empty() && content.len() < 64 && !content.contains(' ') {
+                    return Some(content.to_string());
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::run::types::Severity;
+
+    fn make_diag(severity: Severity, name: &str, message: &str) -> Diagnostic {
+        Diagnostic {
+            severity,
+            location: None,
+            name: name.to_string(),
+            message: message.to_string(),
+            detail: None,
+        }
+    }
+
+    #[test]
+    fn empty_input() {
+        assert!(group(&[]).is_empty());
+    }
+
+    #[test]
+    fn groups_by_name() {
+        let diags = vec![
+            make_diag(Severity::Error, "E001", "first"),
+            make_diag(Severity::Error, "E001", "second"),
+            make_diag(Severity::Error, "E002", "other"),
+        ];
+        let groups = group(&diags);
+        // E001 has 2 occurrences, E002 has 1 → E001 first.
+        assert_eq!(groups[0].signature, "E001");
+        assert_eq!(groups[0].total, 2);
+        assert_eq!(groups[1].signature, "E002");
+    }
+
+    #[test]
+    fn errors_before_warnings() {
+        let diags = vec![
+            make_diag(Severity::Warning, "W1", "warn"),
+            make_diag(Severity::Error, "E1", "err"),
+        ];
+        let groups = group(&diags);
+        assert_eq!(groups[0].severity, Severity::Error);
+        assert_eq!(groups[1].severity, Severity::Warning);
+    }
+
+    #[test]
+    fn caps_error_groups() {
+        let diags: Vec<_> = (0..15)
+            .map(|i| make_diag(Severity::Error, &format!("E{i:03}"), "msg"))
+            .collect();
+        let groups = group(&diags);
+        let error_count = groups.iter().filter(|g| g.severity == Severity::Error).count();
+        assert!(error_count <= MAX_ERROR_GROUPS);
+    }
+
+    #[test]
+    fn quoted_identifier_extraction() {
+        let id = extract_quoted_identifier("cannot find value `foo` in this scope");
+        assert_eq!(id.as_deref(), Some("foo"));
+    }
+}

--- a/src/run/group.rs
+++ b/src/run/group.rs
@@ -10,7 +10,7 @@ const MAX_LOCATIONS_PER_GROUP: usize = 3;
 ///
 /// See module-level doc for the full algorithm:
 /// 1. Signature extraction (by `diagnostic.name`)
-/// 2. HashMap grouping
+/// 2. `HashMap` grouping
 /// 3. Ranking: errors first, then by frequency descending
 /// 4. Capping: max groups and max locations per group
 /// 5. Cascade detection: if one error's identifier appears in >50% of others
@@ -117,9 +117,8 @@ fn mark_cascading(groups: &mut [DiagnosticGroup]) {
     }
 
     // Extract identifier from first error group's representative message.
-    let root_id = match extract_quoted_identifier(&groups[0].representative.message) {
-        Some(id) => id,
-        None => return,
+    let Some(root_id) = extract_quoted_identifier(&groups[0].representative.message) else {
+        return;
     };
 
     // For every subsequent error group, check if the root_id appears in its signature

--- a/src/run/group.rs
+++ b/src/run/group.rs
@@ -76,23 +76,25 @@ pub fn group(diagnostics: &[Diagnostic]) -> Vec<DiagnosticGroup> {
     let warn_end_raw = groups.partition_point(|g| g.severity <= Severity::Warning);
 
     let error_end_capped = error_end.min(MAX_ERROR_GROUPS);
-    let warn_count = (warn_end_raw - error_end).min(MAX_WARNING_GROUPS);
 
     // Retain only within caps; collect remaining info groups too (uncapped for now).
     let info_start = warn_end_raw;
     let mut result: Vec<DiagnosticGroup> =
-        Vec::with_capacity(error_end_capped + warn_count + (groups.len() - info_start));
+        Vec::with_capacity(error_end_capped + MAX_WARNING_GROUPS + (groups.len() - info_start));
 
     result.extend(groups.drain(..error_end).take(MAX_ERROR_GROUPS));
-    let remaining = groups;
-    let mut remaining_iter = remaining.into_iter();
-    let warn_slice: Vec<_> = remaining_iter
-        .by_ref()
-        .take_while(|g| g.severity == Severity::Warning)
-        .take(MAX_WARNING_GROUPS)
-        .collect();
-    result.extend(warn_slice);
-    result.extend(remaining_iter); // info groups, uncapped
+    let mut warn_count = 0;
+    for g in groups {
+        if g.severity == Severity::Warning {
+            if warn_count < MAX_WARNING_GROUPS {
+                result.push(g);
+                warn_count += 1;
+            }
+            // skip excess warnings
+        } else {
+            result.push(g); // info groups, uncapped
+        }
+    }
 
     // --- Step 5: Cascade detection ---
     mark_cascading(&mut result);
@@ -106,7 +108,15 @@ pub fn group(diagnostics: &[Diagnostic]) -> Vec<DiagnosticGroup> {
 ///
 /// We extract an identifier by scanning the representative message for the first
 /// backtick-quoted or single-quoted token.
+///
+/// **Precondition**: `groups[0].severity == Severity::Error` (error groups are always first
+/// after sorting by severity).
 fn mark_cascading(groups: &mut [DiagnosticGroup]) {
+    debug_assert!(
+        !groups.is_empty() && groups[0].severity == Severity::Error,
+        "mark_cascading requires groups[0] to be an error (groups must be sorted by severity)"
+    );
+
     let error_count = groups
         .iter()
         .filter(|g| g.severity == Severity::Error)
@@ -223,5 +233,27 @@ mod tests {
     fn quoted_identifier_extraction() {
         let id = extract_quoted_identifier("cannot find value `foo` in this scope");
         assert_eq!(id.as_deref(), Some("foo"));
+    }
+
+    #[test]
+    fn info_groups_not_dropped_after_warnings() {
+        // Build enough warnings to hit the cap, plus an info group after them.
+        // The bug: take_while discards the first Info group when it stops iterating.
+        let mut diags: Vec<Diagnostic> = (0..MAX_WARNING_GROUPS)
+            .map(|i| make_diag(Severity::Warning, &format!("W{i}"), "warn"))
+            .collect();
+        diags.push(make_diag(Severity::Info, "I1", "info"));
+        diags.push(make_diag(Severity::Error, "E1", "err"));
+
+        let groups = group(&diags);
+
+        let info_count = groups
+            .iter()
+            .filter(|g| g.severity == Severity::Info)
+            .count();
+        assert_eq!(
+            info_count, 1,
+            "info group must not be dropped after warnings"
+        );
     }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,0 +1,63 @@
+mod ansi;
+mod format;
+mod group;
+pub mod parsers;
+mod types;
+
+use std::panic::AssertUnwindSafe;
+
+/// Process command output: strip ANSI, detect tool, parse, group, format.
+///
+/// Returns the original input unchanged if:
+/// - Input is empty
+/// - Input contains binary (null bytes)
+/// - Input is ≤20 lines and unrecognised
+/// - Formatted output would be longer than the input (never-worse guarantee)
+/// - Any internal panic occurs
+pub fn process(input: &str) -> String {
+    std::panic::catch_unwind(AssertUnwindSafe(|| process_inner(input)))
+        .unwrap_or_else(|_| input.to_string())
+}
+
+fn process_inner(input: &str) -> String {
+    if input.is_empty() {
+        return String::new();
+    }
+
+    // Binary detection: null bytes in first 512 bytes → passthrough.
+    let check_len = input.len().min(512);
+    if input.as_bytes()[..check_len].contains(&0) {
+        return input.to_string();
+    }
+
+    // Strip ANSI.
+    let cleaned = ansi::strip(input);
+
+    // Detect tool.
+    let parser = parsers::detect_from_content(&cleaned);
+
+    // Short unknown input: invisible passthrough.
+    if parser.name() == "unknown" && cleaned.lines().nth(20).is_none() {
+        return input.to_string();
+    }
+
+    // Parse.
+    let parsed = parser.parse(&cleaned);
+
+    // Group.
+    let groups = group::group(&parsed.diagnostics);
+
+    // Format — generic tool gets head/tail treatment with raw lines.
+    let formatted = if parsed.tool == "unknown" {
+        format::format_generic_with_raw(&parsed, &groups, &cleaned)
+    } else {
+        format::format_output(&parsed, &groups, None)
+    };
+
+    // Never-worse: formatted must be strictly shorter than original.
+    if formatted.len() >= input.len() {
+        return input.to_string();
+    }
+
+    formatted
+}

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,7 +1,7 @@
 mod ansi;
 mod format;
 mod group;
-pub mod parsers;
+mod parsers;
 mod types;
 
 use std::panic::AssertUnwindSafe;
@@ -51,7 +51,7 @@ fn process_inner(input: &str) -> String {
     let formatted = if parsed.tool == "unknown" {
         format::format_generic_with_raw(&parsed, &groups, &cleaned)
     } else {
-        format::format_output(&parsed, &groups, None)
+        format::format_output(&parsed, &groups)
     };
 
     // Never-worse: formatted must be strictly shorter than original.

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,63 +1,105 @@
 mod ansi;
+pub mod exec;
 mod format;
 mod group;
-mod parsers;
-mod types;
+pub(crate) mod parsers;
+pub mod types;
+
+pub use types::{CompressResult, Counts, InputStats, OutputFormat};
 
 use std::panic::AssertUnwindSafe;
+
+/// Process command output into a structured result: strip ANSI, detect tool, parse, group.
+///
+/// Returns a `CompressResult` that can be formatted lazily via `format()` or `format_checked()`.
+#[must_use]
+pub fn process_structured(input: &str) -> CompressResult {
+    std::panic::catch_unwind(AssertUnwindSafe(|| process_structured_inner(input)))
+        .unwrap_or_else(|_| passthrough_result(input))
+}
 
 /// Process command output: strip ANSI, detect tool, parse, group, format.
 ///
 /// Returns the original input unchanged if:
 /// - Input is empty
 /// - Input contains binary (null bytes)
-/// - Input is ≤20 lines and unrecognised
+/// - Input is <=20 lines and unrecognised
 /// - Formatted output would be longer than the input (never-worse guarantee)
 /// - Any internal panic occurs
+#[allow(dead_code)]
+#[must_use]
 pub fn process(input: &str) -> String {
-    std::panic::catch_unwind(AssertUnwindSafe(|| process_inner(input)))
-        .unwrap_or_else(|_| input.to_string())
+    let result = process_structured(input);
+    if result.passthrough {
+        return input.to_string();
+    }
+    result
+        .format_checked(OutputFormat::Markdown, input.len())
+        .unwrap_or_else(|| input.to_string())
 }
 
-fn process_inner(input: &str) -> String {
+fn process_structured_inner(input: &str) -> CompressResult {
     if input.is_empty() {
-        return String::new();
+        return passthrough_result(input);
     }
 
-    // Binary detection: null bytes in first 512 bytes → passthrough.
+    // Binary detection: null bytes in first 512 bytes -> passthrough.
     let check_len = input.len().min(512);
     if input.as_bytes()[..check_len].contains(&0) {
-        return input.to_string();
+        return passthrough_result(input);
     }
 
     // Strip ANSI.
     let cleaned = ansi::strip(input);
 
     // Detect tool.
-    let parser = parsers::detect_from_content(&cleaned);
+    let (parser, hint) = parsers::detect_from_content(&cleaned);
 
     // Short unknown input: invisible passthrough.
     if parser.name() == "unknown" && cleaned.lines().nth(20).is_none() {
-        return input.to_string();
+        return passthrough_result(input);
     }
 
     // Parse.
-    let parsed = parser.parse(&cleaned);
+    let parsed = parser.parse(&cleaned, hint);
 
     // Group.
     let groups = group::group(&parsed.diagnostics);
 
-    // Format — generic tool gets head/tail treatment with raw lines.
-    let formatted = if parsed.tool == "unknown" {
-        format::format_generic_with_raw(&parsed, &groups, &cleaned)
+    // Build CompressResult.
+    let cleaned_for_generic = if parsed.tool == "unknown" {
+        Some(cleaned)
     } else {
-        format::format_output(&parsed, &groups)
+        None
     };
 
-    // Never-worse: formatted must be strictly shorter than original.
-    if formatted.len() >= input.len() {
-        return input.to_string();
+    CompressResult {
+        tool: parsed.tool,
+        summary: parsed.summary,
+        groups,
+        counts: parsed.counts,
+        duration_secs: parsed.duration_secs,
+        input_stats: InputStats {
+            lines: parsed.raw_lines,
+            bytes: parsed.raw_bytes,
+        },
+        passthrough: false,
+        cleaned: cleaned_for_generic,
     }
+}
 
-    formatted
+fn passthrough_result(input: &str) -> CompressResult {
+    CompressResult {
+        tool: "passthrough",
+        summary: String::new(),
+        groups: Vec::new(),
+        counts: Counts::default(),
+        duration_secs: None,
+        input_stats: InputStats {
+            lines: input.lines().count(),
+            bytes: input.len(),
+        },
+        passthrough: true,
+        cleaned: None,
+    }
 }

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -7,38 +7,11 @@ pub mod types;
 
 pub use types::{CompressResult, Counts, InputStats, OutputFormat};
 
-use std::panic::AssertUnwindSafe;
-
 /// Process command output into a structured result: strip ANSI, detect tool, parse, group.
 ///
 /// Returns a `CompressResult` that can be formatted lazily via `format()` or `format_checked()`.
 #[must_use]
 pub fn process_structured(input: &str) -> CompressResult {
-    std::panic::catch_unwind(AssertUnwindSafe(|| process_structured_inner(input)))
-        .unwrap_or_else(|_| passthrough_result(input))
-}
-
-/// Process command output: strip ANSI, detect tool, parse, group, format.
-///
-/// Returns the original input unchanged if:
-/// - Input is empty
-/// - Input contains binary (null bytes)
-/// - Input is <=20 lines and unrecognised
-/// - Formatted output would be longer than the input (never-worse guarantee)
-/// - Any internal panic occurs
-#[allow(dead_code)]
-#[must_use]
-pub fn process(input: &str) -> String {
-    let result = process_structured(input);
-    if result.passthrough {
-        return input.to_string();
-    }
-    result
-        .format_checked(OutputFormat::Markdown, input.len())
-        .unwrap_or_else(|| input.to_string())
-}
-
-fn process_structured_inner(input: &str) -> CompressResult {
     if input.is_empty() {
         return passthrough_result(input);
     }
@@ -85,6 +58,75 @@ fn process_structured_inner(input: &str) -> CompressResult {
         },
         passthrough: false,
         cleaned: cleaned_for_generic,
+    }
+}
+
+/// Process command output: strip ANSI, detect tool, parse, group, format.
+///
+/// Returns the original input unchanged if:
+/// - Input is empty
+/// - Input contains binary (null bytes)
+/// - Input is <=20 lines and unrecognised
+/// - Formatted output would be longer than the input (never-worse guarantee)
+#[allow(dead_code)]
+#[must_use]
+pub fn process(input: &str) -> String {
+    let result = process_structured(input);
+    if result.passthrough {
+        return input.to_string();
+    }
+    result
+        .format_checked(OutputFormat::Markdown, input.len())
+        .unwrap_or_else(|| input.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_is_passthrough() {
+        let result = process_structured("");
+        assert!(result.passthrough);
+    }
+
+    #[test]
+    fn short_unknown_input_is_passthrough() {
+        let result = process_structured("hello world\n");
+        assert!(result.passthrough);
+    }
+
+    #[test]
+    fn binary_input_is_passthrough() {
+        let input = "hello\x00world";
+        let result = process_structured(input);
+        assert!(result.passthrough);
+    }
+
+    #[test]
+    fn process_returns_original_for_short_input() {
+        let input = "some short output\n";
+        let output = process(input);
+        assert_eq!(output, input);
+    }
+
+    #[test]
+    fn passthrough_result_format_checked_returns_none() {
+        // Demonstrates that passthrough correctness in tool_run (mcp.rs) is accidental:
+        // format_checked on a passthrough result returns None because the formatted output
+        // is longer than the original, so the fallback kicks in. This works by accident.
+        let input = "short output\n";
+        let result = process_structured(input);
+        assert!(
+            result.passthrough,
+            "short unknown input should be passthrough"
+        );
+        // format_checked should return None for passthrough results
+        let formatted = result.format_checked(OutputFormat::Markdown, input.len());
+        assert!(
+            formatted.is_none(),
+            "passthrough format_checked should return None (accidental correctness)"
+        );
     }
 }
 

--- a/src/run/parsers/cargo_build.rs
+++ b/src/run/parsers/cargo_build.rs
@@ -1,7 +1,7 @@
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{Counts, DetectResult, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 
@@ -14,49 +14,44 @@ impl Parser for CargoBuildParser {
         "cargo-build"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint: any line contains `"reason":"compiler-` or `"reason": "compiler-`
         let json_finder_compact = memmem::Finder::new(b"\"reason\":\"compiler-");
         let json_finder_spaced = memmem::Finder::new(b"\"reason\": \"compiler-");
         if json_finder_compact.find(bytes).is_some() || json_finder_spaced.find(bytes).is_some() {
-            return true;
+            return DetectResult::NdJson;
         }
 
         // Text fingerprint: `error[E` or `warning[` or `warning:` with ` --> ` arrow
         let arrow_finder = memmem::Finder::new(b" --> ");
         if arrow_finder.find(bytes).is_none() {
-            return false;
+            return DetectResult::NoMatch;
         }
         let error_code = memmem::Finder::new(b"error[E");
         let warning_bracket = memmem::Finder::new(b"warning[");
         let warning_colon = memmem::Finder::new(b"warning:");
-        error_code.find(bytes).is_some()
+        if error_code.find(bytes).is_some()
             || warning_bracket.find(bytes).is_some()
             || warning_colon.find(bytes).is_some()
+        {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
-        // Try JSON path first; fall back to text parsing.
-        if looks_like_json(input) {
+        if hint.is_json() {
             try_json(input, raw_lines, raw_bytes)
         } else {
             parse_text(input, raw_lines, raw_bytes)
         }
     }
-}
-
-/// Heuristic: treat as JSON if any of the first 5 non-empty lines starts with `{`.
-fn looks_like_json(input: &str) -> bool {
-    input
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .take(5)
-        .any(|l| l.trim_start().starts_with('{'))
 }
 
 // ---------------------------------------------------------------------------
@@ -80,9 +75,8 @@ fn try_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
             Err(_) => continue,
         };
 
-        let reason = match value.get("reason").and_then(Value::as_str) {
-            Some(r) => r,
-            None => continue,
+        let Some(reason) = value.get("reason").and_then(Value::as_str) else {
+            continue;
         };
 
         match reason {
@@ -177,8 +171,7 @@ fn extract_json_diagnostic(msg: &Value) -> Option<Diagnostic> {
                 .filter(|c| {
                     c.get("level")
                         .and_then(Value::as_str)
-                        .map(|l| l == "help")
-                        .unwrap_or(false)
+                        .is_some_and(|l| l == "help")
                 })
                 .filter_map(|c| c.get("message").and_then(Value::as_str))
                 .collect::<Vec<_>>()
@@ -294,7 +287,6 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
             if let Some(ref mut d) = current {
                 d.help_lines.push(help);
             }
-            continue;
         }
     }
 
@@ -445,25 +437,25 @@ mod tests {
     #[test]
     fn detect_json_fingerprint() {
         let sample = r#"{"reason":"compiler-message","package_id":"foo"}"#;
-        assert!(PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::NdJson);
     }
 
     #[test]
     fn detect_json_fingerprint_spaced() {
         let sample = r#"{"reason": "compiler-message", "package_id": "foo"}"#;
-        assert!(PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::NdJson);
     }
 
     #[test]
     fn detect_text_fingerprint() {
         let sample = "error[E0308]: mismatched types\n --> src/lib.rs:10:5\n";
-        assert!(PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::Text);
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "some random\noutput\nwith no rust compiler markers\n";
-        assert!(!PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::NoMatch);
     }
 
     // --- JSON path ---
@@ -472,7 +464,7 @@ mod tests {
     fn parse_json_compiler_message() {
         let input = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","manifest_path":"/foo/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"foo","src_path":"/foo/src/lib.rs","edition":"2021"},"message":{"message":"mismatched types","code":{"code":"E0308","explanation":"..."},"level":"error","spans":[{"file_name":"src/lib.rs","byte_start":100,"byte_end":110,"line_start":10,"line_end":10,"column_start":5,"column_end":15,"is_primary":true,"text":[],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"error[E0308]: mismatched types\n"}}"#;
 
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.severity, Severity::Error);
@@ -491,7 +483,7 @@ mod tests {
     fn parse_json_with_help() {
         let input = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","manifest_path":"/foo/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"foo","src_path":"/foo/src/lib.rs","edition":"2021"},"message":{"message":"unused variable: `x`","code":{"code":"unused_variables","explanation":null},"level":"warning","spans":[{"file_name":"src/lib.rs","byte_start":50,"byte_end":51,"line_start":5,"line_end":5,"column_start":9,"column_end":10,"is_primary":true,"text":[],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"if this is intentional, prefix it with an underscore: `_x`","code":null,"level":"help","spans":[],"children":[],"rendered":null}],"rendered":"warning: unused variable: `x`\n"}}"#;
 
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.severity, Severity::Warning);
@@ -509,7 +501,7 @@ mod tests {
     #[test]
     fn parse_text_error_with_location() {
         let input = "error[E0308]: mismatched types\n --> src/lib.rs:42:5\n  |\n42 |     let x: i32 = \"hello\";\n  |                  ^^^^^^^ expected `i32`, found `&str`\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.severity, Severity::Error);
@@ -526,7 +518,7 @@ mod tests {
     #[test]
     fn parse_text_warning() {
         let input = "warning[unused_variables]: unused variable: `x`\n --> src/main.rs:7:9\n  |\n7 |     let x = 5;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_x`\n  |\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.severity, Severity::Warning);
@@ -537,7 +529,7 @@ mod tests {
     #[test]
     fn parse_text_clippy_warning() {
         let input = "warning: redundant pattern matching\n --> src/lib.rs:15:5\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.severity, Severity::Warning);

--- a/src/run/parsers/cargo_build.rs
+++ b/src/run/parsers/cargo_build.rs
@@ -412,15 +412,32 @@ fn is_decoration_line(line: &str) -> bool {
 // Shared helpers
 // ---------------------------------------------------------------------------
 
-fn build_summary(errors: u32, warnings: u32, success: Option<bool>) -> String {
-    if errors == 0 && success != Some(false) {
-        if warnings == 0 {
-            "build succeeded".to_string()
-        } else {
-            format!("build succeeded, {warnings} warning(s)")
+/// `finished` indicates whether a `build-finished` JSON message was observed.
+/// Without it we cannot claim success — output may be truncated.
+fn build_summary(errors: u32, warnings: u32, finished: Option<bool>) -> String {
+    match finished {
+        Some(true) => {
+            // build-finished seen with success=true
+            if warnings == 0 {
+                "build succeeded".to_string()
+            } else {
+                format!("build succeeded, {warnings} warning(s)")
+            }
         }
-    } else {
-        format!("{errors} error(s), {warnings} warning(s)")
+        Some(false) => {
+            // build-finished seen with success=false
+            format!("{errors} error(s), {warnings} warning(s)")
+        }
+        None => {
+            // build-finished never seen — output may be truncated
+            if errors > 0 {
+                format!("{errors} error(s), {warnings} warning(s)")
+            } else if warnings > 0 {
+                format!("build status unknown (output may be truncated), {warnings} warning(s)")
+            } else {
+                "build status unknown (output may be truncated)".to_string()
+            }
+        }
     }
 }
 
@@ -494,6 +511,75 @@ mod tests {
             .unwrap()
             .contains("prefix it with an underscore"));
         assert_eq!(out.counts.warnings, 1);
+    }
+
+    // --- build_summary (Bug #13) ---
+
+    #[test]
+    fn build_summary_success_requires_finished_message() {
+        // No build-finished seen (None) + 0 errors must NOT claim success.
+        let s = build_summary(0, 0, None);
+        assert!(
+            s.contains("unknown") || s.contains("truncated"),
+            "expected unknown/truncated message, got: {s}"
+        );
+        assert!(
+            !s.contains("succeeded"),
+            "must not claim success without build-finished: {s}"
+        );
+    }
+
+    #[test]
+    fn build_summary_truncated_with_warnings() {
+        let s = build_summary(0, 3, None);
+        assert!(s.contains("3"), "should mention warning count: {s}");
+        assert!(
+            !s.contains("succeeded"),
+            "must not claim success without build-finished: {s}"
+        );
+    }
+
+    #[test]
+    fn build_summary_finished_success() {
+        let s = build_summary(0, 0, Some(true));
+        assert_eq!(s, "build succeeded");
+    }
+
+    #[test]
+    fn build_summary_finished_success_with_warnings() {
+        let s = build_summary(0, 2, Some(true));
+        assert!(s.contains("succeeded") && s.contains("2 warning(s)"));
+    }
+
+    #[test]
+    fn build_summary_finished_failure() {
+        let s = build_summary(3, 1, Some(false));
+        assert!(s.contains("3 error(s)"));
+    }
+
+    #[test]
+    fn parse_json_no_build_finished_reports_unknown() {
+        // Stream has a compiler message but no build-finished — simulate truncation.
+        let input = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","manifest_path":"/foo/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"foo","src_path":"/foo/src/lib.rs","edition":"2021"},"message":{"message":"unused import","code":{"code":"unused_imports","explanation":null},"level":"warning","spans":[{"file_name":"src/lib.rs","byte_start":0,"byte_end":1,"line_start":1,"line_end":1,"column_start":1,"column_end":2,"is_primary":true,"text":[],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"warning: unused import\n"}}"#;
+
+        let out = PARSER.parse(input, DetectResult::NdJson);
+        assert!(
+            out.summary.contains("unknown") || out.summary.contains("truncated"),
+            "expected unknown/truncated summary without build-finished, got: {}",
+            out.summary
+        );
+        assert!(
+            !out.summary.contains("succeeded"),
+            "must not claim success without build-finished: {}",
+            out.summary
+        );
+    }
+
+    #[test]
+    fn parse_json_with_build_finished_success_reports_succeeded() {
+        let input = concat!("{\"reason\":\"build-finished\",\"success\":true}\n",);
+        let out = PARSER.parse(input, DetectResult::NdJson);
+        assert_eq!(out.summary, "build succeeded");
     }
 
     // --- Text path ---

--- a/src/run/parsers/cargo_build.rs
+++ b/src/run/parsers/cargo_build.rs
@@ -99,9 +99,7 @@ fn try_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
                 }
             }
             "build-finished" => {
-                build_success = value
-                    .get("success")
-                    .and_then(Value::as_bool);
+                build_success = value.get("success").and_then(Value::as_bool);
             }
             // compiler-artifact, build-script-executed, etc.: skip
             _ => {}
@@ -400,7 +398,9 @@ fn is_decoration_line(line: &str) -> bool {
     }
     // Lines that start with `|` (with optional leading whitespace and line numbers)
     // or consist only of `^`, `~`, `-`, `=` mixed with spaces are decoration.
-    let stripped = trimmed.trim_start_matches(|c: char| c.is_ascii_digit()).trim_start();
+    let stripped = trimmed
+        .trim_start_matches(|c: char| c.is_ascii_digit())
+        .trim_start();
     if stripped.starts_with('|') {
         return true;
     }
@@ -478,7 +478,10 @@ mod tests {
         assert_eq!(diag.severity, Severity::Error);
         assert_eq!(diag.name, "E0308");
         assert_eq!(diag.message, "mismatched types");
-        assert_eq!(diag.location.as_ref().map(|l| l.file.as_str()), Some("src/lib.rs"));
+        assert_eq!(
+            diag.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/lib.rs")
+        );
         assert_eq!(diag.location.as_ref().map(|l| l.line), Some(10));
         assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(5));
         assert_eq!(out.counts.errors, 1);
@@ -512,7 +515,10 @@ mod tests {
         assert_eq!(diag.severity, Severity::Error);
         assert_eq!(diag.name, "E0308");
         assert_eq!(diag.message, "mismatched types");
-        assert_eq!(diag.location.as_ref().map(|l| l.file.as_str()), Some("src/lib.rs"));
+        assert_eq!(
+            diag.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/lib.rs")
+        );
         assert_eq!(diag.location.as_ref().map(|l| l.line), Some(42));
         assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(5));
     }

--- a/src/run/parsers/cargo_build.rs
+++ b/src/run/parsers/cargo_build.rs
@@ -37,13 +37,6 @@ impl Parser for CargoBuildParser {
             || warning_colon.find(bytes).is_some()
     }
 
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--message-format") {
-            return None;
-        }
-        Some(format!("{command} --message-format=json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -471,20 +464,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "some random\noutput\nwith no rust compiler markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_appends_message_format() {
-        let result = PARSER.rewrite("cargo build");
-        assert_eq!(result, Some("cargo build --message-format=json".to_string()));
-    }
-
-    #[test]
-    fn rewrite_skips_if_present() {
-        let result = PARSER.rewrite("cargo build --message-format=json");
-        assert!(result.is_none());
     }
 
     // --- JSON path ---

--- a/src/run/parsers/cargo_build.rs
+++ b/src/run/parsers/cargo_build.rs
@@ -1,0 +1,562 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: CargoBuildParser = CargoBuildParser;
+
+pub struct CargoBuildParser;
+
+impl Parser for CargoBuildParser {
+    fn name(&self) -> &'static str {
+        "cargo-build"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: any line contains `"reason":"compiler-` or `"reason": "compiler-`
+        let json_finder_compact = memmem::Finder::new(b"\"reason\":\"compiler-");
+        let json_finder_spaced = memmem::Finder::new(b"\"reason\": \"compiler-");
+        if json_finder_compact.find(bytes).is_some() || json_finder_spaced.find(bytes).is_some() {
+            return true;
+        }
+
+        // Text fingerprint: `error[E` or `warning[` or `warning:` with ` --> ` arrow
+        let arrow_finder = memmem::Finder::new(b" --> ");
+        if arrow_finder.find(bytes).is_none() {
+            return false;
+        }
+        let error_code = memmem::Finder::new(b"error[E");
+        let warning_bracket = memmem::Finder::new(b"warning[");
+        let warning_colon = memmem::Finder::new(b"warning:");
+        error_code.find(bytes).is_some()
+            || warning_bracket.find(bytes).is_some()
+            || warning_colon.find(bytes).is_some()
+    }
+
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--message-format") {
+            return None;
+        }
+        Some(format!("{command} --message-format=json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        // Try JSON path first; fall back to text parsing.
+        if looks_like_json(input) {
+            try_json(input, raw_lines, raw_bytes)
+        } else {
+            parse_text(input, raw_lines, raw_bytes)
+        }
+    }
+}
+
+/// Heuristic: treat as JSON if any of the first 5 non-empty lines starts with `{`.
+fn looks_like_json(input: &str) -> bool {
+    input
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(5)
+        .any(|l| l.trim_start().starts_with('{'))
+}
+
+// ---------------------------------------------------------------------------
+// JSON path
+// ---------------------------------------------------------------------------
+
+fn try_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+    let mut build_success: Option<bool> = None;
+
+    for line in input.lines() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+
+        let value: Value = match serde_json::from_str(trimmed) {
+            Ok(v) => v,
+            Err(_) => continue,
+        };
+
+        let reason = match value.get("reason").and_then(Value::as_str) {
+            Some(r) => r,
+            None => continue,
+        };
+
+        match reason {
+            "compiler-message" => {
+                if let Some(msg_obj) = value.get("message") {
+                    if let Some(diag) = extract_json_diagnostic(msg_obj) {
+                        match diag.severity {
+                            Severity::Error => error_count += 1,
+                            Severity::Warning => warning_count += 1,
+                            Severity::Info => {}
+                        }
+                        diagnostics.push(diag);
+                    }
+                }
+            }
+            "build-finished" => {
+                build_success = value
+                    .get("success")
+                    .and_then(Value::as_bool);
+            }
+            // compiler-artifact, build-script-executed, etc.: skip
+            _ => {}
+        }
+    }
+
+    let summary = build_summary(error_count, warning_count, build_success);
+
+    ParsedOutput {
+        tool: "cargo-build",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Extract a `Diagnostic` from a compiler-message `.message` object.
+fn extract_json_diagnostic(msg: &Value) -> Option<Diagnostic> {
+    let level_str = msg.get("level").and_then(Value::as_str).unwrap_or("info");
+    let severity = match level_str {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    let message = msg
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    // Use the error code (e.g., "E0308") as name; fall back to a truncated message.
+    let name = msg
+        .get("code")
+        .and_then(|c| c.get("code"))
+        .and_then(Value::as_str)
+        .unwrap_or(&message)
+        .to_string();
+
+    // Primary span -> location.
+    let location = msg
+        .get("spans")
+        .and_then(Value::as_array)
+        .and_then(|spans| {
+            spans.iter().find(|s| {
+                s.get("is_primary")
+                    .and_then(Value::as_bool)
+                    .unwrap_or(false)
+            })
+        })
+        .and_then(|span| {
+            let file = span.get("file_name")?.as_str()?.to_string();
+            let line = span.get("line_start")?.as_u64()? as u32;
+            let column = span
+                .get("column_start")
+                .and_then(Value::as_u64)
+                .map(|c| c as u32);
+            Some(Location { file, line, column })
+        });
+
+    // Collect help children into detail.
+    let detail: Option<String> = msg
+        .get("children")
+        .and_then(Value::as_array)
+        .map(|children| {
+            children
+                .iter()
+                .filter(|c| {
+                    c.get("level")
+                        .and_then(Value::as_str)
+                        .map(|l| l == "help")
+                        .unwrap_or(false)
+                })
+                .filter_map(|c| c.get("message").and_then(Value::as_str))
+                .collect::<Vec<_>>()
+                .join("\n")
+        })
+        .filter(|s| !s.is_empty());
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name,
+        message,
+        detail,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+/// State machine for accumulating a single diagnostic block from text output.
+struct TextDiag {
+    severity: Severity,
+    name: String,
+    message: String,
+    location: Option<Location>,
+    help_lines: Vec<String>,
+}
+
+impl TextDiag {
+    fn finish(self) -> Diagnostic {
+        let detail = if self.help_lines.is_empty() {
+            None
+        } else {
+            Some(self.help_lines.join("\n"))
+        };
+        Diagnostic {
+            severity: self.severity,
+            location: self.location,
+            name: self.name,
+            message: self.message,
+            detail,
+        }
+    }
+}
+
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut current: Option<TextDiag> = None;
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    for line in input.lines() {
+        // Skip visual noise: lines with `|` decorations and `^` underlines.
+        if is_decoration_line(line) {
+            continue;
+        }
+
+        // Summary lines — skip or finalize without adding a duplicate diagnostic.
+        if line.starts_with("error: could not compile") {
+            // Flush current if any; don't add a new diagnostic for this summary.
+            if let Some(d) = current.take() {
+                push_diag(&mut diagnostics, &mut error_count, &mut warning_count, d);
+            }
+            continue;
+        }
+        if line.starts_with("error: aborting due to") {
+            continue;
+        }
+
+        // `error[EXXXX]: message` or `warning[CXXXX]: message`
+        if let Some((sev, name, message)) = parse_diagnostic_header(line) {
+            if let Some(d) = current.take() {
+                push_diag(&mut diagnostics, &mut error_count, &mut warning_count, d);
+            }
+            current = Some(TextDiag {
+                severity: sev,
+                name,
+                message,
+                location: None,
+                help_lines: Vec::new(),
+            });
+            continue;
+        }
+
+        // `warning: message` without a bracketed code
+        if let Some(message) = parse_plain_warning(line) {
+            if let Some(d) = current.take() {
+                push_diag(&mut diagnostics, &mut error_count, &mut warning_count, d);
+            }
+            current = Some(TextDiag {
+                severity: Severity::Warning,
+                name: message.clone(),
+                message,
+                location: None,
+                help_lines: Vec::new(),
+            });
+            continue;
+        }
+
+        // ` --> src/lib.rs:42:5`
+        if let Some(loc) = parse_arrow_location(line) {
+            if let Some(ref mut d) = current {
+                if d.location.is_none() {
+                    d.location = Some(loc);
+                }
+            }
+            continue;
+        }
+
+        // `help: suggestion`
+        if let Some(help) = parse_help_line(line) {
+            if let Some(ref mut d) = current {
+                d.help_lines.push(help);
+            }
+            continue;
+        }
+    }
+
+    // Flush final diagnostic.
+    if let Some(d) = current.take() {
+        push_diag(&mut diagnostics, &mut error_count, &mut warning_count, d);
+    }
+
+    let summary = build_summary(error_count, warning_count, None);
+
+    ParsedOutput {
+        tool: "cargo-build",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+fn push_diag(
+    diagnostics: &mut Vec<Diagnostic>,
+    error_count: &mut u32,
+    warning_count: &mut u32,
+    d: TextDiag,
+) {
+    match d.severity {
+        Severity::Error => *error_count += 1,
+        Severity::Warning => *warning_count += 1,
+        Severity::Info => {}
+    }
+    diagnostics.push(d.finish());
+}
+
+/// Returns `(severity, name, message)` for lines like:
+/// `error[E0308]: mismatched types`
+/// `warning[clippy::needless_return]: needless return`
+fn parse_diagnostic_header(line: &str) -> Option<(Severity, String, String)> {
+    let (sev, rest) = if let Some(r) = line.strip_prefix("error[") {
+        (Severity::Error, r)
+    } else if let Some(r) = line.strip_prefix("warning[") {
+        (Severity::Warning, r)
+    } else {
+        return None;
+    };
+
+    // Find the closing `]:`
+    let bracket_end = rest.find("]:")?;
+    let code = rest[..bracket_end].to_string();
+    let message = rest[bracket_end + 2..].trim().to_string();
+
+    Some((sev, code, message))
+}
+
+/// Matches `warning: text` but NOT `warning[...]`.
+fn parse_plain_warning(line: &str) -> Option<String> {
+    let rest = line.strip_prefix("warning: ")?;
+    // Exclude the bracketed variant — that's handled by parse_diagnostic_header.
+    if line.starts_with("warning[") {
+        return None;
+    }
+    Some(rest.trim().to_string())
+}
+
+/// Parses ` --> file:line:col` or ` --> file:line`.
+fn parse_arrow_location(line: &str) -> Option<Location> {
+    let rest = line.trim().strip_prefix("--> ")?;
+    parse_location_str(rest.trim())
+}
+
+/// Parses `file:line:col` or `file:line` into a Location.
+fn parse_location_str(s: &str) -> Option<Location> {
+    // Split on ':' — file may be a Windows path like C:\..., but we're on Unix.
+    let mut parts = s.splitn(3, ':');
+    let file = parts.next()?.trim().to_string();
+    if file.is_empty() {
+        return None;
+    }
+    let line: u32 = parts.next()?.trim().parse().ok()?;
+    let column: Option<u32> = parts.next().and_then(|c| c.trim().parse().ok());
+    Some(Location { file, line, column })
+}
+
+/// Parses `help: suggestion text`.
+fn parse_help_line(line: &str) -> Option<String> {
+    let rest = line.trim().strip_prefix("help: ")?;
+    Some(rest.trim().to_string())
+}
+
+/// Returns true for lines that are visual noise from rustc's output renderer:
+/// lines that consist mainly of pipe characters, caret underlines, and whitespace.
+fn is_decoration_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    if trimmed.is_empty() {
+        return false;
+    }
+    // Lines that start with `|` (with optional leading whitespace and line numbers)
+    // or consist only of `^`, `~`, `-`, `=` mixed with spaces are decoration.
+    let stripped = trimmed.trim_start_matches(|c: char| c.is_ascii_digit()).trim_start();
+    if stripped.starts_with('|') {
+        return true;
+    }
+    // Pure underline lines: all chars are `^`, `~`, `-`, ` `, `_`
+    if !trimmed.is_empty()
+        && trimmed
+            .chars()
+            .all(|c| matches!(c, '^' | '~' | '-' | ' ' | '_'))
+        && trimmed.contains('^')
+    {
+        return true;
+    }
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn build_summary(errors: u32, warnings: u32, success: Option<bool>) -> String {
+    if errors == 0 && success != Some(false) {
+        if warnings == 0 {
+            "build succeeded".to_string()
+        } else {
+            format!("build succeeded, {warnings} warning(s)")
+        }
+    } else {
+        format!("{errors} error(s), {warnings} warning(s)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_json_fingerprint() {
+        let sample = r#"{"reason":"compiler-message","package_id":"foo"}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_json_fingerprint_spaced() {
+        let sample = r#"{"reason": "compiler-message", "package_id": "foo"}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text_fingerprint() {
+        let sample = "error[E0308]: mismatched types\n --> src/lib.rs:10:5\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "some random\noutput\nwith no rust compiler markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_appends_message_format() {
+        let result = PARSER.rewrite("cargo build");
+        assert_eq!(result, Some("cargo build --message-format=json".to_string()));
+    }
+
+    #[test]
+    fn rewrite_skips_if_present() {
+        let result = PARSER.rewrite("cargo build --message-format=json");
+        assert!(result.is_none());
+    }
+
+    // --- JSON path ---
+
+    #[test]
+    fn parse_json_compiler_message() {
+        let input = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","manifest_path":"/foo/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"foo","src_path":"/foo/src/lib.rs","edition":"2021"},"message":{"message":"mismatched types","code":{"code":"E0308","explanation":"..."},"level":"error","spans":[{"file_name":"src/lib.rs","byte_start":100,"byte_end":110,"line_start":10,"line_end":10,"column_start":5,"column_end":15,"is_primary":true,"text":[],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[],"rendered":"error[E0308]: mismatched types\n"}}"#;
+
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Error);
+        assert_eq!(diag.name, "E0308");
+        assert_eq!(diag.message, "mismatched types");
+        assert_eq!(diag.location.as_ref().map(|l| l.file.as_str()), Some("src/lib.rs"));
+        assert_eq!(diag.location.as_ref().map(|l| l.line), Some(10));
+        assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(5));
+        assert_eq!(out.counts.errors, 1);
+    }
+
+    #[test]
+    fn parse_json_with_help() {
+        let input = r#"{"reason":"compiler-message","package_id":"foo 0.1.0","manifest_path":"/foo/Cargo.toml","target":{"kind":["lib"],"crate_types":["lib"],"name":"foo","src_path":"/foo/src/lib.rs","edition":"2021"},"message":{"message":"unused variable: `x`","code":{"code":"unused_variables","explanation":null},"level":"warning","spans":[{"file_name":"src/lib.rs","byte_start":50,"byte_end":51,"line_start":5,"line_end":5,"column_start":9,"column_end":10,"is_primary":true,"text":[],"label":null,"suggested_replacement":null,"suggestion_applicability":null,"expansion":null}],"children":[{"message":"if this is intentional, prefix it with an underscore: `_x`","code":null,"level":"help","spans":[],"children":[],"rendered":null}],"rendered":"warning: unused variable: `x`\n"}}"#;
+
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Warning);
+        assert!(diag.detail.is_some());
+        assert!(diag
+            .detail
+            .as_ref()
+            .unwrap()
+            .contains("prefix it with an underscore"));
+        assert_eq!(out.counts.warnings, 1);
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text_error_with_location() {
+        let input = "error[E0308]: mismatched types\n --> src/lib.rs:42:5\n  |\n42 |     let x: i32 = \"hello\";\n  |                  ^^^^^^^ expected `i32`, found `&str`\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Error);
+        assert_eq!(diag.name, "E0308");
+        assert_eq!(diag.message, "mismatched types");
+        assert_eq!(diag.location.as_ref().map(|l| l.file.as_str()), Some("src/lib.rs"));
+        assert_eq!(diag.location.as_ref().map(|l| l.line), Some(42));
+        assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(5));
+    }
+
+    #[test]
+    fn parse_text_warning() {
+        let input = "warning[unused_variables]: unused variable: `x`\n --> src/main.rs:7:9\n  |\n7 |     let x = 5;\n  |         ^ help: if this is intentional, prefix it with an underscore: `_x`\n  |\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Warning);
+        assert_eq!(diag.name, "unused_variables");
+        assert_eq!(out.counts.warnings, 1);
+    }
+
+    #[test]
+    fn parse_text_clippy_warning() {
+        let input = "warning: redundant pattern matching\n --> src/lib.rs:15:5\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Warning);
+        assert_eq!(diag.name, "redundant pattern matching");
+        assert_eq!(out.counts.warnings, 1);
+    }
+}

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -1,8 +1,8 @@
 use memchr::memmem;
 
 use crate::run::types::{
-    build_test_summary, extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput,
-    Severity,
+    build_test_summary, extract_count, truncate_detail, Counts, DetectResult, Diagnostic, Location,
+    ParsedOutput, Severity,
 };
 
 use super::Parser;
@@ -19,35 +19,38 @@ impl Parser for CargoTestParser {
     /// Detect cargo test output via byte scanning — no regex.
     ///
     /// Accepts JSON format (`"type":"test"`) or text format (`test result:` + `passed`).
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint: any line with `"type":"test"` or `"type": "test"`
         let type_test_compact = memmem::Finder::new(r#""type":"test""#);
         let type_test_spaced = memmem::Finder::new(r#""type": "test""#);
         if type_test_compact.find(bytes).is_some() || type_test_spaced.find(bytes).is_some() {
-            return true;
+            return DetectResult::NdJson;
         }
 
         // Text fingerprint: `test result:` AND `passed` both appear in the sample
         let test_result = memmem::Finder::new("test result:");
         let passed = memmem::Finder::new("passed");
-        test_result.find(bytes).is_some() && passed.find(bytes).is_some()
+        if test_result.find(bytes).is_some() && passed.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
-        let trimmed = input.trim_start();
-        if trimmed.starts_with('{') || input.lines().any(|l| l.trim_start().starts_with('{')) {
-            if let Some(parsed) = self.try_json(input) {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
+        if hint == DetectResult::NdJson {
+            if let Some(parsed) = CargoTestParser::try_json(input) {
                 return parsed;
             }
         }
-        self.parse_text(input)
+        CargoTestParser::parse_text(input)
     }
 }
 
 impl CargoTestParser {
-    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+    fn try_json(input: &str) -> Option<ParsedOutput> {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -92,8 +95,10 @@ impl CargoTestParser {
                 ("test", "ignored") => {
                     ignored += 1;
                 }
-                ("suite", "ok") | ("suite", "failed") => {
-                    if let Some(exec_time) = event.get("exec_time").and_then(|v| v.as_f64()) {
+                ("suite", "ok" | "failed") => {
+                    if let Some(exec_time) =
+                        event.get("exec_time").and_then(serde_json::Value::as_f64)
+                    {
                         duration_secs = Some(exec_time);
                     }
                 }
@@ -120,7 +125,7 @@ impl CargoTestParser {
         })
     }
 
-    fn parse_text(&self, input: &str) -> ParsedOutput {
+    fn parse_text(input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -135,7 +140,7 @@ impl CargoTestParser {
             if let Some(rest) = line.find("test result:").map(|i| &line[i + 12..]) {
                 let rest = rest.trim();
                 // Strip leading "ok." or "FAILED." status word
-                let rest = rest.find('.').map(|i| rest[i + 1..].trim()).unwrap_or(rest);
+                let rest = rest.find('.').map_or(rest, |i| rest[i + 1..].trim());
 
                 passed = extract_count(rest, "passed").unwrap_or(0);
                 failed = extract_count(rest, "failed").unwrap_or(0);
@@ -213,7 +218,7 @@ fn parse_ndjson(input: &str) -> Vec<serde_json::Value> {
 /// Extract the most useful failure message from a test's stdout.
 ///
 /// Priority order:
-/// 1. `assertion` lines (assert_eq!, assert!, assert_ne! output)
+/// 1. `assertion` lines (`assert_eq!`, `assert!`, `assert_ne!` output)
 /// 2. `thread '...' panicked at` lines
 /// 3. First non-empty line as fallback
 fn extract_failure_message(stdout: &str) -> String {
@@ -247,7 +252,7 @@ fn extract_failure_message(stdout: &str) -> String {
     // Fallback: first non-empty line
     stdout
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .find(|l| !l.is_empty())
         .unwrap_or("test failed")
         .to_string()
@@ -306,25 +311,26 @@ mod tests {
     #[test]
     fn detect_json_fingerprint() {
         let sample = r#"{"type":"test","event":"ok","name":"foo::bar"}"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
+        assert_eq!(PARSER.detect(sample), DetectResult::NdJson);
     }
 
     #[test]
     fn detect_json_fingerprint_spaced() {
         let sample = r#"{"type": "test", "event": "ok", "name": "foo::bar"}"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text_fingerprint() {
         let sample = "running 5 tests\ntest result: ok. 5 passed; 0 failed; 0 ignored";
-        assert!(PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::Text);
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
-        assert!(!PARSER.detect(sample));
+        assert_eq!(PARSER.detect(sample), DetectResult::NoMatch);
     }
 
     // -- JSON parse ----------------------------------------------------------
@@ -338,7 +344,7 @@ mod tests {
             "{\"type\":\"test\",\"event\":\"ok\",\"name\":\"a::test_three\"}\n",
             "{\"type\":\"suite\",\"event\":\"ok\",\"passed\":3,\"failed\":0,\"ignored\":0,\"exec_time\":0.05}\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.tool, "cargo-test");
         assert_eq!(out.counts.passed, 3);
         assert_eq!(out.counts.failed, 0);
@@ -360,7 +366,7 @@ mod tests {
         let input = format!(
             "{{\"type\":\"suite\",\"event\":\"started\",\"test_count\":1}}\n{event}{{\"type\":\"suite\",\"event\":\"failed\",\"passed\":0,\"failed\":1,\"ignored\":0,\"exec_time\":0.01}}\n",
         );
-        let out = PARSER.parse(&input);
+        let out = PARSER.parse(&input, DetectResult::NdJson);
         assert_eq!(out.counts.failed, 1);
         assert_eq!(out.counts.passed, 0);
         assert_eq!(out.diagnostics.len(), 1);
@@ -381,7 +387,7 @@ mod tests {
     #[test]
     fn parse_text_summary() {
         let input = "running 3 tests\ntest foo ... ok\ntest bar ... ok\ntest baz ... FAILED\n\ntest result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.passed, 2);
         assert_eq!(out.counts.failed, 1);
         assert_eq!(out.counts.skipped, 0);
@@ -404,7 +410,7 @@ mod tests {
             "\n",
             "test result: FAILED. 0 passed; 1 failed; 0 ignored\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.name, "my_mod::test_add");

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -1,0 +1,452 @@
+use memchr::memmem;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+
+use super::Parser;
+
+pub static PARSER: CargoTestParser = CargoTestParser;
+
+pub struct CargoTestParser;
+
+impl Parser for CargoTestParser {
+    fn name(&self) -> &'static str {
+        "cargo-test"
+    }
+
+    /// Detect cargo test output via byte scanning — no regex.
+    ///
+    /// Accepts JSON format (`"type":"test"`) or text format (`test result:` + `passed`).
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: any line with `"type":"test"` or `"type": "test"`
+        let type_test_compact = memmem::Finder::new(r#""type":"test""#);
+        let type_test_spaced = memmem::Finder::new(r#""type": "test""#);
+        if type_test_compact.find(bytes).is_some() || type_test_spaced.find(bytes).is_some() {
+            return true;
+        }
+
+        // Text fingerprint: `test result:` AND `passed` both appear in the sample
+        let test_result = memmem::Finder::new("test result:");
+        let passed = memmem::Finder::new("passed");
+        test_result.find(bytes).is_some() && passed.find(bytes).is_some()
+    }
+
+    /// Rewrite is only possible on nightly (`-Zunstable-options --format json`).
+    /// On stable Rust, we fall back to text parsing, which works fine.
+    /// For now, skip rewrite entirely — the text parser is robust enough.
+    fn rewrite(&self, _command: &str) -> Option<String> {
+        None
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let trimmed = input.trim_start();
+        if trimmed.starts_with('{') || input.lines().any(|l| l.trim_start().starts_with('{')) {
+            if let Some(parsed) = self.try_json(input) {
+                return parsed;
+            }
+        }
+        self.parse_text(input)
+    }
+}
+
+impl CargoTestParser {
+    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let events = parse_ndjson(input);
+        if events.is_empty() {
+            return None;
+        }
+
+        let mut passed: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut ignored: u32 = 0;
+        let mut duration_secs: Option<f64> = None;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        for event in &events {
+            let event_type = event.get("type").and_then(|v| v.as_str()).unwrap_or("");
+            let event_kind = event.get("event").and_then(|v| v.as_str()).unwrap_or("");
+
+            match (event_type, event_kind) {
+                ("test", "ok") => {
+                    passed += 1;
+                }
+                ("test", "failed") => {
+                    failed += 1;
+                    let name = event
+                        .get("name")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("<unknown>")
+                        .to_string();
+                    let stdout = event
+                        .get("stdout")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    let message = extract_failure_message(stdout);
+                    let location = Location::scan_text(stdout);
+                    let detail = truncate_detail(stdout);
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Error,
+                        location,
+                        name,
+                        message,
+                        detail,
+                    });
+                }
+                ("test", "ignored") => {
+                    ignored += 1;
+                }
+                ("suite", "ok") | ("suite", "failed") => {
+                    if let Some(exec_time) = event.get("exec_time").and_then(|v| v.as_f64()) {
+                        duration_secs = Some(exec_time);
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let summary = build_summary(passed, failed, ignored);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped: ignored,
+            ..Counts::default()
+        };
+
+        Some(ParsedOutput {
+            tool: "cargo-test",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs,
+            raw_lines,
+            raw_bytes,
+        })
+    }
+
+    fn parse_text(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut passed: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut ignored: u32 = 0;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // Parse summary line: `test result: ok. 5 passed; 0 failed; 1 ignored`
+        // or `test result: FAILED. 2 passed; 3 failed; 0 ignored`
+        for line in input.lines() {
+            if let Some(rest) = line.find("test result:").map(|i| &line[i + 12..]) {
+                let rest = rest.trim();
+                // Strip leading "ok." or "FAILED." status word
+                let rest = rest
+                    .find('.')
+                    .map(|i| rest[i + 1..].trim())
+                    .unwrap_or(rest);
+
+                passed = extract_count(rest, "passed").unwrap_or(0);
+                failed = extract_count(rest, "failed").unwrap_or(0);
+                ignored = extract_count(rest, "ignored").unwrap_or(0);
+                break;
+            }
+        }
+
+        // Extract failure blocks: `---- test_name stdout ----`
+        let lines: Vec<&str> = input.lines().collect();
+        let mut i = 0;
+        while i < lines.len() {
+            let line = lines[i].trim();
+            // A failure block header looks like: `---- some::test_name stdout ----`
+            if let Some(name) = parse_failure_block_header(line) {
+                // Collect the block content until the next `----` separator or end
+                let block_start = i + 1;
+                let mut block_end = block_start;
+                while block_end < lines.len() {
+                    let next = lines[block_end].trim();
+                    if next.starts_with("----") {
+                        break;
+                    }
+                    block_end += 1;
+                }
+                let block = lines[block_start..block_end].join("\n");
+                let message = extract_failure_message(&block);
+                let location = Location::scan_text(&block);
+                let detail = truncate_detail(&block);
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    location,
+                    name,
+                    message,
+                    detail,
+                });
+                i = block_end;
+                continue;
+            }
+            i += 1;
+        }
+
+        let summary = build_summary(passed, failed, ignored);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped: ignored,
+            ..Counts::default()
+        };
+
+        ParsedOutput {
+            tool: "cargo-test",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn parse_ndjson(input: &str) -> Vec<serde_json::Value> {
+    input
+        .lines()
+        .filter(|line| line.trim_start().starts_with('{'))
+        .filter_map(|line| serde_json::from_str(line).ok())
+        .collect()
+}
+
+/// Build a human-readable summary, omitting zero categories except `passed`.
+fn build_summary(passed: u32, failed: u32, ignored: u32) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("{passed} passed"));
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if ignored > 0 {
+        parts.push(format!("{ignored} ignored"));
+    }
+    parts.join(", ")
+}
+
+/// Extract the most useful failure message from a test's stdout.
+///
+/// Priority order:
+/// 1. `assertion` lines (assert_eq!, assert!, assert_ne! output)
+/// 2. `thread '...' panicked at` lines
+/// 3. First non-empty line as fallback
+fn extract_failure_message(stdout: &str) -> String {
+    // Look for assertion failures first: lines containing "left" / "right" or
+    // the assertion macro name. Cargo prints them as:
+    //   assertion `left == right` failed
+    //   left: 1
+    //   right: 2
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("assertion") && trimmed.contains("failed") {
+            return trimmed.to_string();
+        }
+    }
+
+    // Panic message: `thread 'test_name' panicked at 'message', file:line`
+    // or the newer format: `thread 'test_name' panicked at file:line:`
+    for line in stdout.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains("panicked at") {
+            // Try to extract just the message portion.
+            // Old format: panicked at 'message', src/...
+            // New format: panicked at src/...:  (message on next line)
+            if let Some(msg) = extract_panic_message(trimmed) {
+                return msg;
+            }
+            return trimmed.to_string();
+        }
+    }
+
+    // Fallback: first non-empty line
+    stdout
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("test failed")
+        .to_string()
+}
+
+/// Extract the human message from a panic line.
+///
+/// Old rustc format: `thread 'name' panicked at 'the message', file:line:col`
+/// New rustc format: `thread 'name' panicked at file:line:col:` (message follows on next line)
+fn extract_panic_message(line: &str) -> Option<String> {
+    // Old format: panicked at 'message', ...
+    if let Some(after_at) = line.find("panicked at '") {
+        let after_quote = after_at + "panicked at '".len();
+        if let Some(close) = line[after_quote..].find('\'') {
+            return Some(line[after_quote..after_quote + close].to_string());
+        }
+    }
+    None
+}
+
+/// Parse the header of a stdout failure block.
+///
+/// Matches lines of the form: `---- module::test_name stdout ----`
+/// Returns the test name portion (everything between `---- ` and ` stdout ----`).
+fn parse_failure_block_header(line: &str) -> Option<String> {
+    let line = line.trim();
+    if !line.starts_with("----") || !line.ends_with("----") {
+        return None;
+    }
+    // Strip leading and trailing `----`
+    let inner = line.trim_start_matches('-').trim_end_matches('-').trim();
+    // Strip trailing ` stdout` or ` stderr`
+    let name = if let Some(stripped) = inner.strip_suffix("stdout") {
+        stripped.trim()
+    } else if let Some(stripped) = inner.strip_suffix("stderr") {
+        stripped.trim()
+    } else {
+        return None;
+    };
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_json_fingerprint() {
+        let sample = r#"{"type":"test","event":"ok","name":"foo::bar"}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_json_fingerprint_spaced() {
+        let sample = r#"{"type": "test", "event": "ok", "name": "foo::bar"}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text_fingerprint() {
+        let sample = "running 5 tests\ntest result: ok. 5 passed; 0 failed; 0 ignored";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // -- Rewrite -------------------------------------------------------------
+
+    #[test]
+    fn rewrite_returns_none() {
+        // Rewrite is disabled on stable Rust (requires nightly -Zunstable-options).
+        assert!(PARSER.rewrite("cargo test --lib").is_none());
+        assert!(PARSER.rewrite("cargo test --lib -- --format json").is_none());
+        assert!(PARSER.rewrite("cargo nextest run").is_none());
+    }
+
+    // -- JSON parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_json_all_pass() {
+        let input = concat!(
+            "{\"type\":\"suite\",\"event\":\"started\",\"test_count\":3}\n",
+            "{\"type\":\"test\",\"event\":\"ok\",\"name\":\"a::test_one\"}\n",
+            "{\"type\":\"test\",\"event\":\"ok\",\"name\":\"a::test_two\"}\n",
+            "{\"type\":\"test\",\"event\":\"ok\",\"name\":\"a::test_three\"}\n",
+            "{\"type\":\"suite\",\"event\":\"ok\",\"passed\":3,\"failed\":0,\"ignored\":0,\"exec_time\":0.05}\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.tool, "cargo-test");
+        assert_eq!(out.counts.passed, 3);
+        assert_eq!(out.counts.failed, 0);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.duration_secs, Some(0.05));
+        assert!(out.summary.contains("3 passed"));
+        assert!(!out.summary.contains("failed"));
+    }
+
+    #[test]
+    fn parse_json_with_failure() {
+        let stdout = "thread 'a::test_bad' panicked at 'assertion failed: 1 == 2', src/lib.rs:10:5\n";
+        let event = format!(
+            "{{\"type\":\"test\",\"event\":\"failed\",\"name\":\"a::test_bad\",\"stdout\":{}}}\n",
+            serde_json::to_string(stdout).unwrap()
+        );
+        let input = format!(
+            "{{\"type\":\"suite\",\"event\":\"started\",\"test_count\":1}}\n{event}{{\"type\":\"suite\",\"event\":\"failed\",\"passed\":0,\"failed\":1,\"ignored\":0,\"exec_time\":0.01}}\n",
+        );
+        let out = PARSER.parse(&input);
+        assert_eq!(out.counts.failed, 1);
+        assert_eq!(out.counts.passed, 0);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "a::test_bad");
+        assert_eq!(diag.severity, Severity::Error);
+        // Message should contain the panic content
+        assert!(!diag.message.is_empty());
+        // Location should be extracted
+        let loc = diag.location.as_ref().expect("location should be present");
+        assert_eq!(loc.file, "src/lib.rs");
+        assert_eq!(loc.line, 10);
+        assert_eq!(loc.column, Some(5));
+    }
+
+    // -- Text parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_text_summary() {
+        let input = "running 3 tests\ntest foo ... ok\ntest bar ... ok\ntest baz ... FAILED\n\ntest result: FAILED. 2 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out";
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.passed, 2);
+        assert_eq!(out.counts.failed, 1);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.summary.contains("2 passed"));
+        assert!(out.summary.contains("1 failed"));
+    }
+
+    #[test]
+    fn parse_text_failure_block() {
+        let input = concat!(
+            "running 1 test\n",
+            "test my_mod::test_add ... FAILED\n",
+            "\n",
+            "failures:\n",
+            "\n",
+            "---- my_mod::test_add stdout ----\n",
+            "thread 'my_mod::test_add' panicked at 'assertion failed: `(left == right)`\n",
+            "  left: `1`,\n",
+            " right: `2`', src/lib.rs:15:5\n",
+            "\n",
+            "test result: FAILED. 0 passed; 1 failed; 0 ignored\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "my_mod::test_add");
+        assert_eq!(diag.severity, Severity::Error);
+        // Detail should contain the raw stdout block
+        assert!(diag.detail.is_some());
+        let detail = diag.detail.as_ref().unwrap();
+        assert!(detail.contains("left"));
+    }
+}

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -145,6 +145,8 @@ impl CargoTestParser {
                 passed = extract_count(rest, "passed").unwrap_or(0);
                 failed = extract_count(rest, "failed").unwrap_or(0);
                 ignored = extract_count(rest, "ignored").unwrap_or(0);
+                // NOTE: Only the first `test result:` line is captured. Multi-binary workspace
+                // runs produce multiple summary lines; the JSON path handles those correctly.
                 break;
             }
         }
@@ -235,15 +237,25 @@ fn extract_failure_message(stdout: &str) -> String {
     }
 
     // Panic message: `thread 'test_name' panicked at 'message', file:line`
-    // or the newer format: `thread 'test_name' panicked at file:line:`
-    for line in stdout.lines() {
+    // or the newer format (Rust 1.73+): `thread 'test_name' panicked at file:line:`
+    // followed by the message on the next line.
+    let lines: Vec<&str> = stdout.lines().collect();
+    for (i, line) in lines.iter().enumerate() {
         let trimmed = line.trim();
         if trimmed.contains("panicked at") {
-            // Try to extract just the message portion.
             // Old format: panicked at 'message', src/...
-            // New format: panicked at src/...:  (message on next line)
-            if let Some(msg) = extract_panic_message(trimmed) {
+            if let Some(msg) = extract_panic_message_old(trimmed) {
                 return msg;
+            }
+            // New format (Rust 1.73+): panicked at src/file.rs:line:col:
+            // The message is on the next line.
+            if is_new_panic_format(trimmed) {
+                if let Some(next_line) = lines.get(i + 1) {
+                    let msg = next_line.trim();
+                    if !msg.is_empty() {
+                        return msg.to_string();
+                    }
+                }
             }
             return trimmed.to_string();
         }
@@ -258,19 +270,26 @@ fn extract_failure_message(stdout: &str) -> String {
         .to_string()
 }
 
-/// Extract the human message from a panic line.
+/// Extract the human message from a panic line using the old rustc format.
 ///
-/// Old rustc format: `thread 'name' panicked at 'the message', file:line:col`
-/// New rustc format: `thread 'name' panicked at file:line:col:` (message follows on next line)
-fn extract_panic_message(line: &str) -> Option<String> {
-    // Old format: panicked at 'message', ...
-    if let Some(after_at) = line.find("panicked at '") {
-        let after_quote = after_at + "panicked at '".len();
-        if let Some(close) = line[after_quote..].find('\'') {
-            return Some(line[after_quote..after_quote + close].to_string());
-        }
-    }
-    None
+/// Old format: `thread 'name' panicked at 'the message', file:line:col`
+fn extract_panic_message_old(line: &str) -> Option<String> {
+    let after_at = line.find("panicked at '")?;
+    let after_quote = after_at + "panicked at '".len();
+    let close = line[after_quote..].find('\'')?;
+    Some(line[after_quote..after_quote + close].to_string())
+}
+
+/// Returns true when the line matches the new Rust 1.73+ panic format:
+/// `thread 'name' panicked at file:line:col:`
+/// In this format the location appears inline and ends with `:`, and the
+/// message is on the following line (not quoted on this line).
+fn is_new_panic_format(line: &str) -> bool {
+    // New format does NOT have `panicked at '` (that's the old format).
+    // It ends with `:` after the location (e.g. `panicked at src/lib.rs:10:5:`).
+    line.contains("panicked at")
+        && !line.contains("panicked at '")
+        && line.trim_end().ends_with(':')
 }
 
 /// Parse the header of a stdout failure block.
@@ -393,6 +412,44 @@ mod tests {
         assert_eq!(out.counts.skipped, 0);
         assert!(out.summary.contains("2 passed"));
         assert!(out.summary.contains("1 failed"));
+    }
+
+    // -- Panic format (Bug #7) -----------------------------------------------
+
+    #[test]
+    fn extract_panic_message_new_format() {
+        // Rust 1.73+ format: location inline after "panicked at", message on next line.
+        let stdout = "thread 'my_mod::test_add' panicked at src/lib.rs:10:5:\nexpected true, got false\nnote: run with RUST_BACKTRACE=1\n";
+        let msg = extract_failure_message(stdout);
+        assert_eq!(msg, "expected true, got false");
+    }
+
+    #[test]
+    fn extract_panic_message_old_format_still_works() {
+        // Old format: message quoted inline.
+        let stdout =
+            "thread 'my_mod::test_add' panicked at 'assertion failed: 1 == 2', src/lib.rs:10:5\n";
+        let msg = extract_failure_message(stdout);
+        assert_eq!(msg, "assertion failed: 1 == 2");
+    }
+
+    #[test]
+    fn parse_json_failure_new_panic_format() {
+        // Simulates a failed test whose stdout uses the Rust 1.73+ panic format.
+        let stdout =
+            "thread 'a::test_bad' panicked at src/lib.rs:10:5:\nassertion failed: 2 + 2 == 5\n";
+        let event = format!(
+            "{{\"type\":\"test\",\"event\":\"failed\",\"name\":\"a::test_bad\",\"stdout\":{}}}\n",
+            serde_json::to_string(stdout).unwrap()
+        );
+        let input = format!(
+            "{{\"type\":\"suite\",\"event\":\"started\",\"test_count\":1}}\n{event}{{\"type\":\"suite\",\"event\":\"failed\",\"passed\":0,\"failed\":1,\"ignored\":0,\"exec_time\":0.01}}\n",
+        );
+        let out = PARSER.parse(&input, DetectResult::NdJson);
+        assert_eq!(out.counts.failed, 1);
+        let diag = &out.diagnostics[0];
+        // Should extract the next-line message, not the location string.
+        assert_eq!(diag.message, "assertion failed: 2 + 2 == 5");
     }
 
     #[test]

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -32,13 +32,6 @@ impl Parser for CargoTestParser {
         test_result.find(bytes).is_some() && passed.find(bytes).is_some()
     }
 
-    /// Rewrite is only possible on nightly (`-Zunstable-options --format json`).
-    /// On stable Rust, we fall back to text parsing, which works fine.
-    /// For now, skip rewrite entirely — the text parser is robust enough.
-    fn rewrite(&self, _command: &str) -> Option<String> {
-        None
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let trimmed = input.trim_start();
         if trimmed.starts_with('{') || input.lines().any(|l| l.trim_start().starts_with('{')) {
@@ -351,16 +344,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
         assert!(!PARSER.detect(sample));
-    }
-
-    // -- Rewrite -------------------------------------------------------------
-
-    #[test]
-    fn rewrite_returns_none() {
-        // Rewrite is disabled on stable Rust (requires nightly -Zunstable-options).
-        assert!(PARSER.rewrite("cargo test --lib").is_none());
-        assert!(PARSER.rewrite("cargo test --lib -- --format json").is_none());
-        assert!(PARSER.rewrite("cargo nextest run").is_none());
     }
 
     // -- JSON parse ----------------------------------------------------------

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -1,6 +1,8 @@
 use memchr::memmem;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+use crate::run::types::{
+    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -74,10 +76,7 @@ impl CargoTestParser {
                         .and_then(|v| v.as_str())
                         .unwrap_or("<unknown>")
                         .to_string();
-                    let stdout = event
-                        .get("stdout")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("");
+                    let stdout = event.get("stdout").and_then(|v| v.as_str()).unwrap_or("");
                     let message = extract_failure_message(stdout);
                     let location = Location::scan_text(stdout);
                     let detail = truncate_detail(stdout);
@@ -136,10 +135,7 @@ impl CargoTestParser {
             if let Some(rest) = line.find("test result:").map(|i| &line[i + 12..]) {
                 let rest = rest.trim();
                 // Strip leading "ok." or "FAILED." status word
-                let rest = rest
-                    .find('.')
-                    .map(|i| rest[i + 1..].trim())
-                    .unwrap_or(rest);
+                let rest = rest.find('.').map(|i| rest[i + 1..].trim()).unwrap_or(rest);
 
                 passed = extract_count(rest, "passed").unwrap_or(0);
                 failed = extract_count(rest, "failed").unwrap_or(0);
@@ -311,7 +307,6 @@ fn parse_failure_block_header(line: &str) -> Option<String> {
     Some(name.to_string())
 }
 
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -370,7 +365,8 @@ mod tests {
 
     #[test]
     fn parse_json_with_failure() {
-        let stdout = "thread 'a::test_bad' panicked at 'assertion failed: 1 == 2', src/lib.rs:10:5\n";
+        let stdout =
+            "thread 'a::test_bad' panicked at 'assertion failed: 1 == 2', src/lib.rs:10:5\n";
         let event = format!(
             "{{\"type\":\"test\",\"event\":\"failed\",\"name\":\"a::test_bad\",\"stdout\":{}}}\n",
             serde_json::to_string(stdout).unwrap()

--- a/src/run/parsers/cargo_test.rs
+++ b/src/run/parsers/cargo_test.rs
@@ -1,7 +1,8 @@
 use memchr::memmem;
 
 use crate::run::types::{
-    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    build_test_summary, extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput,
+    Severity,
 };
 
 use super::Parser;
@@ -100,11 +101,10 @@ impl CargoTestParser {
             }
         }
 
-        let summary = build_summary(passed, failed, ignored);
+        let summary = build_test_summary(passed, failed, ignored);
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped: ignored,
             ..Counts::default()
         };
@@ -178,11 +178,10 @@ impl CargoTestParser {
             i += 1;
         }
 
-        let summary = build_summary(passed, failed, ignored);
+        let summary = build_test_summary(passed, failed, ignored);
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped: ignored,
             ..Counts::default()
         };
@@ -209,19 +208,6 @@ fn parse_ndjson(input: &str) -> Vec<serde_json::Value> {
         .filter(|line| line.trim_start().starts_with('{'))
         .filter_map(|line| serde_json::from_str(line).ok())
         .collect()
-}
-
-/// Build a human-readable summary, omitting zero categories except `passed`.
-fn build_summary(passed: u32, failed: u32, ignored: u32) -> String {
-    let mut parts: Vec<String> = Vec::new();
-    parts.push(format!("{passed} passed"));
-    if failed > 0 {
-        parts.push(format!("{failed} failed"));
-    }
-    if ignored > 0 {
-        parts.push(format!("{ignored} ignored"));
-    }
-    parts.join(", ")
 }
 
 /// Extract the most useful failure message from a test's stdout.

--- a/src/run/parsers/eslint.rs
+++ b/src/run/parsers/eslint.rs
@@ -1,0 +1,446 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: EslintParser = EslintParser;
+
+pub struct EslintParser;
+
+impl Parser for EslintParser {
+    fn name(&self) -> &'static str {
+        "eslint"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: array containing objects with "filePath" and "messages".
+        let file_path_finder = memmem::Finder::new(b"\"filePath\"");
+        let messages_finder = memmem::Finder::new(b"\"messages\"");
+        if sample.trim_start().starts_with('[')
+            && file_path_finder.find(bytes).is_some()
+            && messages_finder.find(bytes).is_some()
+        {
+            return true;
+        }
+
+        // Text fingerprint: indented lines with `error` or `warning` and a rule containing `/`
+        // or a well-known bare rule name pattern.
+        sample.lines().any(looks_like_eslint_text_line)
+    }
+
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--format") || command.contains(" -f ") {
+            return None;
+        }
+        Some(format!("{command} --format json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        if input.trim_start().starts_with('[') {
+            parse_json(input, raw_lines, raw_bytes)
+        } else {
+            parse_text(input, raw_lines, raw_bytes)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true if `line` looks like an ESLint text-format diagnostic line.
+///
+/// ESLint text lines are indented and have the form:
+///   `  10:5  error  'x' is defined but never used  no-unused-vars`
+///   `  15:3  warning  Missing semicolon  semi`
+fn looks_like_eslint_text_line(line: &str) -> bool {
+    let trimmed = line.trim_start();
+    // Must be indented (original line starts with whitespace).
+    if trimmed.is_empty() || !line.starts_with(' ') {
+        return false;
+    }
+    // First token must be `line:col`.
+    let Some((loc, rest)) = trimmed.split_once("  ") else {
+        return false;
+    };
+    let loc = loc.trim();
+    if !loc.contains(':') || !loc.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+        return false;
+    }
+    let rest = rest.trim_start();
+    // Next token must be `error` or `warning`.
+    let severity_word = if rest.starts_with("error") {
+        "error"
+    } else if rest.starts_with("warning") {
+        "warning"
+    } else {
+        return false;
+    };
+    // After severity there should be at least two more whitespace-separated fields.
+    // The last field is the rule ID.  A rule ID either contains `/` (scoped: @scope/rule)
+    // or is a plain identifier.  We confirm the line has content after the severity word.
+    let after_severity = rest[severity_word.len()..].trim_start();
+    !after_severity.is_empty()
+}
+
+// ---------------------------------------------------------------------------
+// JSON path
+// ---------------------------------------------------------------------------
+
+fn parse_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    let Ok(Value::Array(files)) = serde_json::from_str::<Value>(input.trim()) else {
+        return empty_output(raw_lines, raw_bytes);
+    };
+
+    for file_obj in &files {
+        let file_path = file_obj
+            .get("filePath")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string();
+
+        let Some(messages) = file_obj.get("messages").and_then(Value::as_array) else {
+            continue;
+        };
+
+        for msg in messages {
+            let Some(diag) = extract_json_message(msg, &file_path) else {
+                continue;
+            };
+            match diag.severity {
+                Severity::Error => error_count += 1,
+                Severity::Warning => warning_count += 1,
+                Severity::Info => {}
+            }
+            diagnostics.push(diag);
+        }
+    }
+
+    let summary = build_summary(error_count, warning_count);
+
+    ParsedOutput {
+        tool: "eslint",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+fn extract_json_message(msg: &Value, file_path: &str) -> Option<Diagnostic> {
+    let message = msg.get("message").and_then(Value::as_str)?.to_string();
+
+    // severity: 2 = Error, 1 = Warning
+    let severity = match msg.get("severity").and_then(Value::as_u64).unwrap_or(1) {
+        2 => Severity::Error,
+        _ => Severity::Warning,
+    };
+
+    let name = msg
+        .get("ruleId")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let line = msg.get("line").and_then(Value::as_u64).unwrap_or(0) as u32;
+    let column = msg
+        .get("column")
+        .and_then(Value::as_u64)
+        .map(|c| c as u32);
+
+    let location = if !file_path.is_empty() && line > 0 {
+        Some(Location {
+            file: file_path.to_string(),
+            line,
+            column,
+        })
+    } else {
+        None
+    };
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+    let mut current_file = String::new();
+
+    for line in input.lines() {
+        // File header: non-indented, non-empty line that is not the summary.
+        if !line.starts_with(' ') && !line.is_empty() {
+            // Skip the summary line (e.g. "✖ 2 problems (1 error, 1 warning)").
+            if !line.trim_start_matches('\u{2716}').trim().starts_with(|c: char| c.is_ascii_digit()) {
+                current_file = line.trim().to_string();
+            }
+            continue;
+        }
+
+        let Some(diag) = parse_text_line(line, &current_file) else {
+            continue;
+        };
+        match diag.severity {
+            Severity::Error => error_count += 1,
+            Severity::Warning => warning_count += 1,
+            Severity::Info => {}
+        }
+        diagnostics.push(diag);
+    }
+
+    let summary = build_summary(error_count, warning_count);
+
+    ParsedOutput {
+        tool: "eslint",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Parse a single indented ESLint text diagnostic line.
+///
+/// Expected format: `  10:5  error  'x' is defined but never used  no-unused-vars`
+fn parse_text_line(line: &str, file: &str) -> Option<Diagnostic> {
+    let trimmed = line.trim_start();
+    if trimmed.is_empty() {
+        return None;
+    }
+
+    // Split on two-or-more spaces to extract fields robustly.
+    // Fields: loc, severity, message, rule_id
+    let fields: Vec<&str> = trimmed
+        .splitn(4, "  ")
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+
+    if fields.len() < 3 {
+        return None;
+    }
+
+    // Field 0: `line:col`
+    let loc = fields[0];
+    let (line_num, column) = parse_location(loc)?;
+
+    // Field 1: severity word
+    let severity = match fields[1] {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        _ => return None,
+    };
+
+    // Fields 2...: message and optional rule ID (last field).
+    // With splitn(4, ..) fields[2] is the message, fields[3] (if present) is the rule.
+    let (message, name) = if fields.len() >= 4 {
+        (fields[2].to_string(), fields[3].to_string())
+    } else {
+        // No rule ID — message is fields[2], name unknown.
+        (fields[2].to_string(), "unknown".to_string())
+    };
+
+    let location = if !file.is_empty() {
+        Some(Location {
+            file: file.to_string(),
+            line: line_num,
+            column: Some(column),
+        })
+    } else {
+        None
+    };
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name,
+        message,
+        detail: None,
+    })
+}
+
+/// Parse `line:col` into `(line, col)`.
+fn parse_location(loc: &str) -> Option<(u32, u32)> {
+    let (line_str, col_str) = loc.split_once(':')?;
+    let line: u32 = line_str.trim().parse().ok()?;
+    let col: u32 = col_str.trim().parse().ok()?;
+    Some((line, col))
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn build_summary(errors: u32, warnings: u32) -> String {
+    if errors == 0 && warnings == 0 {
+        "no issues found".to_string()
+    } else {
+        format!("{} error(s), {} warning(s)", errors, warnings)
+    }
+}
+
+fn empty_output(raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    ParsedOutput {
+        tool: "eslint",
+        summary: "no issues found".to_string(),
+        diagnostics: Vec::new(),
+        counts: Counts::default(),
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_json() {
+        let sample = r#"[{"filePath":"/src/app.js","messages":[]}]"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text() {
+        let sample = "/src/app.js\n  10:5  error  'x' is defined but never used  no-unused-vars\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects() {
+        let sample = "some random\noutput with no eslint markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_appends() {
+        let result = PARSER.rewrite("eslint src/");
+        assert_eq!(result, Some("eslint src/ --format json".to_string()));
+    }
+
+    #[test]
+    fn rewrite_skips() {
+        let result = PARSER.rewrite("eslint src/ --format json");
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn rewrite_skips_short_flag() {
+        let result = PARSER.rewrite("eslint -f json src/");
+        assert!(result.is_none());
+    }
+
+    // --- JSON path ---
+
+    #[test]
+    fn parse_json() {
+        let input = r#"[{
+  "filePath": "/path/to/file.js",
+  "messages": [
+    {
+      "severity": 2,
+      "line": 10,
+      "column": 5,
+      "ruleId": "no-unused-vars",
+      "message": "'x' is defined but never used."
+    },
+    {
+      "severity": 1,
+      "line": 15,
+      "column": 3,
+      "ruleId": "@typescript-eslint/no-explicit-any",
+      "message": "Unexpected any."
+    }
+  ]
+}]"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.name, "no-unused-vars");
+        assert_eq!(first.severity, Severity::Error);
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("/path/to/file.js")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(10));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.name, "@typescript-eslint/no-explicit-any");
+        assert_eq!(second.severity, Severity::Warning);
+
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.counts.warnings, 1);
+        assert_eq!(out.summary, "1 error(s), 1 warning(s)");
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text() {
+        let input = "/path/to/file.js\n  10:5  error  'x' is defined but never used  no-unused-vars\n  15:3  warning  Unexpected any  @typescript-eslint/no-explicit-any\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.name, "no-unused-vars");
+        assert_eq!(first.severity, Severity::Error);
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("/path/to/file.js")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(10));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.severity, Severity::Warning);
+        assert_eq!(second.name, "@typescript-eslint/no-explicit-any");
+
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.counts.warnings, 1);
+        assert_eq!(out.summary, "1 error(s), 1 warning(s)");
+    }
+}

--- a/src/run/parsers/eslint.rs
+++ b/src/run/parsers/eslint.rs
@@ -64,7 +64,13 @@ fn looks_like_eslint_text_line(line: &str) -> bool {
         return false;
     };
     let loc = loc.trim();
-    if !loc.contains(':') || !loc.chars().next().map(|c| c.is_ascii_digit()).unwrap_or(false) {
+    if !loc.contains(':')
+        || !loc
+            .chars()
+            .next()
+            .map(|c| c.is_ascii_digit())
+            .unwrap_or(false)
+    {
         return false;
     }
     let rest = rest.trim_start();
@@ -153,10 +159,7 @@ fn extract_json_message(msg: &Value, file_path: &str) -> Option<Diagnostic> {
         .to_string();
 
     let line = msg.get("line").and_then(Value::as_u64).unwrap_or(0) as u32;
-    let column = msg
-        .get("column")
-        .and_then(Value::as_u64)
-        .map(|c| c as u32);
+    let column = msg.get("column").and_then(Value::as_u64).map(|c| c as u32);
 
     let location = if !file_path.is_empty() && line > 0 {
         Some(Location {
@@ -191,7 +194,11 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
         // File header: non-indented, non-empty line that is not the summary.
         if !line.starts_with(' ') && !line.is_empty() {
             // Skip the summary line (e.g. "✖ 2 problems (1 error, 1 warning)").
-            if !line.trim_start_matches('\u{2716}').trim().starts_with(|c: char| c.is_ascii_digit()) {
+            if !line
+                .trim_start_matches('\u{2716}')
+                .trim()
+                .starts_with(|c: char| c.is_ascii_digit())
+            {
                 current_file = line.trim().to_string();
             }
             continue;

--- a/src/run/parsers/eslint.rs
+++ b/src/run/parsers/eslint.rs
@@ -192,12 +192,15 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
     for line in input.lines() {
         // File header: non-indented, non-empty line that is not the summary.
         if !line.starts_with(' ') && !line.is_empty() {
-            // Skip the summary line (e.g. "✖ 2 problems (1 error, 1 warning)").
-            if !line
-                .trim_start_matches('\u{2716}')
-                .trim()
-                .starts_with(|c: char| c.is_ascii_digit())
-            {
+            // Skip summary lines like "✖ 2 problems (1 error, 1 warning)" or "2 errors".
+            // A summary line starts with a digit (after stripping the ✖ prefix) AND does not
+            // contain '/' or '.' — file paths that happen to start with a digit (e.g.
+            // "1password/config.js") must NOT be treated as summaries.
+            let candidate = line.trim_start_matches('\u{2716}').trim();
+            let is_summary = candidate.starts_with(|c: char| c.is_ascii_digit())
+                && !candidate.contains('/')
+                && !candidate.contains('.');
+            if !is_summary {
                 current_file = line.trim().to_string();
             }
             continue;
@@ -394,6 +397,57 @@ mod tests {
         assert_eq!(out.counts.errors, 1);
         assert_eq!(out.counts.warnings, 1);
         assert_eq!(out.summary, "1 error(s), 1 warning(s)");
+    }
+
+    // --- Bug #11: file path starting with digit skipped as summary -----------
+
+    /// A file path like `1password/config.js` must not be treated as a summary
+    /// line just because it starts with a digit.
+    #[test]
+    fn parse_text_file_path_starting_with_digit() {
+        let input = concat!(
+            "1password/config.js\n",
+            "  10:5  error  'x' is defined but never used  no-unused-vars\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.diagnostics.len(), 1);
+        assert_eq!(
+            out.diagnostics[0]
+                .location
+                .as_ref()
+                .map(|l| l.file.as_str()),
+            Some("1password/config.js")
+        );
+    }
+
+    /// A genuine summary line like `✖ 2 problems (1 error, 1 warning)` must be skipped.
+    #[test]
+    fn parse_text_summary_line_skipped() {
+        // After the file header and diagnostic, a summary line must not overwrite current_file.
+        let input = concat!(
+            "/src/app.js\n",
+            "  10:5  error  unused var  no-unused-vars\n",
+            "\u{2716} 1 problem (1 error, 0 warnings)\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // The summary line should not produce a diagnostic or corrupt the file path.
+        assert_eq!(out.diagnostics.len(), 1);
+        assert_eq!(
+            out.diagnostics[0]
+                .location
+                .as_ref()
+                .map(|l| l.file.as_str()),
+            Some("/src/app.js")
+        );
+    }
+
+    /// Plain `2 errors` summary (no ✖) must also be treated as a summary line.
+    #[test]
+    fn parse_text_plain_digit_summary_skipped() {
+        let input = concat!("/src/app.js\n", "  5:1  error  semi  semi\n", "2 errors\n",);
+        let out = PARSER.parse(input, DetectResult::Text);
+        // "2 errors" has no '/' or '.', so is a summary — must not become current_file.
+        assert_eq!(out.diagnostics.len(), 1);
     }
 
     // --- Text path ---

--- a/src/run/parsers/eslint.rs
+++ b/src/run/parsers/eslint.rs
@@ -1,7 +1,7 @@
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{Counts, DetectResult, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 
@@ -14,7 +14,7 @@ impl Parser for EslintParser {
         "eslint"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint: array containing objects with "filePath" and "messages".
@@ -24,19 +24,23 @@ impl Parser for EslintParser {
             && file_path_finder.find(bytes).is_some()
             && messages_finder.find(bytes).is_some()
         {
-            return true;
+            return DetectResult::SingleJson;
         }
 
         // Text fingerprint: indented lines with `error` or `warning` and a rule containing `/`
         // or a well-known bare rule name pattern.
-        sample.lines().any(looks_like_eslint_text_line)
+        if sample.lines().any(looks_like_eslint_text_line) {
+            DetectResult::Text
+        } else {
+            DetectResult::NoMatch
+        }
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
-        if input.trim_start().starts_with('[') {
+        if hint.is_json() {
             parse_json(input, raw_lines, raw_bytes)
         } else {
             parse_text(input, raw_lines, raw_bytes)
@@ -53,6 +57,7 @@ impl Parser for EslintParser {
 /// ESLint text lines are indented and have the form:
 ///   `  10:5  error  'x' is defined but never used  no-unused-vars`
 ///   `  15:3  warning  Missing semicolon  semi`
+#[allow(clippy::doc_markdown)] // "ESLint" is a tool name, not a code item
 fn looks_like_eslint_text_line(line: &str) -> bool {
     let trimmed = line.trim_start();
     // Must be indented (original line starts with whitespace).
@@ -64,13 +69,7 @@ fn looks_like_eslint_text_line(line: &str) -> bool {
         return false;
     };
     let loc = loc.trim();
-    if !loc.contains(':')
-        || !loc
-            .chars()
-            .next()
-            .map(|c| c.is_ascii_digit())
-            .unwrap_or(false)
-    {
+    if !loc.contains(':') || !loc.chars().next().is_some_and(|c| c.is_ascii_digit()) {
         return false;
     }
     let rest = rest.trim_start();
@@ -232,7 +231,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
     }
 }
 
-/// Parse a single indented ESLint text diagnostic line.
+/// Parse a single indented `ESLint` text diagnostic line.
 ///
 /// Expected format: `  10:5  error  'x' is defined but never used  no-unused-vars`
 fn parse_text_line(line: &str, file: &str) -> Option<Diagnostic> {
@@ -273,14 +272,14 @@ fn parse_text_line(line: &str, file: &str) -> Option<Diagnostic> {
         (fields[2].to_string(), "unknown".to_string())
     };
 
-    let location = if !file.is_empty() {
+    let location = if file.is_empty() {
+        None
+    } else {
         Some(Location {
             file: file.to_string(),
             line: line_num,
             column: Some(column),
         })
-    } else {
-        None
     };
 
     Some(Diagnostic {
@@ -308,7 +307,7 @@ fn build_summary(errors: u32, warnings: u32) -> String {
     if errors == 0 && warnings == 0 {
         "no issues found".to_string()
     } else {
-        format!("{} error(s), {} warning(s)", errors, warnings)
+        format!("{errors} error(s), {warnings} warning(s)")
     }
 }
 
@@ -337,19 +336,19 @@ mod tests {
     #[test]
     fn detect_json() {
         let sample = r#"[{"filePath":"/src/app.js","messages":[]}]"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text() {
         let sample = "/src/app.js\n  10:5  error  'x' is defined but never used  no-unused-vars\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects() {
         let sample = "some random\noutput with no eslint markers\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // --- JSON path ---
@@ -375,7 +374,7 @@ mod tests {
     }
   ]
 }]"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::SingleJson);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -402,7 +401,7 @@ mod tests {
     #[test]
     fn parse_text() {
         let input = "/path/to/file.js\n  10:5  error  'x' is defined but never used  no-unused-vars\n  15:3  warning  Unexpected any  @typescript-eslint/no-explicit-any\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];

--- a/src/run/parsers/eslint.rs
+++ b/src/run/parsers/eslint.rs
@@ -32,13 +32,6 @@ impl Parser for EslintParser {
         sample.lines().any(looks_like_eslint_text_line)
     }
 
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--format") || command.contains(" -f ") {
-            return None;
-        }
-        Some(format!("{command} --format json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -350,26 +343,6 @@ mod tests {
     fn detect_rejects() {
         let sample = "some random\noutput with no eslint markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_appends() {
-        let result = PARSER.rewrite("eslint src/");
-        assert_eq!(result, Some("eslint src/ --format json".to_string()));
-    }
-
-    #[test]
-    fn rewrite_skips() {
-        let result = PARSER.rewrite("eslint src/ --format json");
-        assert!(result.is_none());
-    }
-
-    #[test]
-    fn rewrite_skips_short_flag() {
-        let result = PARSER.rewrite("eslint -f json src/");
-        assert!(result.is_none());
     }
 
     // --- JSON path ---

--- a/src/run/parsers/generic.rs
+++ b/src/run/parsers/generic.rs
@@ -1,0 +1,276 @@
+use memchr::memmem;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: GenericParser = GenericParser;
+
+pub struct GenericParser;
+
+/// Error-level keywords searched via SIMD `memmem` finders.
+///
+/// We build these once and reuse them per parse call.
+struct Finders {
+    error: memmem::Finder<'static>,
+    failed: memmem::Finder<'static>,
+    fatal: memmem::Finder<'static>,
+    exception: memmem::Finder<'static>,
+    panic: memmem::Finder<'static>,
+}
+
+impl Finders {
+    fn new() -> Self {
+        Self {
+            error: memmem::Finder::new("error"),
+            failed: memmem::Finder::new("failed"),
+            fatal: memmem::Finder::new("fatal"),
+            exception: memmem::Finder::new("exception"),
+            panic: memmem::Finder::new("panic"),
+        }
+    }
+
+    fn matches(&self, lower: &[u8]) -> bool {
+        self.error.find(lower).is_some()
+            || self.failed.find(lower).is_some()
+            || self.fatal.find(lower).is_some()
+            || self.exception.find(lower).is_some()
+            || self.panic.find(lower).is_some()
+    }
+}
+
+impl Parser for GenericParser {
+    fn name(&self) -> &'static str {
+        "unknown"
+    }
+
+    /// The generic parser is the implicit fallback; it never claims a match.
+    fn detect(&self, _sample: &str) -> bool {
+        false
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let lines: Vec<&str> = input.lines().collect();
+        let raw_lines = lines.len();
+
+        // ≤20 lines: passthrough — format step will handle this, but we still build
+        // a minimal ParsedOutput so the caller can check `raw_lines`.
+        if raw_lines <= 20 {
+            return ParsedOutput {
+                tool: "unknown",
+                summary: String::new(),
+                diagnostics: Vec::new(),
+                counts: Counts::default(),
+                duration_secs: None,
+                raw_lines,
+                raw_bytes,
+            };
+        }
+
+        let finders = Finders::new();
+        let mut diagnostics = Vec::new();
+        let mut error_count: u32 = 0;
+        // Reusable buffer for ASCII-lowercased bytes — avoids allocation per line.
+        let mut lower_buf: Vec<u8> = Vec::new();
+
+        for line in &lines {
+            // ASCII-lowercase into reusable buffer (all keywords are ASCII).
+            let line_bytes = line.as_bytes();
+            lower_buf.clear();
+            lower_buf.extend(line_bytes.iter().map(|b| b.to_ascii_lowercase()));
+
+            if finders.matches(&lower_buf) {
+                error_count += 1;
+                let location = Location::scan_line(line);
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    location,
+                    name: normalize_message(line.trim()),
+                    message: line.trim().to_string(),
+                    detail: None,
+                });
+            }
+        }
+
+        let summary = if error_count == 0 {
+            format!("{raw_lines} lines, no errors detected")
+        } else {
+            format!("{raw_lines} lines, {error_count} error line(s)")
+        };
+
+        let counts = Counts {
+            errors: error_count,
+            ..Counts::default()
+        };
+
+        ParsedOutput {
+            tool: "unknown",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+/// Normalize an error message into a grouping key by stripping location-specific
+/// parts (file paths, line numbers). Two lines that say the same thing at different
+/// locations should produce the same key.
+///
+/// Example: "error: unused variable `x` at src/lib.rs:42" → "error: unused variable `x`"
+fn normalize_message(msg: &str) -> String {
+    // Strip trailing " at path:line:col" or " at path:line" patterns
+    let trimmed = msg.trim();
+    
+    // Strip leading "path:line:col: " prefix (common in compiler output)
+    let after_prefix = if let Some(loc_end) = find_location_prefix_end(trimmed) {
+        trimmed[loc_end..].trim_start_matches([' ', ':'])
+    } else {
+        trimmed
+    };
+
+    // Strip trailing " at path:line" suffix
+    if let Some(at_pos) = after_prefix.rfind(" at ") {
+        let suffix = &after_prefix[at_pos + 4..];
+        if looks_like_location(suffix) {
+            return after_prefix[..at_pos].to_string();
+        }
+    }
+
+    after_prefix.to_string()
+}
+
+/// Check if a string looks like "path:line" or "path:line:col"
+fn looks_like_location(s: &str) -> bool {
+    let parts: Vec<&str> = s.splitn(3, ':').collect();
+    parts.len() >= 2 && parts[1].chars().all(|c| c.is_ascii_digit()) && !parts[1].is_empty()
+}
+
+/// Find the end of a "path:line:col: " prefix. Returns byte offset after the prefix.
+fn find_location_prefix_end(s: &str) -> Option<usize> {
+    // Look for pattern: non-space chars containing '.', then :digits, optional :digits, then :
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    let mut saw_dot = false;
+    
+    // Scan the path part
+    while i < bytes.len() && bytes[i] != b':' {
+        if bytes[i] == b'.' || bytes[i] == b'/' { saw_dot = true; }
+        if bytes[i] == b' ' { return None; } // paths don't have spaces
+        i += 1;
+    }
+    if !saw_dot || i == 0 || i >= bytes.len() { return None; }
+    
+    // Must have :digits
+    i += 1; // skip :
+    let num_start = i;
+    while i < bytes.len() && bytes[i].is_ascii_digit() { i += 1; }
+    if i == num_start { return None; }
+    
+    // Optional :digits (column)
+    if i < bytes.len() && bytes[i] == b':' {
+        let col_start = i + 1;
+        let mut j = col_start;
+        while j < bytes.len() && bytes[j].is_ascii_digit() { j += 1; }
+        if j > col_start { i = j; }
+    }
+    
+    // Must be followed by : or space
+    if i < bytes.len() && (bytes[i] == b':' || bytes[i] == b' ') {
+        Some(i)
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn short_input_passthrough() {
+        let input = "line 1\nline 2\nline 3";
+        let out = PARSER.parse(input);
+        assert_eq!(out.raw_lines, 3);
+        assert!(out.diagnostics.is_empty());
+    }
+
+    #[test]
+    fn extracts_error_lines() {
+        let mut lines = Vec::new();
+        for i in 0..30 {
+            if i % 5 == 0 {
+                lines.push(format!("ERROR: something failed at line {i}"));
+            } else {
+                lines.push(format!("line {i}: all good"));
+            }
+        }
+        let input = lines.join("\n");
+        let out = PARSER.parse(&input);
+        assert!(!out.diagnostics.is_empty());
+        assert_eq!(out.counts.errors, out.diagnostics.len() as u32);
+    }
+
+    #[test]
+    fn location_extraction() {
+        let loc = Location::scan_line("src/main.rs:42: error: something");
+        assert!(loc.is_some());
+        let loc = loc.unwrap();
+        assert_eq!(loc.file, "src/main.rs");
+        assert_eq!(loc.line, 42);
+    }
+
+    #[test]
+    fn location_with_column() {
+        let loc = Location::scan_line("src/lib.rs:10:5: warning here");
+        assert!(loc.is_some());
+        let loc = loc.unwrap();
+        assert_eq!(loc.line, 10);
+        assert_eq!(loc.column, Some(5));
+    }
+
+    #[test]
+    fn detect_always_false() {
+        assert!(!PARSER.detect("anything"));
+    }
+
+    #[test]
+    fn normalize_strips_location_prefix() {
+        assert_eq!(
+            normalize_message("src/lib.rs:42: error: unused variable"),
+            "error: unused variable"
+        );
+    }
+
+    #[test]
+    fn normalize_strips_at_suffix() {
+        assert_eq!(
+            normalize_message("error: unused variable `x` at src/lib.rs:42"),
+            "error: unused variable `x`"
+        );
+    }
+
+    #[test]
+    fn normalize_preserves_plain_message() {
+        assert_eq!(
+            normalize_message("ERROR: something failed"),
+            "ERROR: something failed"
+        );
+    }
+
+    #[test]
+    fn duplicate_errors_group_by_message() {
+        let mut lines = Vec::new();
+        for i in 0..30 {
+            lines.push(format!("error: unused variable `x` at src/lib.rs:{}", i + 1));
+        }
+        let input = lines.join("\n");
+        let out = PARSER.parse(&input);
+        // All 30 should have the same name (normalized message)
+        let first_name = &out.diagnostics[0].name;
+        assert!(out.diagnostics.iter().all(|d| &d.name == first_name));
+    }
+}

--- a/src/run/parsers/generic.rs
+++ b/src/run/parsers/generic.rs
@@ -124,7 +124,7 @@ impl Parser for GenericParser {
 fn normalize_message(msg: &str) -> String {
     // Strip trailing " at path:line:col" or " at path:line" patterns
     let trimmed = msg.trim();
-    
+
     // Strip leading "path:line:col: " prefix (common in compiler output)
     let after_prefix = if let Some(loc_end) = find_location_prefix_end(trimmed) {
         trimmed[loc_end..].trim_start_matches([' ', ':'])
@@ -155,29 +155,43 @@ fn find_location_prefix_end(s: &str) -> Option<usize> {
     let bytes = s.as_bytes();
     let mut i = 0;
     let mut saw_dot = false;
-    
+
     // Scan the path part
     while i < bytes.len() && bytes[i] != b':' {
-        if bytes[i] == b'.' || bytes[i] == b'/' { saw_dot = true; }
-        if bytes[i] == b' ' { return None; } // paths don't have spaces
+        if bytes[i] == b'.' || bytes[i] == b'/' {
+            saw_dot = true;
+        }
+        if bytes[i] == b' ' {
+            return None;
+        } // paths don't have spaces
         i += 1;
     }
-    if !saw_dot || i == 0 || i >= bytes.len() { return None; }
-    
+    if !saw_dot || i == 0 || i >= bytes.len() {
+        return None;
+    }
+
     // Must have :digits
     i += 1; // skip :
     let num_start = i;
-    while i < bytes.len() && bytes[i].is_ascii_digit() { i += 1; }
-    if i == num_start { return None; }
-    
+    while i < bytes.len() && bytes[i].is_ascii_digit() {
+        i += 1;
+    }
+    if i == num_start {
+        return None;
+    }
+
     // Optional :digits (column)
     if i < bytes.len() && bytes[i] == b':' {
         let col_start = i + 1;
         let mut j = col_start;
-        while j < bytes.len() && bytes[j].is_ascii_digit() { j += 1; }
-        if j > col_start { i = j; }
+        while j < bytes.len() && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j > col_start {
+            i = j;
+        }
     }
-    
+
     // Must be followed by : or space
     if i < bytes.len() && (bytes[i] == b':' || bytes[i] == b' ') {
         Some(i)
@@ -265,7 +279,10 @@ mod tests {
     fn duplicate_errors_group_by_message() {
         let mut lines = Vec::new();
         for i in 0..30 {
-            lines.push(format!("error: unused variable `x` at src/lib.rs:{}", i + 1));
+            lines.push(format!(
+                "error: unused variable `x` at src/lib.rs:{}",
+                i + 1
+            ));
         }
         let input = lines.join("\n");
         let out = PARSER.parse(&input);

--- a/src/run/parsers/generic.rs
+++ b/src/run/parsers/generic.rs
@@ -1,6 +1,6 @@
 use memchr::memmem;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{Counts, DetectResult, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 
@@ -45,11 +45,11 @@ impl Parser for GenericParser {
     }
 
     /// The generic parser is the implicit fallback; it never claims a match.
-    fn detect(&self, _sample: &str) -> bool {
-        false
+    fn detect(&self, _sample: &str) -> DetectResult {
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, _hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let lines: Vec<&str> = input.lines().collect();
         let raw_lines = lines.len();
@@ -78,7 +78,7 @@ impl Parser for GenericParser {
             // ASCII-lowercase into reusable buffer (all keywords are ASCII).
             let line_bytes = line.as_bytes();
             lower_buf.clear();
-            lower_buf.extend(line_bytes.iter().map(|b| b.to_ascii_lowercase()));
+            lower_buf.extend(line_bytes.iter().map(u8::to_ascii_lowercase));
 
             if finders.matches(&lower_buf) {
                 error_count += 1;
@@ -207,7 +207,7 @@ mod tests {
     #[test]
     fn short_input_passthrough() {
         let input = "line 1\nline 2\nline 3";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.raw_lines, 3);
         assert!(out.diagnostics.is_empty());
     }
@@ -223,7 +223,7 @@ mod tests {
             }
         }
         let input = lines.join("\n");
-        let out = PARSER.parse(&input);
+        let out = PARSER.parse(&input, DetectResult::Text);
         assert!(!out.diagnostics.is_empty());
         assert_eq!(out.counts.errors, out.diagnostics.len() as u32);
     }
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn detect_always_false() {
-        assert!(!PARSER.detect("anything"));
+        assert!(!PARSER.detect("anything").matched());
     }
 
     #[test]
@@ -285,7 +285,7 @@ mod tests {
             ));
         }
         let input = lines.join("\n");
-        let out = PARSER.parse(&input);
+        let out = PARSER.parse(&input, DetectResult::Text);
         // All 30 should have the same name (normalized message)
         let first_name = &out.diagnostics[0].name;
         assert!(out.diagnostics.iter().all(|d| &d.name == first_name));

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -1,0 +1,527 @@
+use std::collections::HashMap;
+
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, truncate_detail};
+
+use super::Parser;
+
+pub static PARSER: GoTestParser = GoTestParser;
+
+pub struct GoTestParser;
+
+impl Parser for GoTestParser {
+    fn name(&self) -> &'static str {
+        "go-test"
+    }
+
+    /// Detect `go test` output via byte scanning — no regex.
+    ///
+    /// Accepts JSON format (`"Action":"` + `"Package":"`) or text format
+    /// (`--- FAIL:` or `--- PASS:`).
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: both "Action":" and "Package":" must appear.
+        let action = memmem::Finder::new(r#""Action":""#);
+        let package = memmem::Finder::new(r#""Package":""#);
+        if action.find(bytes).is_some() && package.find(bytes).is_some() {
+            return true;
+        }
+
+        // Text fingerprint: at least one of the canonical test result markers.
+        let fail_marker = memmem::Finder::new("--- FAIL:");
+        let pass_marker = memmem::Finder::new("--- PASS:");
+        fail_marker.find(bytes).is_some() || pass_marker.find(bytes).is_some()
+    }
+
+    /// Insert `-json` after `go test` when it is absent, enabling structured output.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// // go test ./...  →  go test -json ./...
+    /// // go test -json ./...  →  None (already present)
+    /// ```
+    fn rewrite(&self, command: &str) -> Option<String> {
+        // Already has -json — nothing to do.
+        if command.contains("-json") {
+            return None;
+        }
+        // Find "go test" and insert "-json " immediately after.
+        let needle = "go test";
+        let pos = command.find(needle)?;
+        let after = pos + needle.len();
+        Some(format!("{}{}{}", &command[..after], " -json", &command[after..]))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        // Try JSON (NDJSON) first — any line starting with `{` signals JSON mode.
+        if input.lines().any(|l| l.trim_start().starts_with('{')) {
+            if let Some(parsed) = self.try_json(input) {
+                return parsed;
+            }
+        }
+        self.parse_text(input)
+    }
+}
+
+impl GoTestParser {
+    /// Parse `go test -json` NDJSON output.
+    ///
+    /// Each line is an independent JSON object (event). We drive a per-test
+    /// state machine keyed by `(Package, Test)` to accumulate output lines,
+    /// then produce a `Diagnostic` on failure.
+    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut passed: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut skipped: u32 = 0;
+        let mut duration_secs: f64 = 0.0;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // Accumulated output lines per (package, test_name).
+        let mut output_buf: HashMap<(String, String), Vec<String>> = HashMap::new();
+
+        let events: Vec<Value> = input
+            .lines()
+            .filter(|l| l.trim_start().starts_with('{'))
+            .filter_map(|l| serde_json::from_str(l).ok())
+            .collect();
+
+        if events.is_empty() {
+            return None;
+        }
+
+        for event in &events {
+            let action = event.get("Action").and_then(|v| v.as_str()).unwrap_or("");
+            let pkg = event
+                .get("Package")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+            let test_name = event.get("Test").and_then(|v| v.as_str());
+
+            match action {
+                "run" => {
+                    if let Some(name) = test_name {
+                        output_buf.entry((pkg, name.to_string())).or_default();
+                    }
+                }
+                "output" => {
+                    if let Some(name) = test_name {
+                        let text = event
+                            .get("Output")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string();
+                        output_buf
+                            .entry((pkg, name.to_string()))
+                            .or_default()
+                            .push(text);
+                    }
+                }
+                "pass" => {
+                    if let Some(elapsed) = event.get("Elapsed").and_then(|v| v.as_f64()) {
+                        if test_name.is_some() {
+                            duration_secs += elapsed;
+                        }
+                    }
+                    if let Some(name) = test_name {
+                        passed += 1;
+                        output_buf.remove(&(pkg, name.to_string()));
+                    }
+                }
+                "fail" => {
+                    if let Some(elapsed) = event.get("Elapsed").and_then(|v| v.as_f64()) {
+                        if test_name.is_some() {
+                            duration_secs += elapsed;
+                        }
+                    }
+                    if let Some(name) = test_name {
+                        failed += 1;
+                        let key = (pkg.clone(), name.to_string());
+                        let lines = output_buf.remove(&key).unwrap_or_default();
+                        let combined = lines.join("");
+                        let message = extract_failure_message(&combined);
+                        let location = Location::scan_text(&combined);
+                        let detail = truncate_detail(&combined);
+                        let diag_name = if pkg.is_empty() {
+                            name.to_string()
+                        } else {
+                            format!("{}::{}", pkg, name)
+                        };
+                        diagnostics.push(Diagnostic {
+                            severity: Severity::Error,
+                            location,
+                            name: diag_name,
+                            message,
+                            detail,
+                        });
+                    }
+                }
+                "skip" => {
+                    if let Some(name) = test_name {
+                        skipped += 1;
+                        output_buf.remove(&(pkg, name.to_string()));
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        let duration = if duration_secs > 0.0 {
+            Some(duration_secs)
+        } else {
+            None
+        };
+        let summary = build_summary(passed, failed, skipped);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped,
+            ..Counts::default()
+        };
+
+        Some(ParsedOutput {
+            tool: "go-test",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs: duration,
+            raw_lines,
+            raw_bytes,
+        })
+    }
+
+    /// Parse plain `go test` text output (without `-json`).
+    fn parse_text(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut passed: u32 = 0;
+        let mut skipped: u32 = 0;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // Current failure block being accumulated.
+        let mut failure_name: Option<String> = None;
+        let mut failure_lines: Vec<String> = Vec::new();
+
+        for line in input.lines() {
+            // --- FAIL: TestName (0.00s)
+            if let Some(rest) = line.strip_prefix("--- FAIL: ") {
+                // Flush any previous block first.
+                if let Some(name) = failure_name.take() {
+                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
+                    failure_lines.clear();
+                }
+                // Parse "TestName (0.00s)" — take everything before the first space.
+                let name = rest.split_whitespace().next().unwrap_or(rest).to_string();
+                failure_name = Some(name);
+                continue;
+            }
+
+            // --- PASS: TestName (0.00s)
+            if line.starts_with("--- PASS: ") {
+                if let Some(name) = failure_name.take() {
+                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
+                    failure_lines.clear();
+                }
+                passed += 1;
+                continue;
+            }
+
+            // --- SKIP: TestName (0.00s)
+            if line.starts_with("--- SKIP: ") {
+                if let Some(name) = failure_name.take() {
+                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
+                    failure_lines.clear();
+                }
+                skipped += 1;
+                continue;
+            }
+
+            // FAIL\tpackage\t0.00s — package-level failure; already counted via --- FAIL lines.
+            // ok  \tpackage\t0.00s — package passed; count sub-tests already tallied above.
+            if line.starts_with("ok  \t") || line.starts_with("FAIL\t") {
+                if let Some(name) = failure_name.take() {
+                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
+                    failure_lines.clear();
+                }
+                // The package-level "ok" lines don't add to passed individually since
+                // individual --- PASS lines already do; just ensure we close any open block.
+                continue;
+            }
+
+            // Indented detail line belonging to the current failure block.
+            if failure_name.is_some() {
+                failure_lines.push(line.to_string());
+            }
+        }
+
+        // Flush any trailing failure block.
+        if let Some(name) = failure_name.take() {
+            diagnostics.push(build_text_diagnostic(name, &failure_lines));
+        }
+
+        // Failure count comes directly from the collected diagnostics.
+        let failed = diagnostics.len() as u32;
+
+        let summary = build_summary(passed, failed, skipped);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped,
+            ..Counts::default()
+        };
+
+        ParsedOutput {
+            tool: "go-test",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_text_diagnostic(name: String, lines: &[String]) -> Diagnostic {
+    let combined = lines.join("\n");
+    let message = extract_failure_message(&combined);
+    let location = Location::scan_text(&combined);
+    let detail = truncate_detail(&combined);
+    Diagnostic {
+        severity: Severity::Error,
+        location,
+        name,
+        message,
+        detail,
+    }
+}
+
+/// Build a human-readable summary, omitting zero categories except `passed`.
+fn build_summary(passed: u32, failed: u32, skipped: u32) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("{passed} passed"));
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if skipped > 0 {
+        parts.push(format!("{skipped} skipped"));
+    }
+    parts.join(", ")
+}
+
+/// Extract the most useful failure message from accumulated output text.
+///
+/// Priority:
+/// 1. Lines containing `Error:` or `error:` (testify-style)
+/// 2. Lines matching `    file_test.go:N: message` (standard t.Error/t.Fatal format)
+/// 3. First non-empty line
+fn extract_failure_message(output: &str) -> String {
+    // Testify / assertion errors: "Error: Not equal:" etc.
+    for line in output.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("Error:") || trimmed.starts_with("error:") {
+            return trimmed.to_string();
+        }
+    }
+
+    // Standard t.Errorf / t.Fatalf lines: "    file_test.go:42: the message"
+    for line in output.lines() {
+        let trimmed = line.trim();
+        // Pattern: something like `foo_test.go:42: message`
+        if let Some(msg) = extract_test_log_message(trimmed) {
+            return msg;
+        }
+    }
+
+    // Fallback: first non-empty line.
+    output
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty())
+        .unwrap_or("test failed")
+        .to_string()
+}
+
+/// Parse a `file_test.go:42: message` line and return just the message part.
+fn extract_test_log_message(line: &str) -> Option<String> {
+    // Find `filename:digits:` pattern and return the text after it.
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let mut i = 0;
+
+    while i < len {
+        if bytes[i] != b':' {
+            i += 1;
+            continue;
+        }
+        // Check for digits immediately after colon.
+        let num_start = i + 1;
+        let mut num_end = num_start;
+        while num_end < len && bytes[num_end].is_ascii_digit() {
+            num_end += 1;
+        }
+        if num_end == num_start {
+            i += 1;
+            continue;
+        }
+        // The digits must be followed by `:` for the message separator.
+        if num_end >= len || bytes[num_end] != b':' {
+            i += 1;
+            continue;
+        }
+        // Verify the token before the colon looks like a filename.
+        let path_end = i;
+        let path_start = bytes[..path_end]
+            .iter()
+            .rposition(|&b| b == b' ' || b == b'\t')
+            .map(|p| p + 1)
+            .unwrap_or(0);
+        let path_bytes = &bytes[path_start..path_end];
+        let looks_like_file = path_bytes.contains(&b'.');
+        if !looks_like_file {
+            i += 1;
+            continue;
+        }
+        // Everything after "filename:digits:" is the message.
+        let msg_start = num_end + 1;
+        if msg_start < len {
+            return Some(line[msg_start..].trim().to_string());
+        }
+        i += 1;
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_json_fingerprint() {
+        let sample = r#"{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestFoo"}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text_fingerprint() {
+        let sample = "=== RUN   TestFoo\n--- FAIL: TestFoo (0.00s)\n    foo_test.go:10: expected 1 got 2\nFAIL\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building foo...\nDone.\nAll steps completed.\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // -- Rewrite -------------------------------------------------------------
+
+    #[test]
+    fn rewrite_inserts_json() {
+        let result = PARSER.rewrite("go test ./...").unwrap();
+        assert_eq!(result, "go test -json ./...");
+    }
+
+    #[test]
+    fn rewrite_skips_if_present() {
+        assert!(PARSER.rewrite("go test -json ./...").is_none());
+        assert!(PARSER.rewrite("go test -count=1 -json ./...").is_none());
+    }
+
+    // -- JSON parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_json_all_pass() {
+        let input = concat!(
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestA\"}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"output\",\"Package\":\"ex/pkg\",\"Test\":\"TestA\",\"Output\":\"    foo_test.go:5: ok\\n\"}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestA\",\"Elapsed\":0.01}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestB\"}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestB\",\"Elapsed\":0.02}\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.tool, "go-test");
+        assert_eq!(out.counts.passed, 2);
+        assert_eq!(out.counts.failed, 0);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.diagnostics.is_empty());
+        assert!(out.summary.contains("2 passed"));
+        assert!(!out.summary.contains("failed"));
+    }
+
+    #[test]
+    fn parse_json_with_failure() {
+        let input = concat!(
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestBad\"}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"output\",\"Package\":\"ex/pkg\",\"Test\":\"TestBad\",\"Output\":\"    foo_test.go:42: got 1 want 2\\n\"}\n",
+            "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"fail\",\"Package\":\"ex/pkg\",\"Test\":\"TestBad\",\"Elapsed\":0.05}\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.failed, 1);
+        assert_eq!(out.counts.passed, 0);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert!(diag.name.contains("TestBad"));
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(!diag.message.is_empty());
+        let loc = diag.location.as_ref().expect("location should be present");
+        assert_eq!(loc.file, "foo_test.go");
+        assert_eq!(loc.line, 42);
+    }
+
+    // -- Text parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_text_failure() {
+        let input = concat!(
+            "=== RUN   TestAdd\n",
+            "--- FAIL: TestAdd (0.00s)\n",
+            "    math_test.go:15: expected 4, got 3\n",
+            "FAIL\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "TestAdd");
+        assert_eq!(diag.severity, Severity::Error);
+        let loc = diag.location.as_ref().expect("location should be present");
+        assert_eq!(loc.file, "math_test.go");
+        assert_eq!(loc.line, 15);
+    }
+
+    #[test]
+    fn parse_text_pass_summary() {
+        let input = concat!(
+            "=== RUN   TestOne\n",
+            "--- PASS: TestOne (0.01s)\n",
+            "=== RUN   TestTwo\n",
+            "--- PASS: TestTwo (0.00s)\n",
+            "ok  \texample.com/mypkg\t0.015s\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.passed, 2);
+        assert_eq!(out.counts.failed, 0);
+        assert!(out.diagnostics.is_empty());
+        assert!(out.summary.contains("2 passed"));
+    }
+}

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, truncate_detail};
+use crate::run::types::{truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -36,26 +36,6 @@ impl Parser for GoTestParser {
         fail_marker.find(bytes).is_some() || pass_marker.find(bytes).is_some()
     }
 
-    /// Insert `-json` after `go test` when it is absent, enabling structured output.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// // go test ./...  →  go test -json ./...
-    /// // go test -json ./...  →  None (already present)
-    /// ```
-    fn rewrite(&self, command: &str) -> Option<String> {
-        // Already has -json — nothing to do.
-        if command.contains("-json") {
-            return None;
-        }
-        // Find "go test" and insert "-json " immediately after.
-        let needle = "go test";
-        let pos = command.find(needle)?;
-        let after = pos + needle.len();
-        Some(format!("{}{}{}", &command[..after], " -json", &command[after..]))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         // Try JSON (NDJSON) first — any line starting with `{` signals JSON mode.
         if input.lines().any(|l| l.trim_start().starts_with('{')) {
@@ -432,20 +412,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "Building foo...\nDone.\nAll steps completed.\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // -- Rewrite -------------------------------------------------------------
-
-    #[test]
-    fn rewrite_inserts_json() {
-        let result = PARSER.rewrite("go test ./...").unwrap();
-        assert_eq!(result, "go test -json ./...");
-    }
-
-    #[test]
-    fn rewrite_skips_if_present() {
-        assert!(PARSER.rewrite("go test -json ./...").is_none());
-        assert!(PARSER.rewrite("go test -count=1 -json ./...").is_none());
     }
 
     // -- JSON parse ----------------------------------------------------------

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -4,7 +4,8 @@ use memchr::memmem;
 use serde_json::Value;
 
 use crate::run::types::{
-    build_test_summary, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    build_test_summary, truncate_detail, Counts, DetectResult, Diagnostic, Location, ParsedOutput,
+    Severity,
 };
 
 use super::Parser;
@@ -22,30 +23,33 @@ impl Parser for GoTestParser {
     ///
     /// Accepts JSON format (`"Action":"` + `"Package":"`) or text format
     /// (`--- FAIL:` or `--- PASS:`).
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint: both "Action":" and "Package":" must appear.
         let action = memmem::Finder::new(r#""Action":""#);
         let package = memmem::Finder::new(r#""Package":""#);
         if action.find(bytes).is_some() && package.find(bytes).is_some() {
-            return true;
+            return DetectResult::NdJson;
         }
 
         // Text fingerprint: at least one of the canonical test result markers.
         let fail_marker = memmem::Finder::new("--- FAIL:");
         let pass_marker = memmem::Finder::new("--- PASS:");
-        fail_marker.find(bytes).is_some() || pass_marker.find(bytes).is_some()
+        if fail_marker.find(bytes).is_some() || pass_marker.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
-        // Try JSON (NDJSON) first — any line starting with `{` signals JSON mode.
-        if input.lines().any(|l| l.trim_start().starts_with('{')) {
-            if let Some(parsed) = self.try_json(input) {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
+        if hint.is_json() {
+            if let Some(parsed) = GoTestParser::try_json(input) {
                 return parsed;
             }
         }
-        self.parse_text(input)
+        GoTestParser::parse_text(input)
     }
 }
 
@@ -55,7 +59,7 @@ impl GoTestParser {
     /// Each line is an independent JSON object (event). We drive a per-test
     /// state machine keyed by `(Package, Test)` to accumulate output lines,
     /// then produce a `Diagnostic` on failure.
-    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+    fn try_json(input: &str) -> Option<ParsedOutput> {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -107,7 +111,8 @@ impl GoTestParser {
                     }
                 }
                 "pass" => {
-                    if let Some(elapsed) = event.get("Elapsed").and_then(|v| v.as_f64()) {
+                    if let Some(elapsed) = event.get("Elapsed").and_then(serde_json::Value::as_f64)
+                    {
                         if test_name.is_some() {
                             duration_secs += elapsed;
                         }
@@ -118,7 +123,8 @@ impl GoTestParser {
                     }
                 }
                 "fail" => {
-                    if let Some(elapsed) = event.get("Elapsed").and_then(|v| v.as_f64()) {
+                    if let Some(elapsed) = event.get("Elapsed").and_then(serde_json::Value::as_f64)
+                    {
                         if test_name.is_some() {
                             duration_secs += elapsed;
                         }
@@ -134,7 +140,7 @@ impl GoTestParser {
                         let diag_name = if pkg.is_empty() {
                             name.to_string()
                         } else {
-                            format!("{}::{}", pkg, name)
+                            format!("{pkg}::{name}")
                         };
                         diagnostics.push(Diagnostic {
                             severity: Severity::Error,
@@ -180,7 +186,18 @@ impl GoTestParser {
     }
 
     /// Parse plain `go test` text output (without `-json`).
-    fn parse_text(&self, input: &str) -> ParsedOutput {
+    ///
+    /// Go test output structure:
+    /// ```text
+    /// === RUN   TestFoo
+    ///     foo_test.go:15: expected 4, got 3   -- detail comes BEFORE the result line
+    /// --- FAIL: TestFoo (0.00s)
+    /// ```
+    ///
+    /// Lines are accumulated per-test (keyed by `=== RUN` name). On `--- FAIL:` we
+    /// flush the accumulated lines as a diagnostic. On `--- PASS:` / `--- SKIP:`
+    /// we discard them.
+    fn parse_text(input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -188,65 +205,56 @@ impl GoTestParser {
         let mut skipped: u32 = 0;
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
 
-        // Current failure block being accumulated.
-        let mut failure_name: Option<String> = None;
-        let mut failure_lines: Vec<String> = Vec::new();
+        // Lines accumulated since the last `=== RUN`, keyed by test name.
+        let mut current_name: Option<String> = None;
+        let mut current_lines: Vec<String> = Vec::new();
 
         for line in input.lines() {
-            // --- FAIL: TestName (0.00s)
-            if let Some(rest) = line.strip_prefix("--- FAIL: ") {
-                // Flush any previous block first.
-                if let Some(name) = failure_name.take() {
-                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
-                    failure_lines.clear();
-                }
-                // Parse "TestName (0.00s)" — take everything before the first space.
-                let name = rest.split_whitespace().next().unwrap_or(rest).to_string();
-                failure_name = Some(name);
+            // === RUN   TestName — start accumulating for a new test.
+            if let Some(rest) = line.strip_prefix("=== RUN") {
+                let name = rest.trim().to_string();
+                current_name = if name.is_empty() { None } else { Some(name) };
+                current_lines.clear();
                 continue;
             }
 
-            // --- PASS: TestName (0.00s)
+            // --- FAIL: TestName (0.00s) — emit diagnostic from accumulated lines.
+            if let Some(rest) = line.strip_prefix("--- FAIL: ") {
+                let name = rest.split_whitespace().next().unwrap_or(rest).to_string();
+                // Use lines accumulated since `=== RUN` (the detail comes BEFORE this line).
+                let lines = std::mem::take(&mut current_lines);
+                diagnostics.push(build_text_diagnostic(name, &lines));
+                current_name = None;
+                continue;
+            }
+
+            // --- PASS: TestName (0.00s) — discard accumulated lines, count pass.
             if line.starts_with("--- PASS: ") {
-                if let Some(name) = failure_name.take() {
-                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
-                    failure_lines.clear();
-                }
+                current_lines.clear();
+                current_name = None;
                 passed += 1;
                 continue;
             }
 
-            // --- SKIP: TestName (0.00s)
+            // --- SKIP: TestName (0.00s) — discard accumulated lines, count skip.
             if line.starts_with("--- SKIP: ") {
-                if let Some(name) = failure_name.take() {
-                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
-                    failure_lines.clear();
-                }
+                current_lines.clear();
+                current_name = None;
                 skipped += 1;
                 continue;
             }
 
-            // FAIL\tpackage\t0.00s — package-level failure; already counted via --- FAIL lines.
-            // ok  \tpackage\t0.00s — package passed; count sub-tests already tallied above.
+            // FAIL\tpackage or ok\tpackage — package-level summary lines; close any open block.
             if line.starts_with("ok  \t") || line.starts_with("FAIL\t") {
-                if let Some(name) = failure_name.take() {
-                    diagnostics.push(build_text_diagnostic(name, &failure_lines));
-                    failure_lines.clear();
-                }
-                // The package-level "ok" lines don't add to passed individually since
-                // individual --- PASS lines already do; just ensure we close any open block.
+                current_lines.clear();
+                current_name = None;
                 continue;
             }
 
-            // Indented detail line belonging to the current failure block.
-            if failure_name.is_some() {
-                failure_lines.push(line.to_string());
+            // Any other line while a test is running: accumulate as detail.
+            if current_name.is_some() {
+                current_lines.push(line.to_string());
             }
-        }
-
-        // Flush any trailing failure block.
-        if let Some(name) = failure_name.take() {
-            diagnostics.push(build_text_diagnostic(name, &failure_lines));
         }
 
         // Failure count comes directly from the collected diagnostics.
@@ -317,7 +325,7 @@ fn extract_failure_message(output: &str) -> String {
     // Fallback: first non-empty line.
     output
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .find(|l| !l.is_empty())
         .unwrap_or("test failed")
         .to_string()
@@ -355,8 +363,7 @@ fn extract_test_log_message(line: &str) -> Option<String> {
         let path_start = bytes[..path_end]
             .iter()
             .rposition(|&b| b == b' ' || b == b'\t')
-            .map(|p| p + 1)
-            .unwrap_or(0);
+            .map_or(0, |p| p + 1);
         let path_bytes = &bytes[path_start..path_end];
         let looks_like_file = path_bytes.contains(&b'.');
         if !looks_like_file {
@@ -386,19 +393,19 @@ mod tests {
     #[test]
     fn detect_json_fingerprint() {
         let sample = r#"{"Time":"2024-01-01T00:00:00Z","Action":"run","Package":"example.com/pkg","Test":"TestFoo"}"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text_fingerprint() {
-        let sample = "=== RUN   TestFoo\n--- FAIL: TestFoo (0.00s)\n    foo_test.go:10: expected 1 got 2\nFAIL\n";
-        assert!(PARSER.detect(sample));
+        let sample = "=== RUN   TestFoo\n    foo_test.go:10: expected 1 got 2\n--- FAIL: TestFoo (0.00s)\nFAIL\n";
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "Building foo...\nDone.\nAll steps completed.\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // -- JSON parse ----------------------------------------------------------
@@ -412,7 +419,7 @@ mod tests {
             "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestB\"}\n",
             "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestB\",\"Elapsed\":0.02}\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.tool, "go-test");
         assert_eq!(out.counts.passed, 2);
         assert_eq!(out.counts.failed, 0);
@@ -429,7 +436,7 @@ mod tests {
             "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"output\",\"Package\":\"ex/pkg\",\"Test\":\"TestBad\",\"Output\":\"    foo_test.go:42: got 1 want 2\\n\"}\n",
             "{\"Time\":\"2024-01-01T00:00:00Z\",\"Action\":\"fail\",\"Package\":\"ex/pkg\",\"Test\":\"TestBad\",\"Elapsed\":0.05}\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.counts.failed, 1);
         assert_eq!(out.counts.passed, 0);
         assert_eq!(out.diagnostics.len(), 1);
@@ -444,22 +451,29 @@ mod tests {
 
     // -- Text parse ----------------------------------------------------------
 
+    // Bug 2 regression: detail lines come BEFORE `--- FAIL:` in real Go output.
+    // The old parser accumulated lines AFTER `--- FAIL:`, so it always got empty detail.
     #[test]
-    fn parse_text_failure() {
+    fn parse_text_failure_detail_before_fail_line() {
         let input = concat!(
             "=== RUN   TestAdd\n",
-            "--- FAIL: TestAdd (0.00s)\n",
             "    math_test.go:15: expected 4, got 3\n",
+            "--- FAIL: TestAdd (0.00s)\n",
             "FAIL\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.name, "TestAdd");
         assert_eq!(diag.severity, Severity::Error);
+        // Location must be extracted from the detail line (before --- FAIL).
         let loc = diag.location.as_ref().expect("location should be present");
         assert_eq!(loc.file, "math_test.go");
         assert_eq!(loc.line, 15);
+        assert!(
+            diag.message.contains("expected 4, got 3"),
+            "message should come from the detail line"
+        );
     }
 
     #[test]
@@ -471,7 +485,7 @@ mod tests {
             "--- PASS: TestTwo (0.00s)\n",
             "ok  \texample.com/mypkg\t0.015s\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.passed, 2);
         assert_eq!(out.counts.failed, 0);
         assert!(out.diagnostics.is_empty());

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -113,8 +113,13 @@ impl GoTestParser {
                 "pass" => {
                     if let Some(elapsed) = event.get("Elapsed").and_then(serde_json::Value::as_f64)
                     {
-                        if test_name.is_some() {
-                            duration_secs += elapsed;
+                        // Only count top-level tests (no '/' in name). Subtests have the form
+                        // "TestFoo/subtest" — their time is already included in the parent's
+                        // elapsed, so adding both would double-count.
+                        if let Some(name) = test_name {
+                            if !name.contains('/') {
+                                duration_secs += elapsed;
+                            }
                         }
                     }
                     if let Some(name) = test_name {
@@ -125,8 +130,11 @@ impl GoTestParser {
                 "fail" => {
                     if let Some(elapsed) = event.get("Elapsed").and_then(serde_json::Value::as_f64)
                     {
-                        if test_name.is_some() {
-                            duration_secs += elapsed;
+                        // Same rule: only top-level test durations to avoid double-counting.
+                        if let Some(name) = test_name {
+                            if !name.contains('/') {
+                                duration_secs += elapsed;
+                            }
                         }
                     }
                     if let Some(name) = test_name {
@@ -209,6 +217,11 @@ impl GoTestParser {
         let mut current_name: Option<String> = None;
         let mut current_lines: Vec<String> = Vec::new();
 
+        // Duration: prefer the package-level `ok`/`FAIL` line time.
+        // Accumulate top-level (non-subtest) durations as fallback.
+        let mut pkg_duration: Option<f64> = None;
+        let mut toplevel_duration: f64 = 0.0;
+
         for line in input.lines() {
             // === RUN   TestName — start accumulating for a new test.
             if let Some(rest) = line.strip_prefix("=== RUN") {
@@ -221,6 +234,12 @@ impl GoTestParser {
             // --- FAIL: TestName (0.00s) — emit diagnostic from accumulated lines.
             if let Some(rest) = line.strip_prefix("--- FAIL: ") {
                 let name = rest.split_whitespace().next().unwrap_or(rest).to_string();
+                // Only count top-level tests for fallback duration (no '/' means not a subtest).
+                if !name.contains('/') {
+                    if let Some(secs) = parse_test_duration(rest) {
+                        toplevel_duration += secs;
+                    }
+                }
                 // Use lines accumulated since `=== RUN` (the detail comes BEFORE this line).
                 let lines = std::mem::take(&mut current_lines);
                 diagnostics.push(build_text_diagnostic(name, &lines));
@@ -229,7 +248,14 @@ impl GoTestParser {
             }
 
             // --- PASS: TestName (0.00s) — discard accumulated lines, count pass.
-            if line.starts_with("--- PASS: ") {
+            if let Some(rest) = line.strip_prefix("--- PASS: ") {
+                let name = rest.split_whitespace().next().unwrap_or(rest).to_string();
+                // Only count top-level tests for fallback duration.
+                if !name.contains('/') {
+                    if let Some(secs) = parse_test_duration(rest) {
+                        toplevel_duration += secs;
+                    }
+                }
                 current_lines.clear();
                 current_name = None;
                 passed += 1;
@@ -244,8 +270,12 @@ impl GoTestParser {
                 continue;
             }
 
-            // FAIL\tpackage or ok\tpackage — package-level summary lines; close any open block.
+            // ok  \tpackage\t0.65s  or  FAIL\tpackage\t0.65s — package-level summary.
+            // This is the authoritative total duration; prefer it over per-test accumulation.
             if line.starts_with("ok  \t") || line.starts_with("FAIL\t") {
+                if let Some(secs) = parse_package_duration(line) {
+                    pkg_duration = Some(secs);
+                }
                 current_lines.clear();
                 current_name = None;
                 continue;
@@ -260,6 +290,13 @@ impl GoTestParser {
         // Failure count comes directly from the collected diagnostics.
         let failed = diagnostics.len() as u32;
 
+        // Prefer the package-level duration; fall back to sum of top-level tests.
+        let duration_secs = pkg_duration.or(if toplevel_duration > 0.0 {
+            Some(toplevel_duration)
+        } else {
+            None
+        });
+
         let summary = build_test_summary(passed, failed, skipped);
         let counts = Counts {
             passed,
@@ -273,7 +310,7 @@ impl GoTestParser {
             summary,
             diagnostics,
             counts,
-            duration_secs: None,
+            duration_secs,
             raw_lines,
             raw_bytes,
         }
@@ -283,6 +320,30 @@ impl GoTestParser {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+/// Parse the duration from a `--- PASS:` / `--- FAIL:` rest string like `TestFoo (0.50s)`.
+///
+/// Returns seconds as `f64`, or `None` if no valid duration is found.
+fn parse_test_duration(rest: &str) -> Option<f64> {
+    // rest looks like: `TestFoo (0.50s)` or `TestFoo/sub (0.20s)`
+    let open = rest.rfind('(')?;
+    let close = rest[open..].find(')')? + open;
+    let inner = rest[open + 1..close].trim();
+    // Strip trailing 's'
+    let num_str = inner.strip_suffix('s')?;
+    num_str.parse::<f64>().ok()
+}
+
+/// Parse the duration from a package-level `ok` or `FAIL` line.
+///
+/// `ok  \tmypackage\t0.65s` → `Some(0.65)`
+/// `FAIL\tmypackage\t0.65s` → `Some(0.65)`
+fn parse_package_duration(line: &str) -> Option<f64> {
+    // The duration is the last whitespace-separated token ending in 's'.
+    let last = line.split_whitespace().last()?;
+    let num_str = last.strip_suffix('s')?;
+    num_str.parse::<f64>().ok()
+}
 
 fn build_text_diagnostic(name: String, lines: &[String]) -> Diagnostic {
     let combined = lines.join("\n");
@@ -490,5 +551,71 @@ mod tests {
         assert_eq!(out.counts.failed, 0);
         assert!(out.diagnostics.is_empty());
         assert!(out.summary.contains("2 passed"));
+    }
+
+    // -- Bug #8: duration double-counting -----------------------------------------
+
+    /// Package-level `ok` line must be used as the authoritative duration.
+    /// Subtest durations must NOT be summed in (that would double-count).
+    #[test]
+    fn parse_text_duration_uses_ok_line() {
+        // TestFoo (0.50s) includes subtest time; ok line gives 0.65s (total).
+        // Without the fix, summing all --- PASS lines gives 0.50+0.20+0.30+0.10 = 1.10s.
+        let input = concat!(
+            "=== RUN   TestFoo\n",
+            "=== RUN   TestFoo/subtest1\n",
+            "--- PASS: TestFoo/subtest1 (0.20s)\n",
+            "=== RUN   TestFoo/subtest2\n",
+            "--- PASS: TestFoo/subtest2 (0.30s)\n",
+            "--- PASS: TestFoo (0.50s)\n",
+            "=== RUN   TestBar\n",
+            "--- PASS: TestBar (0.10s)\n",
+            "ok  \tmypackage\t0.65s\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // Should use the ok line's 0.65s, not the double-counted sum.
+        assert_eq!(out.duration_secs, Some(0.65));
+    }
+
+    /// When no `ok`/`FAIL` package line is present, only top-level (non-subtest)
+    /// durations should be summed — subtests must be excluded.
+    #[test]
+    fn parse_text_duration_toplevel_only_fallback() {
+        let input = concat!(
+            "=== RUN   TestFoo\n",
+            "=== RUN   TestFoo/sub\n",
+            "--- PASS: TestFoo/sub (0.30s)\n",
+            "--- PASS: TestFoo (0.50s)\n",
+            "=== RUN   TestBar\n",
+            "--- PASS: TestBar (0.10s)\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // 0.50 + 0.10 = 0.60 (TestFoo/sub must not be included).
+        let dur = out.duration_secs.expect("duration should be present");
+        assert!((dur - 0.60).abs() < 1e-9, "expected 0.60, got {dur}");
+    }
+
+    /// JSON parse: subtest elapsed times must not be added to the total.
+    #[test]
+    fn parse_json_duration_no_subtest_double_count() {
+        let input = concat!(
+            // Top-level test: elapsed 0.50s
+            "{\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo\"}\n",
+            // Subtest 1: elapsed 0.20s (already included in TestFoo's 0.50s)
+            "{\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo/sub1\"}\n",
+            "{\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo/sub1\",\"Elapsed\":0.20}\n",
+            // Subtest 2: elapsed 0.30s
+            "{\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo/sub2\"}\n",
+            "{\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo/sub2\",\"Elapsed\":0.30}\n",
+            // Parent test
+            "{\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestFoo\",\"Elapsed\":0.50}\n",
+            // Another top-level test: elapsed 0.10s
+            "{\"Action\":\"run\",\"Package\":\"ex/pkg\",\"Test\":\"TestBar\"}\n",
+            "{\"Action\":\"pass\",\"Package\":\"ex/pkg\",\"Test\":\"TestBar\",\"Elapsed\":0.10}\n",
+        );
+        let out = PARSER.parse(input, DetectResult::NdJson);
+        // Should be 0.50 + 0.10 = 0.60, not 0.50 + 0.20 + 0.30 + 0.10 = 1.10.
+        let dur = out.duration_secs.expect("duration should be present");
+        assert!((dur - 0.60).abs() < 1e-9, "expected 0.60, got {dur}");
     }
 }

--- a/src/run/parsers/go_test.rs
+++ b/src/run/parsers/go_test.rs
@@ -3,7 +3,9 @@ use std::collections::HashMap;
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{
+    build_test_summary, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -158,11 +160,10 @@ impl GoTestParser {
         } else {
             None
         };
-        let summary = build_summary(passed, failed, skipped);
+        let summary = build_test_summary(passed, failed, skipped);
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped,
             ..Counts::default()
         };
@@ -251,11 +252,10 @@ impl GoTestParser {
         // Failure count comes directly from the collected diagnostics.
         let failed = diagnostics.len() as u32;
 
-        let summary = build_summary(passed, failed, skipped);
+        let summary = build_test_summary(passed, failed, skipped);
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped,
             ..Counts::default()
         };
@@ -288,19 +288,6 @@ fn build_text_diagnostic(name: String, lines: &[String]) -> Diagnostic {
         message,
         detail,
     }
-}
-
-/// Build a human-readable summary, omitting zero categories except `passed`.
-fn build_summary(passed: u32, failed: u32, skipped: u32) -> String {
-    let mut parts: Vec<String> = Vec::new();
-    parts.push(format!("{passed} passed"));
-    if failed > 0 {
-        parts.push(format!("{failed} failed"));
-    }
-    if skipped > 0 {
-        parts.push(format!("{skipped} skipped"));
-    }
-    parts.join(", ")
 }
 
 /// Extract the most useful failure message from accumulated output text.

--- a/src/run/parsers/golangci_lint.rs
+++ b/src/run/parsers/golangci_lint.rs
@@ -56,13 +56,12 @@ impl Parser for GolangciLintParser {
 // Helpers
 // ---------------------------------------------------------------------------
 
-/// Heuristic: treat as JSON if any of the first 5 non-empty lines starts with `{`.
+/// Check for golangci-lint JSON fingerprints (`"FromLinter"` or `"Issues"` keys).
 fn looks_like_json(input: &str) -> bool {
-    input
-        .lines()
-        .filter(|l| !l.trim().is_empty())
-        .take(5)
-        .any(|l| l.trim_start().starts_with('{'))
+    let bytes = input.as_bytes();
+    let from_linter = memchr::memmem::Finder::new(b"\"FromLinter\"");
+    let issues_key = memchr::memmem::Finder::new(b"\"Issues\"");
+    from_linter.find(bytes).is_some() || issues_key.find(bytes).is_some()
 }
 
 /// Returns true if `line` matches `path.go:N:M: linterName: message` (with or without column).
@@ -80,8 +79,7 @@ fn looks_like_lint_line(line: &str) -> bool {
         return false;
     }
     // Must have at least two `: ` separators after the path (location + linter name + message)
-    let colons: Vec<_> = after_go.match_indices(": ").collect();
-    colons.len() >= 2
+    after_go.matches(": ").count() >= 2
 }
 
 // ---------------------------------------------------------------------------
@@ -121,7 +119,8 @@ fn try_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
             if let Some(diag) = extract_json_issue(&value) {
                 match diag.severity {
                     Severity::Error => error_count += 1,
-                    Severity::Warning | Severity::Info => warning_count += 1,
+                    Severity::Warning => warning_count += 1,
+                    Severity::Info => {}
                 }
                 diagnostics.push(diag);
             }

--- a/src/run/parsers/golangci_lint.rs
+++ b/src/run/parsers/golangci_lint.rs
@@ -1,0 +1,430 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: GolangciLintParser = GolangciLintParser;
+
+pub struct GolangciLintParser;
+
+impl Parser for GolangciLintParser {
+    fn name(&self) -> &'static str {
+        "golangci-lint"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint (single-object): `"Issues"` and `"Severity"` both present.
+        let issues_finder = memmem::Finder::new(b"\"Issues\"");
+        let severity_finder = memmem::Finder::new(b"\"Severity\"");
+        if issues_finder.find(bytes).is_some() && severity_finder.find(bytes).is_some() {
+            return true;
+        }
+
+        // JSON fingerprint (per-line): lines with `"FromLinter"` and `"Text"`.
+        let from_linter_finder = memmem::Finder::new(b"\"FromLinter\"");
+        let text_finder = memmem::Finder::new(b"\"Text\"");
+        if from_linter_finder.find(bytes).is_some() && text_finder.find(bytes).is_some() {
+            return true;
+        }
+
+        // Text fingerprint: `.go:N:M: linterName: message` — look for `.go:` with a digit after.
+        let go_finder = memmem::Finder::new(b".go:");
+        if go_finder.find(bytes).is_none() {
+            return false;
+        }
+        // Confirm at least one line looks like a real golangci-lint text line.
+        sample.lines().any(looks_like_lint_line)
+    }
+
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--out-format") {
+            return None;
+        }
+        Some(format!("{command} --out-format=json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        if looks_like_json(input) {
+            try_json(input, raw_lines, raw_bytes)
+        } else {
+            parse_text(input, raw_lines, raw_bytes)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Heuristic: treat as JSON if any of the first 5 non-empty lines starts with `{`.
+fn looks_like_json(input: &str) -> bool {
+    input
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .take(5)
+        .any(|l| l.trim_start().starts_with('{'))
+}
+
+/// Returns true if `line` matches `path.go:N:M: linterName: message` (with or without column).
+fn looks_like_lint_line(line: &str) -> bool {
+    // Must contain `.go:`
+    let Some(go_pos) = line.find(".go:") else {
+        return false;
+    };
+    let after_go = &line[go_pos + 4..]; // skip ".go:"
+    // Expect a digit immediately after `.go:`
+    let Some(first) = after_go.chars().next() else {
+        return false;
+    };
+    if !first.is_ascii_digit() {
+        return false;
+    }
+    // Must have at least two `: ` separators after the path (location + linter name + message)
+    let colons: Vec<_> = after_go.match_indices(": ").collect();
+    colons.len() >= 2
+}
+
+// ---------------------------------------------------------------------------
+// JSON path
+// ---------------------------------------------------------------------------
+
+fn try_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    // Try parsing as a single JSON object first (standard golangci-lint JSON output).
+    let trimmed = input.trim();
+    if let Ok(value) = serde_json::from_str::<Value>(trimmed) {
+        if let Some(issues) = value.get("Issues").and_then(Value::as_array) {
+            for issue in issues {
+                if let Some(diag) = extract_json_issue(issue) {
+                    match diag.severity {
+                        Severity::Error => error_count += 1,
+                        Severity::Warning => warning_count += 1,
+                        Severity::Info => {}
+                    }
+                    diagnostics.push(diag);
+                }
+            }
+        }
+    } else {
+        // Fall back to per-line JSON (one JSON object per line).
+        for line in input.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            if let Some(diag) = extract_json_issue(&value) {
+                match diag.severity {
+                    Severity::Error => error_count += 1,
+                    Severity::Warning | Severity::Info => warning_count += 1,
+                }
+                diagnostics.push(diag);
+            }
+        }
+    }
+
+    let linter_count = count_unique_linters(&diagnostics);
+    let summary = build_summary(diagnostics.len(), linter_count);
+
+    ParsedOutput {
+        tool: "golangci-lint",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Extract a `Diagnostic` from a single golangci-lint JSON issue object.
+fn extract_json_issue(issue: &Value) -> Option<Diagnostic> {
+    let from_linter = issue
+        .get("FromLinter")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let message = issue.get("Text").and_then(Value::as_str)?.to_string();
+
+    let severity_str = issue
+        .get("Severity")
+        .and_then(Value::as_str)
+        .unwrap_or("warning");
+    let severity = if severity_str == "error" {
+        Severity::Error
+    } else {
+        Severity::Warning
+    };
+
+    let location = issue.get("Pos").and_then(|pos| {
+        let file = pos.get("Filename")?.as_str()?.to_string();
+        let line = pos.get("Line")?.as_u64()? as u32;
+        let column = pos.get("Column").and_then(Value::as_u64).map(|c| c as u32);
+        Some(Location { file, line, column })
+    });
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name: from_linter,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    for line in input.lines() {
+        if let Some(diag) = parse_lint_line(line) {
+            match diag.severity {
+                Severity::Error => error_count += 1,
+                Severity::Warning => warning_count += 1,
+                Severity::Info => {}
+            }
+            diagnostics.push(diag);
+        }
+    }
+
+    let linter_count = count_unique_linters(&diagnostics);
+    let summary = build_summary(diagnostics.len(), linter_count);
+
+    ParsedOutput {
+        tool: "golangci-lint",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Parse a single golangci-lint text line.
+///
+/// Formats handled:
+/// - `path/to/file.go:N:M: linterName: message`
+/// - `path/to/file.go:N: linterName: message`
+fn parse_lint_line(line: &str) -> Option<Diagnostic> {
+    if !looks_like_lint_line(line) {
+        return None;
+    }
+
+    let go_pos = line.find(".go:")?;
+    let path = &line[..go_pos + 3]; // up to and including ".go"
+    let rest = &line[go_pos + 4..]; // after ".go:"
+
+    // rest is now `N:M: linterName: message` or `N: linterName: message`
+    // Split off the line number.
+    let (line_num_str, after_line) = rest.split_once(':')?;
+    let line_num: u32 = line_num_str.trim().parse().ok()?;
+
+    // Check whether next token is a column number or the linter name.
+    let (column, after_loc) = if let Some((maybe_col, remainder)) = after_line.split_once(':') {
+        let maybe_col = maybe_col.trim();
+        if let Ok(col) = maybe_col.parse::<u32>() {
+            // `M: linterName: message`
+            (Some(col), remainder)
+        } else {
+            // No column — `maybe_col` is linter name start; treat after_line as `: linterName: message`
+            (None, after_line)
+        }
+    } else {
+        return None;
+    };
+
+    // after_loc is ` linterName: message` (with leading space after the colon)
+    let after_loc = after_loc.trim_start_matches(' ');
+    let (linter_name, message) = after_loc.split_once(": ")?;
+    let linter_name = linter_name.trim().to_string();
+    let message = message.trim().to_string();
+
+    if linter_name.is_empty() || message.is_empty() {
+        return None;
+    }
+
+    Some(Diagnostic {
+        severity: Severity::Warning,
+        location: Some(Location {
+            file: path.to_string(),
+            line: line_num,
+            column,
+        }),
+        name: linter_name,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn count_unique_linters(diagnostics: &[Diagnostic]) -> usize {
+    let mut names: Vec<&str> = diagnostics.iter().map(|d| d.name.as_str()).collect();
+    names.sort_unstable();
+    names.dedup();
+    names.len()
+}
+
+fn build_summary(issue_count: usize, linter_count: usize) -> String {
+    if issue_count == 0 {
+        "no issues found".to_string()
+    } else {
+        format!(
+            "{} issue(s) from {} linter(s)",
+            issue_count, linter_count
+        )
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_json_fingerprint() {
+        let sample = r#"{ "Issues": [], "Severity": "warning" }"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text_fingerprint() {
+        let sample = "pkg/foo/bar.go:42:5: govet: printf: wrong type\npkg/foo/bar.go:10:1: errcheck: unchecked error\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "some random\noutput\nwith no golang lint markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_appends_format() {
+        let result = PARSER.rewrite("golangci-lint run");
+        assert_eq!(
+            result,
+            Some("golangci-lint run --out-format=json".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_skips_if_present() {
+        let result = PARSER.rewrite("golangci-lint run --out-format=json");
+        assert!(result.is_none());
+    }
+
+    // --- JSON path ---
+
+    #[test]
+    fn parse_json_issues() {
+        let input = r#"{
+  "Issues": [
+    {
+      "FromLinter": "govet",
+      "Text": "printf: fmt.Sprintf format %d has arg str of wrong type string",
+      "Severity": "warning",
+      "Pos": { "Filename": "main.go", "Line": 42, "Column": 5 }
+    },
+    {
+      "FromLinter": "errcheck",
+      "Text": "Error return value of `os.Remove` is not checked",
+      "Severity": "error",
+      "Pos": { "Filename": "cmd/root.go", "Line": 17, "Column": 2 }
+    }
+  ]
+}"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let govet = &out.diagnostics[0];
+        assert_eq!(govet.name, "govet");
+        assert_eq!(govet.severity, Severity::Warning);
+        assert_eq!(govet.location.as_ref().map(|l| l.file.as_str()), Some("main.go"));
+        assert_eq!(govet.location.as_ref().map(|l| l.line), Some(42));
+        assert_eq!(govet.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let errcheck = &out.diagnostics[1];
+        assert_eq!(errcheck.name, "errcheck");
+        assert_eq!(errcheck.severity, Severity::Error);
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.counts.warnings, 1);
+        assert_eq!(out.summary, "2 issue(s) from 2 linter(s)");
+    }
+
+    #[test]
+    fn parse_json_no_issues() {
+        let input = r#"{ "Issues": [] }"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 0);
+        assert_eq!(out.summary, "no issues found");
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text_lint_lines() {
+        let input = "main.go:42:5: govet: printf: wrong type\ncmd/root.go:17:2: errcheck: unchecked error\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.name, "govet");
+        assert_eq!(first.message, "printf: wrong type");
+        assert_eq!(first.location.as_ref().map(|l| l.file.as_str()), Some("main.go"));
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(42));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.name, "errcheck");
+        assert_eq!(second.location.as_ref().map(|l| l.line), Some(17));
+    }
+
+    #[test]
+    fn parse_text_groups_by_linter() {
+        let input = "a.go:1:1: govet: msg one\nb.go:2:3: govet: msg two\nc.go:5:1: errcheck: msg three\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 3);
+        // Two govet issues, one errcheck — 2 distinct linters.
+        assert_eq!(out.summary, "3 issue(s) from 2 linter(s)");
+        // All are warnings (text path has no severity info, defaults to Warning).
+        assert_eq!(out.counts.warnings, 3);
+        assert_eq!(out.counts.errors, 0);
+    }
+}

--- a/src/run/parsers/golangci_lint.rs
+++ b/src/run/parsers/golangci_lint.rs
@@ -72,7 +72,7 @@ fn looks_like_lint_line(line: &str) -> bool {
         return false;
     };
     let after_go = &line[go_pos + 4..]; // skip ".go:"
-    // Expect a digit immediately after `.go:`
+                                        // Expect a digit immediately after `.go:`
     let Some(first) = after_go.chars().next() else {
         return false;
     };
@@ -291,10 +291,7 @@ fn build_summary(issue_count: usize, linter_count: usize) -> String {
     if issue_count == 0 {
         "no issues found".to_string()
     } else {
-        format!(
-            "{} issue(s) from {} linter(s)",
-            issue_count, linter_count
-        )
+        format!("{} issue(s) from {} linter(s)", issue_count, linter_count)
     }
 }
 
@@ -352,7 +349,10 @@ mod tests {
         let govet = &out.diagnostics[0];
         assert_eq!(govet.name, "govet");
         assert_eq!(govet.severity, Severity::Warning);
-        assert_eq!(govet.location.as_ref().map(|l| l.file.as_str()), Some("main.go"));
+        assert_eq!(
+            govet.location.as_ref().map(|l| l.file.as_str()),
+            Some("main.go")
+        );
         assert_eq!(govet.location.as_ref().map(|l| l.line), Some(42));
         assert_eq!(govet.location.as_ref().and_then(|l| l.column), Some(5));
 
@@ -383,7 +383,10 @@ mod tests {
         let first = &out.diagnostics[0];
         assert_eq!(first.name, "govet");
         assert_eq!(first.message, "printf: wrong type");
-        assert_eq!(first.location.as_ref().map(|l| l.file.as_str()), Some("main.go"));
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("main.go")
+        );
         assert_eq!(first.location.as_ref().map(|l| l.line), Some(42));
         assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
 
@@ -394,7 +397,8 @@ mod tests {
 
     #[test]
     fn parse_text_groups_by_linter() {
-        let input = "a.go:1:1: govet: msg one\nb.go:2:3: govet: msg two\nc.go:5:1: errcheck: msg three\n";
+        let input =
+            "a.go:1:1: govet: msg one\nb.go:2:3: govet: msg two\nc.go:5:1: errcheck: msg three\n";
         let out = PARSER.parse(input);
         assert_eq!(out.diagnostics.len(), 3);
         // Two govet issues, one errcheck — 2 distinct linters.

--- a/src/run/parsers/golangci_lint.rs
+++ b/src/run/parsers/golangci_lint.rs
@@ -1,7 +1,7 @@
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{Counts, DetectResult, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 
@@ -14,37 +14,41 @@ impl Parser for GolangciLintParser {
         "golangci-lint"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint (single-object): `"Issues"` and `"Severity"` both present.
         let issues_finder = memmem::Finder::new(b"\"Issues\"");
         let severity_finder = memmem::Finder::new(b"\"Severity\"");
         if issues_finder.find(bytes).is_some() && severity_finder.find(bytes).is_some() {
-            return true;
+            return DetectResult::SingleJson;
         }
 
         // JSON fingerprint (per-line): lines with `"FromLinter"` and `"Text"`.
         let from_linter_finder = memmem::Finder::new(b"\"FromLinter\"");
         let text_finder = memmem::Finder::new(b"\"Text\"");
         if from_linter_finder.find(bytes).is_some() && text_finder.find(bytes).is_some() {
-            return true;
+            return DetectResult::NdJson;
         }
 
         // Text fingerprint: `.go:N:M: linterName: message` — look for `.go:` with a digit after.
         let go_finder = memmem::Finder::new(b".go:");
         if go_finder.find(bytes).is_none() {
-            return false;
+            return DetectResult::NoMatch;
         }
         // Confirm at least one line looks like a real golangci-lint text line.
-        sample.lines().any(looks_like_lint_line)
+        if sample.lines().any(looks_like_lint_line) {
+            DetectResult::Text
+        } else {
+            DetectResult::NoMatch
+        }
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
-        if looks_like_json(input) {
+        if hint.is_json() {
             try_json(input, raw_lines, raw_bytes)
         } else {
             parse_text(input, raw_lines, raw_bytes)
@@ -55,14 +59,6 @@ impl Parser for GolangciLintParser {
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-/// Check for golangci-lint JSON fingerprints (`"FromLinter"` or `"Issues"` keys).
-fn looks_like_json(input: &str) -> bool {
-    let bytes = input.as_bytes();
-    let from_linter = memchr::memmem::Finder::new(b"\"FromLinter\"");
-    let issues_key = memchr::memmem::Finder::new(b"\"Issues\"");
-    from_linter.find(bytes).is_some() || issues_key.find(bytes).is_some()
-}
 
 /// Returns true if `line` matches `path.go:N:M: linterName: message` (with or without column).
 fn looks_like_lint_line(line: &str) -> bool {
@@ -290,7 +286,7 @@ fn build_summary(issue_count: usize, linter_count: usize) -> String {
     if issue_count == 0 {
         "no issues found".to_string()
     } else {
-        format!("{} issue(s) from {} linter(s)", issue_count, linter_count)
+        format!("{issue_count} issue(s) from {linter_count} linter(s)")
     }
 }
 
@@ -307,19 +303,19 @@ mod tests {
     #[test]
     fn detect_json_fingerprint() {
         let sample = r#"{ "Issues": [], "Severity": "warning" }"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text_fingerprint() {
         let sample = "pkg/foo/bar.go:42:5: govet: printf: wrong type\npkg/foo/bar.go:10:1: errcheck: unchecked error\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "some random\noutput\nwith no golang lint markers\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // --- JSON path ---
@@ -342,7 +338,7 @@ mod tests {
     }
   ]
 }"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::SingleJson);
         assert_eq!(out.diagnostics.len(), 2);
 
         let govet = &out.diagnostics[0];
@@ -366,7 +362,7 @@ mod tests {
     #[test]
     fn parse_json_no_issues() {
         let input = r#"{ "Issues": [] }"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 0);
         assert_eq!(out.summary, "no issues found");
     }
@@ -376,7 +372,7 @@ mod tests {
     #[test]
     fn parse_text_lint_lines() {
         let input = "main.go:42:5: govet: printf: wrong type\ncmd/root.go:17:2: errcheck: unchecked error\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -398,7 +394,7 @@ mod tests {
     fn parse_text_groups_by_linter() {
         let input =
             "a.go:1:1: govet: msg one\nb.go:2:3: govet: msg two\nc.go:5:1: errcheck: msg three\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 3);
         // Two govet issues, one errcheck — 2 distinct linters.
         assert_eq!(out.summary, "3 issue(s) from 2 linter(s)");

--- a/src/run/parsers/golangci_lint.rs
+++ b/src/run/parsers/golangci_lint.rs
@@ -40,13 +40,6 @@ impl Parser for GolangciLintParser {
         sample.lines().any(looks_like_lint_line)
     }
 
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--out-format") {
-            return None;
-        }
-        Some(format!("{command} --out-format=json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -331,23 +324,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "some random\noutput\nwith no golang lint markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_appends_format() {
-        let result = PARSER.rewrite("golangci-lint run");
-        assert_eq!(
-            result,
-            Some("golangci-lint run --out-format=json".to_string())
-        );
-    }
-
-    #[test]
-    fn rewrite_skips_if_present() {
-        let result = PARSER.rewrite("golangci-lint run --out-format=json");
-        assert!(result.is_none());
     }
 
     // --- JSON path ---

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -51,7 +51,7 @@ impl Parser for JestParser {
 
     fn parse(&self, input: &str) -> ParsedOutput {
         let trimmed = input.trim_start();
-        if trimmed.starts_with('{') || trimmed.starts_with('[') {
+        if trimmed.starts_with('{') {
             if let Some(parsed) = self.try_json(input) {
                 return parsed;
             }
@@ -158,7 +158,6 @@ impl JestParser {
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped: pending,
             ..Counts::default()
         };
@@ -245,7 +244,6 @@ impl JestParser {
         let counts = Counts {
             passed,
             failed,
-            errors: failed,
             skipped: pending,
             ..Counts::default()
         };

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -3,7 +3,8 @@ use serde_json::Value;
 
 use crate::run::ansi;
 use crate::run::types::{
-    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    extract_count, truncate_detail, Counts, DetectResult, Diagnostic, Location, ParsedOutput,
+    Severity,
 };
 
 use super::Parser;
@@ -21,20 +22,20 @@ impl Parser for JestParser {
     ///
     /// Accepts JSON format (`"numPassedTests"` or `"numFailedTests"`) or text
     /// format (`Tests:` + `passed`/`failed`, or Vitest markers `✓`/`×` + `Tests`).
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint: Jest and Vitest both emit these keys.
         let num_passed = memmem::Finder::new(r#""numPassedTests""#);
         let num_failed = memmem::Finder::new(r#""numFailedTests""#);
         if num_passed.find(bytes).is_some() || num_failed.find(bytes).is_some() {
-            return true;
+            return DetectResult::SingleJson;
         }
 
         // Text fingerprint: summary line must contain "Tests:" AND a status word.
         let tests_label = memmem::Finder::new("Tests:");
         if tests_label.find(bytes).is_none() {
-            return false;
+            return DetectResult::NoMatch;
         }
 
         let passed_finder = memmem::Finder::new("passed");
@@ -43,25 +44,29 @@ impl Parser for JestParser {
         let vitest_pass = memmem::Finder::new("✓");
         let vitest_fail = memmem::Finder::new("×");
 
-        passed_finder.find(bytes).is_some()
+        if passed_finder.find(bytes).is_some()
             || failed_finder.find(bytes).is_some()
             || vitest_pass.find(bytes).is_some()
             || vitest_fail.find(bytes).is_some()
+        {
+            DetectResult::Text
+        } else {
+            DetectResult::NoMatch
+        }
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
-        let trimmed = input.trim_start();
-        if trimmed.starts_with('{') {
-            if let Some(parsed) = self.try_json(input) {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
+        if hint.is_json() {
+            if let Some(parsed) = JestParser::try_json(input) {
                 return parsed;
             }
         }
-        self.parse_text(input)
+        JestParser::parse_text(input)
     }
 }
 
 impl JestParser {
-    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+    fn try_json(input: &str) -> Option<ParsedOutput> {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -70,15 +75,15 @@ impl JestParser {
 
         let passed = root
             .get("numPassedTests")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0) as u32;
         let failed = root
             .get("numFailedTests")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0) as u32;
         let pending = root
             .get("numPendingTests")
-            .and_then(|v| v.as_u64())
+            .and_then(serde_json::Value::as_u64)
             .unwrap_or(0) as u32;
 
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
@@ -91,7 +96,7 @@ impl JestParser {
                     if let Some(runtime) = suite
                         .get("perfStats")
                         .and_then(|ps| ps.get("runtime"))
-                        .and_then(|v| v.as_f64())
+                        .and_then(serde_json::Value::as_f64)
                     {
                         duration_secs = Some(runtime / 1000.0);
                     } else {
@@ -99,12 +104,12 @@ impl JestParser {
                             .get("perfStats")
                             .and_then(|ps| ps.get("start"))
                             .or_else(|| suite.get("startTime"))
-                            .and_then(|v| v.as_f64());
+                            .and_then(serde_json::Value::as_f64);
                         let end = suite
                             .get("perfStats")
                             .and_then(|ps| ps.get("end"))
                             .or_else(|| suite.get("endTime"))
-                            .and_then(|v| v.as_f64());
+                            .and_then(serde_json::Value::as_f64);
                         if let (Some(s), Some(e)) = (start, end) {
                             duration_secs = Some((e - s) / 1000.0);
                         }
@@ -129,8 +134,8 @@ impl JestParser {
 
                     let failure_messages: Vec<&str> = assertion
                         .get("failureMessages")
-                        .and_then(|v| v.as_array())
-                        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+                        .and_then(serde_json::Value::as_array)
+                        .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect())
                         .unwrap_or_default();
 
                     let first_message = failure_messages.first().copied().unwrap_or("");
@@ -173,7 +178,7 @@ impl JestParser {
         })
     }
 
-    fn parse_text(&self, input: &str) -> ParsedOutput {
+    fn parse_text(input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
@@ -281,7 +286,10 @@ fn build_summary(passed: u32, failed: u32, pending: u32) -> String {
 ///
 /// Prefers `fullName`; falls back to `ancestorTitles` joined with ` > ` + `title`.
 fn build_test_name(assertion: &Value) -> String {
-    if let Some(full) = assertion.get("fullName").and_then(|v| v.as_str()) {
+    if let Some(full) = assertion
+        .get("fullName")
+        .and_then(serde_json::Value::as_str)
+    {
         if !full.is_empty() {
             return full.to_string();
         }
@@ -289,8 +297,8 @@ fn build_test_name(assertion: &Value) -> String {
 
     let ancestors: Vec<&str> = assertion
         .get("ancestorTitles")
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .and_then(serde_json::Value::as_array)
+        .map(|arr| arr.iter().filter_map(serde_json::Value::as_str).collect())
         .unwrap_or_default();
 
     let title = assertion
@@ -328,7 +336,7 @@ fn extract_jest_message(text: &str) -> String {
     // Fallback: first non-empty line that isn't a stack frame.
     clean
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .find(|l| !l.is_empty() && !l.starts_with("at ") && !l.starts_with("●"))
         .unwrap_or("test failed")
         .to_string()
@@ -446,19 +454,19 @@ mod tests {
     #[test]
     fn detect_json_fingerprint() {
         let sample = r#"{"numPassedTests":3,"numFailedTests":0,"testResults":[]}"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text_fingerprint() {
         let sample = "PASS src/add.test.js\nTests:  3 passed, 3 total\nTime: 0.5s";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // -- JSON parse ----------------------------------------------------------
@@ -478,7 +486,7 @@ mod tests {
                 ]
             }]
         }"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::SingleJson);
         assert_eq!(out.tool, "jest");
         assert_eq!(out.counts.passed, 3);
         assert_eq!(out.counts.failed, 0);
@@ -511,7 +519,7 @@ mod tests {
                 ]
             }]
         }"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::SingleJson);
         assert_eq!(out.counts.failed, 1);
         assert_eq!(out.counts.passed, 1);
         assert_eq!(out.diagnostics.len(), 1);
@@ -537,7 +545,7 @@ mod tests {
             "Snapshots: 0 total\n",
             "Time: 1.2s\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.passed, 2);
         assert_eq!(out.counts.failed, 1);
         assert_eq!(out.counts.skipped, 0);
@@ -561,7 +569,7 @@ mod tests {
             "\n",
             "Tests:  0 passed, 1 failed, 1 total\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
         let diag = &out.diagnostics[0];
         assert_eq!(diag.name, "subtract › returns correct value");

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -47,18 +47,6 @@ impl Parser for JestParser {
             || vitest_fail.find(bytes).is_some()
     }
 
-    /// Append `--json` to the command unless it is already present.
-    ///
-    /// Handles bare `jest`, `vitest`, and package-manager–prefixed invocations
-    /// (`npx jest`, `yarn jest`, `pnpm jest`, etc.).
-    fn rewrite(&self, command: &str) -> Option<String> {
-        let json_flag = memmem::Finder::new("--json");
-        if json_flag.find(command.as_bytes()).is_some() {
-            return None;
-        }
-        Some(format!("{command} --json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let trimmed = input.trim_start();
         if trimmed.starts_with('{') || trimmed.starts_with('[') {
@@ -478,26 +466,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
         assert!(!PARSER.detect(sample));
-    }
-
-    // -- Rewrite -------------------------------------------------------------
-
-    #[test]
-    fn rewrite_appends_json() {
-        assert_eq!(
-            PARSER.rewrite("npx jest"),
-            Some("npx jest --json".to_string())
-        );
-        assert_eq!(
-            PARSER.rewrite("yarn vitest run"),
-            Some("yarn vitest run --json".to_string())
-        );
-    }
-
-    #[test]
-    fn rewrite_skips_if_present() {
-        assert!(PARSER.rewrite("jest --json").is_none());
-        assert!(PARSER.rewrite("npx jest --json --coverage").is_none());
     }
 
     // -- JSON parse ----------------------------------------------------------

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -1,0 +1,612 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::ansi;
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+
+use super::Parser;
+
+pub static PARSER: JestParser = JestParser;
+
+pub struct JestParser;
+
+impl Parser for JestParser {
+    fn name(&self) -> &'static str {
+        "jest"
+    }
+
+    /// Detect Jest/Vitest output via byte scanning — no regex.
+    ///
+    /// Accepts JSON format (`"numPassedTests"` or `"numFailedTests"`) or text
+    /// format (`Tests:` + `passed`/`failed`, or Vitest markers `✓`/`×` + `Tests`).
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: Jest and Vitest both emit these keys.
+        let num_passed = memmem::Finder::new(r#""numPassedTests""#);
+        let num_failed = memmem::Finder::new(r#""numFailedTests""#);
+        if num_passed.find(bytes).is_some() || num_failed.find(bytes).is_some() {
+            return true;
+        }
+
+        // Text fingerprint: summary line must contain "Tests:" AND a status word.
+        let tests_label = memmem::Finder::new("Tests:");
+        if tests_label.find(bytes).is_none() {
+            return false;
+        }
+
+        let passed_finder = memmem::Finder::new("passed");
+        let failed_finder = memmem::Finder::new("failed");
+        // Vitest markers (UTF-8 encoded)
+        let vitest_pass = memmem::Finder::new("✓");
+        let vitest_fail = memmem::Finder::new("×");
+
+        passed_finder.find(bytes).is_some()
+            || failed_finder.find(bytes).is_some()
+            || vitest_pass.find(bytes).is_some()
+            || vitest_fail.find(bytes).is_some()
+    }
+
+    /// Append `--json` to the command unless it is already present.
+    ///
+    /// Handles bare `jest`, `vitest`, and package-manager–prefixed invocations
+    /// (`npx jest`, `yarn jest`, `pnpm jest`, etc.).
+    fn rewrite(&self, command: &str) -> Option<String> {
+        let json_flag = memmem::Finder::new("--json");
+        if json_flag.find(command.as_bytes()).is_some() {
+            return None;
+        }
+        Some(format!("{command} --json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let trimmed = input.trim_start();
+        if trimmed.starts_with('{') || trimmed.starts_with('[') {
+            if let Some(parsed) = self.try_json(input) {
+                return parsed;
+            }
+        }
+        self.parse_text(input)
+    }
+}
+
+impl JestParser {
+    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        // Jest JSON output is a single object, not NDJSON.
+        let root: Value = serde_json::from_str(input.trim()).ok()?;
+
+        let passed = root
+            .get("numPassedTests")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let failed = root
+            .get("numFailedTests")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let pending = root
+            .get("numPendingTests")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        let mut duration_secs: Option<f64> = None;
+
+        if let Some(test_results) = root.get("testResults").and_then(|v| v.as_array()) {
+            for suite in test_results {
+                // Duration from perfStats or endTime - startTime.
+                if duration_secs.is_none() {
+                    if let Some(runtime) = suite
+                        .get("perfStats")
+                        .and_then(|ps| ps.get("runtime"))
+                        .and_then(|v| v.as_f64())
+                    {
+                        duration_secs = Some(runtime / 1000.0);
+                    } else {
+                        let start = suite
+                            .get("perfStats")
+                            .and_then(|ps| ps.get("start"))
+                            .or_else(|| suite.get("startTime"))
+                            .and_then(|v| v.as_f64());
+                        let end = suite
+                            .get("perfStats")
+                            .and_then(|ps| ps.get("end"))
+                            .or_else(|| suite.get("endTime"))
+                            .and_then(|v| v.as_f64());
+                        if let (Some(s), Some(e)) = (start, end) {
+                            duration_secs = Some((e - s) / 1000.0);
+                        }
+                    }
+                }
+
+                let assertions = suite
+                    .get("assertionResults")
+                    .and_then(|v| v.as_array());
+                let Some(assertions) = assertions else {
+                    continue;
+                };
+
+                for assertion in assertions {
+                    let status = assertion
+                        .get("status")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+                    if status != "failed" {
+                        continue;
+                    }
+
+                    let name = build_test_name(assertion);
+
+                    let failure_messages: Vec<&str> = assertion
+                        .get("failureMessages")
+                        .and_then(|v| v.as_array())
+                        .map(|arr| {
+                            arr.iter()
+                                .filter_map(|v| v.as_str())
+                                .collect()
+                        })
+                        .unwrap_or_default();
+
+                    let first_message = failure_messages.first().copied().unwrap_or("");
+                    let message = extract_jest_message(first_message);
+                    let location = extract_location_from_failure(first_message);
+
+                    let detail = if first_message.is_empty() {
+                        None
+                    } else {
+                        truncate_detail(&ansi::strip(first_message))
+                    };
+
+                    diagnostics.push(Diagnostic {
+                        severity: Severity::Error,
+                        location,
+                        name,
+                        message,
+                        detail,
+                    });
+                }
+            }
+        }
+
+        let summary = build_summary(passed, failed, pending);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped: pending,
+            ..Counts::default()
+        };
+
+        Some(ParsedOutput {
+            tool: "jest",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs,
+            raw_lines,
+            raw_bytes,
+        })
+    }
+
+    fn parse_text(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut passed: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut pending: u32 = 0;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // Summary line: `Tests:  3 passed, 1 failed, 4 total`
+        for line in input.lines() {
+            if let Some(rest) = line.find("Tests:").map(|i| &line[i + 6..]) {
+                let rest = rest.trim();
+                passed = extract_count(rest, "passed").unwrap_or(0);
+                failed = extract_count(rest, "failed").unwrap_or(0);
+                pending = extract_count(rest, "skipped")
+                    .or_else(|| extract_count(rest, "pending"))
+                    .or_else(|| extract_count(rest, "todo"))
+                    .unwrap_or(0);
+                break;
+            }
+        }
+
+        // Failure blocks: `● describe > test name` followed by message lines until the
+        // next `●` or end of output.
+        let lines: Vec<&str> = input.lines().collect();
+        let mut i = 0;
+        while i < lines.len() {
+            let line = lines[i];
+            if let Some(name) = parse_bullet_header(line) {
+                let block_start = i + 1;
+                let mut block_end = block_start;
+                while block_end < lines.len() {
+                    let next = lines[block_end];
+                    // Next failure block or section separator ends this block.
+                    if parse_bullet_header(next).is_some() {
+                        break;
+                    }
+                    // Blank line followed by a non-indented line typically ends a block.
+                    if next.trim().is_empty()
+                        && block_end + 1 < lines.len()
+                        && !lines[block_end + 1].starts_with(' ')
+                        && !lines[block_end + 1].starts_with('\t')
+                        && !lines[block_end + 1].trim().is_empty()
+                    {
+                        break;
+                    }
+                    block_end += 1;
+                }
+
+                let block = lines[block_start..block_end].join("\n");
+                let message = extract_jest_message(&block);
+                let location = extract_location_from_failure(&block);
+                let detail = truncate_detail(&block);
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    location,
+                    name,
+                    message,
+                    detail,
+                });
+                i = block_end;
+                continue;
+            }
+            i += 1;
+        }
+
+        let summary = build_summary(passed, failed, pending);
+        let counts = Counts {
+            passed,
+            failed,
+            errors: failed,
+            skipped: pending,
+            ..Counts::default()
+        };
+
+        ParsedOutput {
+            tool: "jest",
+            summary,
+            diagnostics,
+            counts,
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build a human-readable summary, omitting zero categories except `passed`.
+fn build_summary(passed: u32, failed: u32, pending: u32) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("{passed} passed"));
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if pending > 0 {
+        parts.push(format!("{pending} skipped"));
+    }
+    parts.join(", ")
+}
+
+/// Build a test name from a Jest assertion result object.
+///
+/// Prefers `fullName`; falls back to `ancestorTitles` joined with ` > ` + `title`.
+fn build_test_name(assertion: &Value) -> String {
+    if let Some(full) = assertion.get("fullName").and_then(|v| v.as_str()) {
+        if !full.is_empty() {
+            return full.to_string();
+        }
+    }
+
+    let ancestors: Vec<&str> = assertion
+        .get("ancestorTitles")
+        .and_then(|v| v.as_array())
+        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
+        .unwrap_or_default();
+
+    let title = assertion
+        .get("title")
+        .and_then(|v| v.as_str())
+        .unwrap_or("<unknown>");
+
+    if ancestors.is_empty() {
+        title.to_string()
+    } else {
+        format!("{} > {title}", ancestors.join(" > "))
+    }
+}
+
+/// Extract the most useful human-readable message from a Jest failure string.
+///
+/// Priority:
+/// 1. `expect(...)` lines — the matcher description
+/// 2. `Error:` lines
+/// 3. First non-empty, non-ANSI, non-`at ` line
+fn extract_jest_message(text: &str) -> String {
+    let clean = ansi::strip(text);
+
+    // Look for expect() description lines or Error: lines.
+    for line in clean.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("expect(") || trimmed.starts_with("Expected") {
+            return trimmed.to_string();
+        }
+        if trimmed.starts_with("Error:") || trimmed.starts_with("AssertionError:") {
+            return trimmed.to_string();
+        }
+    }
+
+    // Fallback: first non-empty line that isn't a stack frame.
+    clean
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty() && !l.starts_with("at ") && !l.starts_with("●"))
+        .unwrap_or("test failed")
+        .to_string()
+}
+
+/// Scan a failure message for a `file:line:col` stack frame pattern.
+///
+/// Jest stack frames look like: `at Object.<anonymous> (src/foo.test.js:42:5)`.
+fn extract_location_from_failure(text: &str) -> Option<Location> {
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if !trimmed.starts_with("at ") {
+            continue;
+        }
+        // Look for a `(path:line:col)` or `(path:line)` group.
+        if let Some(loc) = extract_paren_location(trimmed) {
+            return Some(loc);
+        }
+    }
+    None
+}
+
+/// Extract a `Location` from a parenthesised path, e.g. `(src/foo.test.js:42:5)`.
+fn extract_paren_location(line: &str) -> Option<Location> {
+    let open = line.rfind('(')?;
+    let close = line[open..].find(')')? + open;
+    let inner = &line[open + 1..close];
+    parse_path_with_coords(inner)
+}
+
+/// Parse `path:line` or `path:line:col` from a plain string.
+fn parse_path_with_coords(s: &str) -> Option<Location> {
+    // Walk backwards from end, collecting col then line numbers.
+    let bytes = s.as_bytes();
+    let mut end = bytes.len();
+
+    // Optional column.
+    let col = if end > 0 {
+        let col_end = end;
+        let mut col_start = col_end;
+        while col_start > 0 && bytes[col_start - 1].is_ascii_digit() {
+            col_start -= 1;
+        }
+        if col_start < col_end && col_start > 0 && bytes[col_start - 1] == b':' {
+            let val: u32 = std::str::from_utf8(&bytes[col_start..col_end])
+                .ok()?
+                .parse()
+                .ok()?;
+            end = col_start - 1; // strip `:col`
+            Some(val)
+        } else {
+            None
+        }
+    } else {
+        None
+    };
+
+    // Line number (required).
+    let line_end = end;
+    let mut line_start = line_end;
+    while line_start > 0 && bytes[line_start - 1].is_ascii_digit() {
+        line_start -= 1;
+    }
+    if line_start == line_end || line_start == 0 || bytes[line_start - 1] != b':' {
+        return None;
+    }
+    let line_num: u32 = std::str::from_utf8(&bytes[line_start..line_end])
+        .ok()?
+        .parse()
+        .ok()?;
+    let path_end = line_start - 1; // strip `:line`
+
+    if path_end == 0 {
+        return None;
+    }
+
+    let file = std::str::from_utf8(&bytes[..path_end]).ok()?;
+
+    // Must look like a path (contains `.` or `/`) and not be empty.
+    let looks_like_path = file.contains('.') || file.contains('/');
+    if !looks_like_path || file.is_empty() {
+        return None;
+    }
+
+    Some(Location {
+        file: file.to_string(),
+        line: line_num,
+        column: col,
+    })
+}
+
+/// Parse the leading `●` failure block header: `  ● describe > test name`.
+///
+/// Returns the test name (the text after `●`), or `None` if the line is not a header.
+fn parse_bullet_header(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix('●')?;
+    let name = rest.trim();
+    if name.is_empty() {
+        return None;
+    }
+    Some(name.to_string())
+}
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_json_fingerprint() {
+        let sample = r#"{"numPassedTests":3,"numFailedTests":0,"testResults":[]}"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text_fingerprint() {
+        let sample = "PASS src/add.test.js\nTests:  3 passed, 3 total\nTime: 0.5s";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building project...\nCompiling foo v0.1.0\nFinished in 1.2s";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // -- Rewrite -------------------------------------------------------------
+
+    #[test]
+    fn rewrite_appends_json() {
+        assert_eq!(
+            PARSER.rewrite("npx jest"),
+            Some("npx jest --json".to_string())
+        );
+        assert_eq!(
+            PARSER.rewrite("yarn vitest run"),
+            Some("yarn vitest run --json".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_skips_if_present() {
+        assert!(PARSER.rewrite("jest --json").is_none());
+        assert!(PARSER.rewrite("npx jest --json --coverage").is_none());
+    }
+
+    // -- JSON parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_json_all_pass() {
+        let input = r#"{
+            "numPassedTests": 3,
+            "numFailedTests": 0,
+            "numPendingTests": 0,
+            "testResults": [{
+                "perfStats": {"runtime": 450},
+                "assertionResults": [
+                    {"status": "passed", "fullName": "add returns 2", "failureMessages": []},
+                    {"status": "passed", "fullName": "add returns 4", "failureMessages": []},
+                    {"status": "passed", "fullName": "add returns 6", "failureMessages": []}
+                ]
+            }]
+        }"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.tool, "jest");
+        assert_eq!(out.counts.passed, 3);
+        assert_eq!(out.counts.failed, 0);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.duration_secs, Some(0.45));
+        assert!(out.summary.contains("3 passed"));
+        assert!(!out.summary.contains("failed"));
+    }
+
+    #[test]
+    fn parse_json_with_failure() {
+        let input = r#"{
+            "numPassedTests": 1,
+            "numFailedTests": 1,
+            "numPendingTests": 0,
+            "testResults": [{
+                "perfStats": {"runtime": 200},
+                "assertionResults": [
+                    {"status": "passed", "fullName": "add returns 2", "failureMessages": []},
+                    {
+                        "status": "failed",
+                        "fullName": "add returns wrong value",
+                        "title": "returns wrong value",
+                        "ancestorTitles": ["add"],
+                        "failureMessages": [
+                            "Error: expect(received).toBe(expected)\n\nExpected: 5\nReceived: 4\n\n    at Object.<anonymous> (src/add.test.js:10:5)"
+                        ]
+                    }
+                ]
+            }]
+        }"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.failed, 1);
+        assert_eq!(out.counts.passed, 1);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "add returns wrong value");
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(!diag.message.is_empty());
+        let loc = diag.location.as_ref().expect("location should be present");
+        assert_eq!(loc.file, "src/add.test.js");
+        assert_eq!(loc.line, 10);
+        assert_eq!(loc.column, Some(5));
+    }
+
+    // -- Text parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_text_summary() {
+        let input = concat!(
+            "PASS src/add.test.js\n",
+            "FAIL src/sub.test.js\n",
+            "\n",
+            "Tests:  2 passed, 1 failed, 3 total\n",
+            "Snapshots: 0 total\n",
+            "Time: 1.2s\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.passed, 2);
+        assert_eq!(out.counts.failed, 1);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.summary.contains("2 passed"));
+        assert!(out.summary.contains("1 failed"));
+    }
+
+    #[test]
+    fn parse_text_failure_block() {
+        let input = concat!(
+            "FAIL src/sub.test.js\n",
+            "\n",
+            "  ● subtract › returns correct value\n",
+            "\n",
+            "    expect(received).toBe(expected)\n",
+            "\n",
+            "    Expected: 1\n",
+            "    Received: 2\n",
+            "\n",
+            "      at Object.<anonymous> (src/sub.test.js:8:5)\n",
+            "\n",
+            "Tests:  0 passed, 1 failed, 1 total\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "subtract › returns correct value");
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(diag.detail.is_some());
+        let detail = diag.detail.as_ref().unwrap();
+        assert!(detail.contains("Expected"));
+    }
+}

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -2,7 +2,9 @@ use memchr::memmem;
 use serde_json::Value;
 
 use crate::run::ansi;
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+use crate::run::types::{
+    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -109,9 +111,7 @@ impl JestParser {
                     }
                 }
 
-                let assertions = suite
-                    .get("assertionResults")
-                    .and_then(|v| v.as_array());
+                let assertions = suite.get("assertionResults").and_then(|v| v.as_array());
                 let Some(assertions) = assertions else {
                     continue;
                 };
@@ -130,11 +130,7 @@ impl JestParser {
                     let failure_messages: Vec<&str> = assertion
                         .get("failureMessages")
                         .and_then(|v| v.as_array())
-                        .map(|arr| {
-                            arr.iter()
-                                .filter_map(|v| v.as_str())
-                                .collect()
-                        })
+                        .map(|arr| arr.iter().filter_map(|v| v.as_str()).collect())
                         .unwrap_or_default();
 
                     let first_message = failure_messages.first().copied().unwrap_or("");
@@ -438,7 +434,6 @@ fn parse_bullet_header(line: &str) -> Option<String> {
     }
     Some(name.to_string())
 }
-
 
 // ---------------------------------------------------------------------------
 // Tests

--- a/src/run/parsers/jest.rs
+++ b/src/run/parsers/jest.rs
@@ -91,28 +91,27 @@ impl JestParser {
 
         if let Some(test_results) = root.get("testResults").and_then(|v| v.as_array()) {
             for suite in test_results {
-                // Duration from perfStats or endTime - startTime.
-                if duration_secs.is_none() {
-                    if let Some(runtime) = suite
+                // Accumulate duration across all suites. Jest reports per-suite
+                // runtimes in perfStats.runtime (ms); sum them for total wall time.
+                if let Some(runtime) = suite
+                    .get("perfStats")
+                    .and_then(|ps| ps.get("runtime"))
+                    .and_then(serde_json::Value::as_f64)
+                {
+                    *duration_secs.get_or_insert(0.0) += runtime / 1000.0;
+                } else {
+                    let start = suite
                         .get("perfStats")
-                        .and_then(|ps| ps.get("runtime"))
-                        .and_then(serde_json::Value::as_f64)
-                    {
-                        duration_secs = Some(runtime / 1000.0);
-                    } else {
-                        let start = suite
-                            .get("perfStats")
-                            .and_then(|ps| ps.get("start"))
-                            .or_else(|| suite.get("startTime"))
-                            .and_then(serde_json::Value::as_f64);
-                        let end = suite
-                            .get("perfStats")
-                            .and_then(|ps| ps.get("end"))
-                            .or_else(|| suite.get("endTime"))
-                            .and_then(serde_json::Value::as_f64);
-                        if let (Some(s), Some(e)) = (start, end) {
-                            duration_secs = Some((e - s) / 1000.0);
-                        }
+                        .and_then(|ps| ps.get("start"))
+                        .or_else(|| suite.get("startTime"))
+                        .and_then(serde_json::Value::as_f64);
+                    let end = suite
+                        .get("perfStats")
+                        .and_then(|ps| ps.get("end"))
+                        .or_else(|| suite.get("endTime"))
+                        .and_then(serde_json::Value::as_f64);
+                    if let (Some(s), Some(e)) = (start, end) {
+                        *duration_secs.get_or_insert(0.0) += (e - s) / 1000.0;
                     }
                 }
 
@@ -186,8 +185,12 @@ impl JestParser {
         let mut failed: u32 = 0;
         let mut pending: u32 = 0;
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        // Use the LAST `Time:` line — in multi-suite runs Jest prints per-suite times
+        // followed by the overall summary time at the end. We want the overall value.
+        let mut duration_secs: Option<f64> = None;
 
         // Summary line: `Tests:  3 passed, 1 failed, 4 total`
+        // Time line:    `Time:   1.234 s, estimated 2 s`  or  `Time: 0.5s`
         for line in input.lines() {
             if let Some(rest) = line.find("Tests:").map(|i| &line[i + 6..]) {
                 let rest = rest.trim();
@@ -197,7 +200,15 @@ impl JestParser {
                     .or_else(|| extract_count(rest, "pending"))
                     .or_else(|| extract_count(rest, "todo"))
                     .unwrap_or(0);
-                break;
+            }
+            if let Some(rest) = line.find("Time:").map(|i| &line[i + 5..]) {
+                // Take the first whitespace-separated token and strip a trailing 's' if present.
+                if let Some(tok) = rest.split_whitespace().next() {
+                    let num_str = tok.strip_suffix('s').unwrap_or(tok);
+                    if let Ok(secs) = num_str.parse::<f64>() {
+                        duration_secs = Some(secs);
+                    }
+                }
             }
         }
 
@@ -258,7 +269,7 @@ impl JestParser {
             summary,
             diagnostics,
             counts,
-            duration_secs: None,
+            duration_secs,
             raw_lines,
             raw_bytes,
         }
@@ -551,6 +562,38 @@ mod tests {
         assert_eq!(out.counts.skipped, 0);
         assert!(out.summary.contains("2 passed"));
         assert!(out.summary.contains("1 failed"));
+    }
+
+    // -- Bug #10: only first suite's duration used ----------------------------
+
+    /// In a multi-suite run Jest emits a `Time:` line per suite, then an overall
+    /// summary `Time:` at the end.  We must use the LAST one (the overall).
+    #[test]
+    fn parse_text_duration_uses_last_time_line() {
+        let input = concat!(
+            "PASS src/a.test.js\n",
+            "Time: 0.3s\n",
+            "PASS src/b.test.js\n",
+            "Time: 0.4s\n",
+            "\n",
+            "Tests:  4 passed, 4 total\n",
+            "Time: 0.9s\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // Should be 0.9s (the last Time: line), not 0.3s (the first).
+        assert_eq!(out.duration_secs, Some(0.9));
+    }
+
+    /// Single-suite: the one `Time:` line should be captured.
+    #[test]
+    fn parse_text_duration_single_suite() {
+        let input = concat!(
+            "PASS src/add.test.js\n",
+            "Tests:  3 passed, 3 total\n",
+            "Time: 0.5s\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.duration_secs, Some(0.5));
     }
 
     #[test]

--- a/src/run/parsers/mod.rs
+++ b/src/run/parsers/mod.rs
@@ -50,4 +50,3 @@ pub fn detect_from_content(input: &str) -> &'static dyn Parser {
     }
     &generic::PARSER
 }
-

--- a/src/run/parsers/mod.rs
+++ b/src/run/parsers/mod.rs
@@ -6,20 +6,23 @@ pub mod go_test;
 pub mod golangci_lint;
 pub mod jest;
 pub mod mypy;
+pub mod npm;
+pub mod pip;
 pub mod pytest;
 pub mod ruff;
 pub mod tsc;
 
-use crate::run::types::ParsedOutput;
+use crate::run::types::{DetectResult, ParsedOutput};
 
 /// A tool-specific parser that can detect its own input and produce structured output.
 pub trait Parser: Send + Sync {
     fn name(&self) -> &'static str;
 
-    /// Returns true if `sample` (first ~200 lines) looks like output from this tool.
-    fn detect(&self, sample: &str) -> bool;
+    /// Returns a `DetectResult` indicating whether `sample` (first ~200 lines)
+    /// looks like output from this tool, and if so, what format it's in.
+    fn detect(&self, sample: &str) -> DetectResult;
 
-    fn parse(&self, input: &str) -> ParsedOutput;
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput;
 }
 
 /// Static registry — ordered by detection priority.
@@ -38,6 +41,8 @@ static PARSERS: &[&dyn Parser] = &[
     // Text-only parsers — no distinctive JSON fingerprint.
     &pytest::PARSER,
     &tsc::PARSER,
+    &npm::PARSER,
+    &pip::PARSER,
 ];
 
 /// Truncate input to the first `n` lines without allocation.
@@ -55,12 +60,39 @@ fn truncate_to_n_lines(input: &str, n: usize) -> &str {
 }
 
 /// Detect the appropriate parser by scanning the first ~200 lines of content.
-pub fn detect_from_content(input: &str) -> &'static dyn Parser {
+pub fn detect_from_content(input: &str) -> (&'static dyn Parser, DetectResult) {
     let sample = truncate_to_n_lines(input, 200);
     for p in PARSERS {
-        if p.detect(sample) {
-            return *p;
+        let result = p.detect(sample);
+        if result.matched() {
+            return (*p, result);
         }
     }
-    &generic::PARSER
+    (&generic::PARSER, DetectResult::Text)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Bug 5 regression: ruff's weak fingerprint was before mypy in PARSERS.
+    // Verify that mypy JSON is correctly detected as mypy (not ruff) when
+    // detect_from_content walks the PARSERS array in order.
+    #[test]
+    fn detect_mypy_json_not_claimed_by_ruff() {
+        let mypy_json = concat!(
+            r#"{"file": "src/main.py", "line": 42, "column": 5, "severity": "error", "message": "Incompatible types in assignment", "code": "assignment"}"#,
+            "\n",
+        );
+        let (parser, _result) = detect_from_content(mypy_json);
+        assert_eq!(
+            parser.name(),
+            "mypy",
+            "mypy NDJSON should be detected as mypy, not ruff (ruff is before mypy in PARSERS)"
+        );
+    }
 }

--- a/src/run/parsers/mod.rs
+++ b/src/run/parsers/mod.rs
@@ -19,11 +19,6 @@ pub trait Parser: Send + Sync {
     /// Returns true if `sample` (first ~200 lines) looks like output from this tool.
     fn detect(&self, sample: &str) -> bool;
 
-    /// Optional: rewrite the command string before execution (wrapper mode).
-    fn rewrite(&self, _command: &str) -> Option<String> {
-        None
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput;
 }
 
@@ -56,51 +51,3 @@ pub fn detect_from_content(input: &str) -> &'static dyn Parser {
     &generic::PARSER
 }
 
-/// Detect the appropriate parser from a command string (wrapper mode).
-pub fn detect_from_command(command: &str) -> &'static dyn Parser {
-    // Match command prefixes to parsers.
-    let cmd = command.trim();
-    if cmd.starts_with("cargo test") || cmd.starts_with("cargo nextest") {
-        return &cargo_test::PARSER;
-    }
-    if cmd.starts_with("cargo build")
-        || cmd.starts_with("cargo check")
-        || cmd.starts_with("cargo clippy")
-    {
-        return &cargo_build::PARSER;
-    }
-    if cmd.starts_with("go test") {
-        return &go_test::PARSER;
-    }
-    if cmd.starts_with("golangci-lint") {
-        return &golangci_lint::PARSER;
-    }
-    // Jest / Vitest — handle bare, npx/yarn/pnpm prefixed invocations.
-    let jest_keywords = ["jest", "vitest"];
-    for kw in jest_keywords {
-        if cmd.contains(kw) {
-            return &jest::PARSER;
-        }
-    }
-    if cmd.starts_with("pytest") || cmd.starts_with("python -m pytest") {
-        return &pytest::PARSER;
-    }
-    // ESLint — bare, npx/yarn/pnpm prefixed.
-    if cmd.contains("eslint") {
-        return &eslint::PARSER;
-    }
-    // Ruff — `ruff check` or `ruff` bare.
-    if cmd.starts_with("ruff") {
-        return &ruff::PARSER;
-    }
-    // mypy — bare or `python -m mypy`.
-    if cmd.starts_with("mypy") || cmd.starts_with("python -m mypy") {
-        return &mypy::PARSER;
-    }
-    // tsc — bare, `npx tsc`, `yarn tsc`, `pnpm tsc`.
-    // Match when any whitespace-delimited word is exactly `tsc`.
-    if cmd.split_whitespace().any(|w| w == "tsc") {
-        return &tsc::PARSER;
-    }
-    &generic::PARSER
-}

--- a/src/run/parsers/mod.rs
+++ b/src/run/parsers/mod.rs
@@ -40,11 +40,25 @@ static PARSERS: &[&dyn Parser] = &[
     &tsc::PARSER,
 ];
 
+/// Truncate input to the first `n` lines without allocation.
+fn truncate_to_n_lines(input: &str, n: usize) -> &str {
+    let mut count = 0;
+    for (i, b) in input.bytes().enumerate() {
+        if b == b'\n' {
+            count += 1;
+            if count >= n {
+                return &input[..=i];
+            }
+        }
+    }
+    input
+}
+
 /// Detect the appropriate parser by scanning the first ~200 lines of content.
 pub fn detect_from_content(input: &str) -> &'static dyn Parser {
-    let sample: String = input.lines().take(200).collect::<Vec<_>>().join("\n");
+    let sample = truncate_to_n_lines(input, 200);
     for p in PARSERS {
-        if p.detect(&sample) {
+        if p.detect(sample) {
             return *p;
         }
     }

--- a/src/run/parsers/mod.rs
+++ b/src/run/parsers/mod.rs
@@ -1,0 +1,106 @@
+pub mod cargo_build;
+pub mod cargo_test;
+pub mod eslint;
+pub mod generic;
+pub mod go_test;
+pub mod golangci_lint;
+pub mod jest;
+pub mod mypy;
+pub mod pytest;
+pub mod ruff;
+pub mod tsc;
+
+use crate::run::types::ParsedOutput;
+
+/// A tool-specific parser that can detect its own input and produce structured output.
+pub trait Parser: Send + Sync {
+    fn name(&self) -> &'static str;
+
+    /// Returns true if `sample` (first ~200 lines) looks like output from this tool.
+    fn detect(&self, sample: &str) -> bool;
+
+    /// Optional: rewrite the command string before execution (wrapper mode).
+    fn rewrite(&self, _command: &str) -> Option<String> {
+        None
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput;
+}
+
+/// Static registry — ordered by detection priority.
+/// JSON formats first (most distinctive fingerprints), then text-only.
+/// The generic fallback is implicit and never registered here.
+static PARSERS: &[&dyn Parser] = &[
+    &cargo_test::PARSER,
+    &cargo_build::PARSER,
+    &go_test::PARSER,
+    &golangci_lint::PARSER,
+    &jest::PARSER,
+    // JSON-capable linter parsers.
+    &eslint::PARSER,
+    &ruff::PARSER,
+    &mypy::PARSER,
+    // Text-only parsers — no distinctive JSON fingerprint.
+    &pytest::PARSER,
+    &tsc::PARSER,
+];
+
+/// Detect the appropriate parser by scanning the first ~200 lines of content.
+pub fn detect_from_content(input: &str) -> &'static dyn Parser {
+    let sample: String = input.lines().take(200).collect::<Vec<_>>().join("\n");
+    for p in PARSERS {
+        if p.detect(&sample) {
+            return *p;
+        }
+    }
+    &generic::PARSER
+}
+
+/// Detect the appropriate parser from a command string (wrapper mode).
+pub fn detect_from_command(command: &str) -> &'static dyn Parser {
+    // Match command prefixes to parsers.
+    let cmd = command.trim();
+    if cmd.starts_with("cargo test") || cmd.starts_with("cargo nextest") {
+        return &cargo_test::PARSER;
+    }
+    if cmd.starts_with("cargo build")
+        || cmd.starts_with("cargo check")
+        || cmd.starts_with("cargo clippy")
+    {
+        return &cargo_build::PARSER;
+    }
+    if cmd.starts_with("go test") {
+        return &go_test::PARSER;
+    }
+    if cmd.starts_with("golangci-lint") {
+        return &golangci_lint::PARSER;
+    }
+    // Jest / Vitest — handle bare, npx/yarn/pnpm prefixed invocations.
+    let jest_keywords = ["jest", "vitest"];
+    for kw in jest_keywords {
+        if cmd.contains(kw) {
+            return &jest::PARSER;
+        }
+    }
+    if cmd.starts_with("pytest") || cmd.starts_with("python -m pytest") {
+        return &pytest::PARSER;
+    }
+    // ESLint — bare, npx/yarn/pnpm prefixed.
+    if cmd.contains("eslint") {
+        return &eslint::PARSER;
+    }
+    // Ruff — `ruff check` or `ruff` bare.
+    if cmd.starts_with("ruff") {
+        return &ruff::PARSER;
+    }
+    // mypy — bare or `python -m mypy`.
+    if cmd.starts_with("mypy") || cmd.starts_with("python -m mypy") {
+        return &mypy::PARSER;
+    }
+    // tsc — bare, `npx tsc`, `yarn tsc`, `pnpm tsc`.
+    // Match when any whitespace-delimited word is exactly `tsc`.
+    if cmd.split_whitespace().any(|w| w == "tsc") {
+        return &tsc::PARSER;
+    }
+    &generic::PARSER
+}

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -33,9 +33,7 @@ impl Parser for MypyParser {
         if error_finder.find(bytes).is_none() {
             return false;
         }
-        sample
-            .lines()
-            .any(looks_like_mypy_text_line)
+        sample.lines().any(looks_like_mypy_text_line)
     }
 
     fn parse(&self, input: &str) -> ParsedOutput {
@@ -137,7 +135,10 @@ fn parse_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
 }
 
 fn extract_json_diagnostic(value: &Value) -> Option<Diagnostic> {
-    let severity_str = value.get("severity").and_then(Value::as_str).unwrap_or("note");
+    let severity_str = value
+        .get("severity")
+        .and_then(Value::as_str)
+        .unwrap_or("note");
     let severity = match severity_str {
         "error" => Severity::Error,
         "warning" => Severity::Warning,
@@ -159,7 +160,10 @@ fn extract_json_diagnostic(value: &Value) -> Option<Diagnostic> {
         .to_string();
 
     let line = value.get("line").and_then(Value::as_u64).unwrap_or(0) as u32;
-    let column = value.get("column").and_then(Value::as_u64).map(|c| c as u32);
+    let column = value
+        .get("column")
+        .and_then(Value::as_u64)
+        .map(|c| c as u32);
 
     let location = if !file.is_empty() {
         Some(Location { file, line, column })

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -1,0 +1,432 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: MypyParser = MypyParser;
+
+pub struct MypyParser;
+
+impl Parser for MypyParser {
+    fn name(&self) -> &'static str {
+        "mypy"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint (mypy --output=json NDJSON): lines with "severity" + "message" + .py
+        let severity_finder = memmem::Finder::new(b"\"severity\"");
+        let message_finder = memmem::Finder::new(b"\"message\"");
+        let py_finder = memmem::Finder::new(b".py\"");
+        if severity_finder.find(bytes).is_some()
+            && message_finder.find(bytes).is_some()
+            && py_finder.find(bytes).is_some()
+        {
+            return true;
+        }
+
+        // Text fingerprint: `path.py:N: error:` or `path.py:N: warning:`
+        let error_finder = memmem::Finder::new(b".py:");
+        if error_finder.find(bytes).is_none() {
+            return false;
+        }
+        sample
+            .lines()
+            .any(looks_like_mypy_text_line)
+    }
+
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--output") {
+            return None;
+        }
+        Some(format!("{command} --output=json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        // Detect JSON vs text: look for NDJSON objects with "severity" key
+        let trimmed = input.trim_start();
+        if trimmed.starts_with('{') {
+            let severity_finder = memmem::Finder::new(b"\"severity\"");
+            if severity_finder.find(trimmed.as_bytes()).is_some() {
+                return parse_json(input, raw_lines, raw_bytes);
+            }
+        }
+
+        parse_text(input, raw_lines, raw_bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true if `line` looks like a mypy text diagnostic line.
+///
+/// Format: `src/main.py:42: error: Incompatible types  [assignment]`
+fn looks_like_mypy_text_line(line: &str) -> bool {
+    looks_like_mypy_text_line_inner(line).unwrap_or(false)
+}
+
+fn looks_like_mypy_text_line_inner(line: &str) -> Option<bool> {
+    // Must contain `.py:` followed by a line number and `: error:` or `: warning:` or `: note:`
+    let py_col = line.find(".py:")?;
+    let after_py = &line[py_col + 4..];
+    // Next portion should be digits then `: severity:`
+    let colon_pos = after_py.find(':')?;
+    let line_num_part = &after_py[..colon_pos];
+    if !line_num_part.chars().all(|c| c.is_ascii_digit()) || line_num_part.is_empty() {
+        return Some(false);
+    }
+    let after_line = &after_py[colon_pos + 1..];
+    let severity_part = after_line.trim_start();
+    Some(
+        severity_part.starts_with("error:")
+            || severity_part.starts_with("warning:")
+            || severity_part.starts_with("note:"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// JSON path
+// ---------------------------------------------------------------------------
+
+/// Parse mypy NDJSON output (one JSON object per line).
+///
+/// Each line looks like:
+/// ```json
+/// {"file": "src/main.py", "line": 42, "column": 5, "severity": "error", "message": "Incompatible types", "code": "assignment"}
+/// ```
+fn parse_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    for line in input.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(value) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        let Some(diag) = extract_json_diagnostic(&value) else {
+            continue;
+        };
+        match diag.severity {
+            Severity::Error => error_count += 1,
+            Severity::Warning => warning_count += 1,
+            Severity::Info => {}
+        }
+        diagnostics.push(diag);
+    }
+
+    let summary = build_summary(error_count, warning_count);
+
+    ParsedOutput {
+        tool: "mypy",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+fn extract_json_diagnostic(value: &Value) -> Option<Diagnostic> {
+    let severity_str = value.get("severity").and_then(Value::as_str).unwrap_or("note");
+    let severity = match severity_str {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    let message = value.get("message").and_then(Value::as_str)?.to_string();
+
+    let name = value
+        .get("code")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let file = value
+        .get("file")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let line = value.get("line").and_then(Value::as_u64).unwrap_or(0) as u32;
+    let column = value.get("column").and_then(Value::as_u64).map(|c| c as u32);
+
+    let location = if !file.is_empty() {
+        Some(Location { file, line, column })
+    } else {
+        None
+    };
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+/// Parse mypy text output.
+///
+/// Diagnostic format: `src/main.py:42: error: Incompatible types in assignment  [assignment]`
+/// Summary format: `Found 2 errors in 1 file (checked 5 source files)`
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    // Check for summary line to extract counts if diagnostics are absent
+    let mut found_summary_errors: Option<u32> = None;
+
+    for line in input.lines() {
+        if let Some(diag) = parse_text_line(line) {
+            match diag.severity {
+                Severity::Error => error_count += 1,
+                Severity::Warning => warning_count += 1,
+                Severity::Info => {}
+            }
+            diagnostics.push(diag);
+            continue;
+        }
+
+        // `Found N errors in M file(s)` or `Found N errors`
+        if let Some(n) = parse_summary_line(line) {
+            found_summary_errors = Some(n);
+        }
+    }
+
+    // If we got a summary but no diagnostics (e.g. abbreviated output), use summary counts
+    if diagnostics.is_empty() {
+        if let Some(n) = found_summary_errors {
+            error_count = n;
+        }
+    }
+
+    let summary = build_summary(error_count, warning_count);
+
+    ParsedOutput {
+        tool: "mypy",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Parse a single mypy text diagnostic line.
+///
+/// Format: `path.py:N: severity: message  [code]`
+fn parse_text_line(line: &str) -> Option<Diagnostic> {
+    if !looks_like_mypy_text_line(line) {
+        return None;
+    }
+
+    // Split on the first `: ` that follows a `path.py:N` prefix.
+    // Find `.py:digits:` pattern to locate the end of the location prefix.
+    let py_col = line.find(".py:")?;
+    let after_py = &line[py_col + 4..];
+    let colon_pos = after_py.find(':')?;
+    // `location_end` is the index in `line` of the `:` after the line number
+    let location_end = py_col + 4 + colon_pos;
+    let file = line[..py_col + 3].to_string(); // includes ".py"
+    let line_num: u32 = after_py[..colon_pos].trim().parse().ok()?;
+
+    // After `path.py:N:` we have ` severity: message  [code]`
+    let rest = line[location_end + 1..].trim_start();
+
+    let (severity_str, after_severity) = if let Some(r) = rest.strip_prefix("error:") {
+        ("error", r)
+    } else if let Some(r) = rest.strip_prefix("warning:") {
+        ("warning", r)
+    } else if let Some(r) = rest.strip_prefix("note:") {
+        ("note", r)
+    } else {
+        return None;
+    };
+
+    let severity = match severity_str {
+        "error" => Severity::Error,
+        "warning" => Severity::Warning,
+        _ => Severity::Info,
+    };
+
+    let message_raw = after_severity.trim();
+
+    // Extract optional `[code]` at the end of the message
+    let (message, name) = if message_raw.ends_with(']') {
+        if let Some(bracket_start) = message_raw.rfind("  [") {
+            let msg = message_raw[..bracket_start].trim().to_string();
+            let code = message_raw[bracket_start + 3..message_raw.len() - 1].to_string();
+            (msg, code)
+        } else {
+            (message_raw.to_string(), severity_str.to_string())
+        }
+    } else {
+        (message_raw.to_string(), severity_str.to_string())
+    };
+
+    Some(Diagnostic {
+        severity,
+        location: Some(Location {
+            file,
+            line: line_num,
+            column: None,
+        }),
+        name,
+        message,
+        detail: None,
+    })
+}
+
+/// Extract error count from `Found N errors in M file(s)` summary lines.
+fn parse_summary_line(line: &str) -> Option<u32> {
+    let rest = line.trim().strip_prefix("Found ")?;
+    let space = rest.find(' ')?;
+    rest[..space].parse().ok()
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn build_summary(errors: u32, warnings: u32) -> String {
+    if errors == 0 && warnings == 0 {
+        "no issues found".to_string()
+    } else {
+        format!("{errors} error(s), {warnings} warning(s)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_text() {
+        let sample = "src/main.py:42: error: Incompatible types in assignment  [assignment]\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects() {
+        let sample = "some random\noutput with no mypy markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_appends() {
+        let result = PARSER.rewrite("mypy src/");
+        assert_eq!(result, Some("mypy src/ --output=json".to_string()));
+    }
+
+    #[test]
+    fn rewrite_skips() {
+        let result = PARSER.rewrite("mypy src/ --output=json");
+        assert!(result.is_none());
+    }
+
+    // --- JSON path ---
+
+    #[test]
+    fn parse_json() {
+        let input = concat!(
+            r#"{"file": "src/main.py", "line": 42, "column": 5, "severity": "error", "message": "Incompatible types in assignment", "code": "assignment"}"#,
+            "\n",
+            r#"{"file": "src/main.py", "line": 43, "column": 1, "severity": "note", "message": "Expected \"int\", got \"str\"", "code": null}"#,
+            "\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.severity, Severity::Error);
+        assert_eq!(first.name, "assignment");
+        assert_eq!(first.message, "Incompatible types in assignment");
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/main.py")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(42));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.severity, Severity::Info);
+
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.counts.warnings, 0);
+        assert_eq!(out.summary, "1 error(s), 0 warning(s)");
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text() {
+        let input = concat!(
+            "src/main.py:42: error: Incompatible types in assignment  [assignment]\n",
+            "src/main.py:43: note: Expected \"int\", got \"str\"\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.severity, Severity::Error);
+        assert_eq!(first.name, "assignment");
+        assert_eq!(first.message, "Incompatible types in assignment");
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/main.py")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(42));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.severity, Severity::Info);
+
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.summary, "1 error(s), 0 warning(s)");
+    }
+
+    #[test]
+    fn parse_text_summary() {
+        // When mypy emits only a summary line (e.g., with --no-error-summary off),
+        // we should still capture the count.
+        let input = "Found 3 errors in 2 files (checked 10 source files)\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.errors, 3);
+        assert_eq!(out.summary, "3 error(s), 0 warning(s)");
+    }
+}

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -38,13 +38,6 @@ impl Parser for MypyParser {
             .any(looks_like_mypy_text_line)
     }
 
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--output") {
-            return None;
-        }
-        Some(format!("{command} --output=json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -344,20 +337,6 @@ mod tests {
     fn detect_rejects() {
         let sample = "some random\noutput with no mypy markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_appends() {
-        let result = PARSER.rewrite("mypy src/");
-        assert_eq!(result, Some("mypy src/ --output=json".to_string()));
-    }
-
-    #[test]
-    fn rewrite_skips() {
-        let result = PARSER.rewrite("mypy src/ --output=json");
-        assert!(result.is_none());
     }
 
     // --- JSON path ---

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -1,7 +1,9 @@
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{
+    build_lint_summary, parse_found_count, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -44,7 +46,10 @@ impl Parser for MypyParser {
         let trimmed = input.trim_start();
         if trimmed.starts_with('{') {
             let severity_finder = memmem::Finder::new(b"\"severity\"");
-            if severity_finder.find(trimmed.as_bytes()).is_some() {
+            let message_finder = memmem::Finder::new(b"\"message\"");
+            if severity_finder.find(trimmed.as_bytes()).is_some()
+                && message_finder.find(trimmed.as_bytes()).is_some()
+            {
                 return parse_json(input, raw_lines, raw_bytes);
             }
         }
@@ -117,7 +122,7 @@ fn parse_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
         diagnostics.push(diag);
     }
 
-    let summary = build_summary(error_count, warning_count);
+    let summary = build_lint_summary(error_count, warning_count);
 
     ParsedOutput {
         tool: "mypy",
@@ -208,7 +213,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
         }
 
         // `Found N errors in M file(s)` or `Found N errors`
-        if let Some(n) = parse_summary_line(line) {
+        if let Some(n) = parse_found_count(line) {
             found_summary_errors = Some(n);
         }
     }
@@ -220,7 +225,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
         }
     }
 
-    let summary = build_summary(error_count, warning_count);
+    let summary = build_lint_summary(error_count, warning_count);
 
     ParsedOutput {
         tool: "mypy",
@@ -278,7 +283,7 @@ fn parse_text_line(line: &str) -> Option<Diagnostic> {
 
     // Extract optional `[code]` at the end of the message
     let (message, name) = if message_raw.ends_with(']') {
-        if let Some(bracket_start) = message_raw.rfind("  [") {
+        if let Some(bracket_start) = message_raw.rfind("  [").or_else(|| message_raw.rfind(" [")) {
             let msg = message_raw[..bracket_start].trim().to_string();
             let code = message_raw[bracket_start + 3..message_raw.len() - 1].to_string();
             (msg, code)
@@ -300,25 +305,6 @@ fn parse_text_line(line: &str) -> Option<Diagnostic> {
         message,
         detail: None,
     })
-}
-
-/// Extract error count from `Found N errors in M file(s)` summary lines.
-fn parse_summary_line(line: &str) -> Option<u32> {
-    let rest = line.trim().strip_prefix("Found ")?;
-    let space = rest.find(' ')?;
-    rest[..space].parse().ok()
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-fn build_summary(errors: u32, warnings: u32) -> String {
-    if errors == 0 && warnings == 0 {
-        "no issues found".to_string()
-    } else {
-        format!("{errors} error(s), {warnings} warning(s)")
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -372,7 +358,7 @@ mod tests {
 
         assert_eq!(out.counts.errors, 1);
         assert_eq!(out.counts.warnings, 0);
-        assert_eq!(out.summary, "1 error(s), 0 warning(s)");
+        assert_eq!(out.summary, "1 error(s)");
     }
 
     // --- Text path ---
@@ -400,7 +386,7 @@ mod tests {
         assert_eq!(second.severity, Severity::Info);
 
         assert_eq!(out.counts.errors, 1);
-        assert_eq!(out.summary, "1 error(s), 0 warning(s)");
+        assert_eq!(out.summary, "1 error(s)");
     }
 
     #[test]
@@ -410,6 +396,6 @@ mod tests {
         let input = "Found 3 errors in 2 files (checked 10 source files)\n";
         let out = PARSER.parse(input);
         assert_eq!(out.counts.errors, 3);
-        assert_eq!(out.summary, "3 error(s), 0 warning(s)");
+        assert_eq!(out.summary, "3 error(s)");
     }
 }

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -278,11 +278,17 @@ fn parse_text_line(line: &str) -> Option<Diagnostic> {
 
     let message_raw = after_severity.trim();
 
-    // Extract optional `[code]` at the end of the message
+    // Extract optional `[code]` at the end of the message.
+    // Try double-space prefix first ("  ["), then single-space (" [").
+    // The offset to skip past the opening bracket differs: "  [" → +3, " [" → +2.
     let (message, name) = if message_raw.ends_with(']') {
-        if let Some(bracket_start) = message_raw.rfind("  [").or_else(|| message_raw.rfind(" [")) {
+        if let Some(bracket_start) = message_raw.rfind("  [") {
             let msg = message_raw[..bracket_start].trim().to_string();
             let code = message_raw[bracket_start + 3..message_raw.len() - 1].to_string();
+            (msg, code)
+        } else if let Some(bracket_start) = message_raw.rfind(" [") {
+            let msg = message_raw[..bracket_start].trim().to_string();
+            let code = message_raw[bracket_start + 2..message_raw.len() - 1].to_string();
             (msg, code)
         } else {
             (message_raw.to_string(), severity_str.to_string())
@@ -384,6 +390,21 @@ mod tests {
 
         assert_eq!(out.counts.errors, 1);
         assert_eq!(out.summary, "1 error(s)");
+    }
+
+    // Bug 6 regression: single-space " [code]" prefix must use offset +2, not +3.
+    // Without the fix, the extracted code would be "assignment]" (off-by-one).
+    #[test]
+    fn parse_text_single_space_bracket_code() {
+        let input = "src/main.py:10: error: Incompatible types [assignment]\n";
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(
+            diag.name, "assignment",
+            "code must not include leading space or bracket"
+        );
+        assert_eq!(diag.message, "Incompatible types");
     }
 
     #[test]

--- a/src/run/parsers/mypy.rs
+++ b/src/run/parsers/mypy.rs
@@ -2,7 +2,8 @@ use memchr::memmem;
 use serde_json::Value;
 
 use crate::run::types::{
-    build_lint_summary, parse_found_count, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    build_lint_summary, parse_found_count, Counts, DetectResult, Diagnostic, Location,
+    ParsedOutput, Severity,
 };
 
 use super::Parser;
@@ -16,7 +17,7 @@ impl Parser for MypyParser {
         "mypy"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // JSON fingerprint (mypy --output=json NDJSON): lines with "severity" + "message" + .py
@@ -27,34 +28,30 @@ impl Parser for MypyParser {
             && message_finder.find(bytes).is_some()
             && py_finder.find(bytes).is_some()
         {
-            return true;
+            return DetectResult::NdJson;
         }
 
         // Text fingerprint: `path.py:N: error:` or `path.py:N: warning:`
         let error_finder = memmem::Finder::new(b".py:");
         if error_finder.find(bytes).is_none() {
-            return false;
+            return DetectResult::NoMatch;
         }
-        sample.lines().any(looks_like_mypy_text_line)
+        if sample.lines().any(looks_like_mypy_text_line) {
+            DetectResult::Text
+        } else {
+            DetectResult::NoMatch
+        }
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
-        // Detect JSON vs text: look for NDJSON objects with "severity" key
-        let trimmed = input.trim_start();
-        if trimmed.starts_with('{') {
-            let severity_finder = memmem::Finder::new(b"\"severity\"");
-            let message_finder = memmem::Finder::new(b"\"message\"");
-            if severity_finder.find(trimmed.as_bytes()).is_some()
-                && message_finder.find(trimmed.as_bytes()).is_some()
-            {
-                return parse_json(input, raw_lines, raw_bytes);
-            }
+        if hint.is_json() {
+            parse_json(input, raw_lines, raw_bytes)
+        } else {
+            parse_text(input, raw_lines, raw_bytes)
         }
-
-        parse_text(input, raw_lines, raw_bytes)
     }
 }
 
@@ -170,10 +167,10 @@ fn extract_json_diagnostic(value: &Value) -> Option<Diagnostic> {
         .and_then(Value::as_u64)
         .map(|c| c as u32);
 
-    let location = if !file.is_empty() {
-        Some(Location { file, line, column })
-    } else {
+    let location = if file.is_empty() {
         None
+    } else {
+        Some(Location { file, line, column })
     };
 
     Some(Diagnostic {
@@ -320,13 +317,13 @@ mod tests {
     #[test]
     fn detect_text() {
         let sample = "src/main.py:42: error: Incompatible types in assignment  [assignment]\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects() {
         let sample = "some random\noutput with no mypy markers\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // --- JSON path ---
@@ -339,7 +336,7 @@ mod tests {
             r#"{"file": "src/main.py", "line": 43, "column": 1, "severity": "note", "message": "Expected \"int\", got \"str\"", "code": null}"#,
             "\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::NdJson);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -369,7 +366,7 @@ mod tests {
             "src/main.py:42: error: Incompatible types in assignment  [assignment]\n",
             "src/main.py:43: note: Expected \"int\", got \"str\"\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -394,8 +391,32 @@ mod tests {
         // When mypy emits only a summary line (e.g., with --no-error-summary off),
         // we should still capture the count.
         let input = "Found 3 errors in 2 files (checked 10 source files)\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.errors, 3);
         assert_eq!(out.summary, "3 error(s)");
+    }
+
+    // Bug 5 regression: ruff's weak fingerprint was before mypy in PARSERS, so
+    // mypy JSON output could be claimed by ruff if ruff matched first.
+    // With the strengthened ruff fingerprint (Bug 3 fix), mypy JSON must NOT be
+    // detected as ruff — mypy NDJSON uses "severity"/"message"/"file", not "filename"/"row".
+    #[test]
+    fn mypy_json_not_claimed_by_ruff() {
+        let mypy_json = concat!(
+            r#"{"file": "src/main.py", "line": 42, "column": 5, "severity": "error", "message": "Incompatible types in assignment", "code": "assignment"}"#,
+            "\n",
+        );
+        // ruff.detect() should NOT match mypy's NDJSON format.
+        let ruff_result = crate::run::parsers::ruff::PARSER.detect(mypy_json);
+        assert!(
+            !ruff_result.matched(),
+            "ruff should not claim mypy NDJSON output (mypy uses 'file'/'severity', not 'filename'/'location'/'row')"
+        );
+        // mypy.detect() should match.
+        let mypy_result = PARSER.detect(mypy_json);
+        assert!(
+            mypy_result.matched(),
+            "mypy should detect its own NDJSON output"
+        );
     }
 }

--- a/src/run/parsers/npm.rs
+++ b/src/run/parsers/npm.rs
@@ -26,11 +26,13 @@ impl Parser for NpmParser {
             return DetectResult::Text;
         }
 
-        // npm diagnostics
+        // npm diagnostics (both lowercase "npm warn" and legacy uppercase "npm WARN")
         let npm_warn = memmem::Finder::new("npm warn");
+        let npm_warn_upper = memmem::Finder::new("npm WARN");
         let npm_error = memmem::Finder::new("npm error");
         let npm_err_bang = memmem::Finder::new("npm ERR!");
         if npm_warn.find(bytes).is_some()
+            || npm_warn_upper.find(bytes).is_some()
             || npm_error.find(bytes).is_some()
             || npm_err_bang.find(bytes).is_some()
         {
@@ -218,6 +220,16 @@ mod tests {
     fn detect_yarn() {
         let sample = "[YN0000]: Done in 3s\nsuccess Saved lockfile.\n";
         assert!(PARSER.detect(sample).matched());
+    }
+
+    // Bug 9 regression: older npm emits "npm WARN" (uppercase). detect() must match it.
+    #[test]
+    fn detect_npm_warn_uppercase() {
+        let sample = "npm WARN deprecated inflight@1.0.6: This module is not supported\n";
+        assert!(
+            PARSER.detect(sample).matched(),
+            "detect() must match uppercase 'npm WARN'"
+        );
     }
 
     #[test]

--- a/src/run/parsers/npm.rs
+++ b/src/run/parsers/npm.rs
@@ -1,0 +1,308 @@
+use memchr::memmem;
+
+use crate::run::types::{
+    build_lint_summary, truncate_detail, Counts, DetectResult, Diagnostic, ParsedOutput, Severity,
+};
+
+use super::Parser;
+
+pub static PARSER: NpmParser = NpmParser;
+
+pub struct NpmParser;
+
+impl Parser for NpmParser {
+    fn name(&self) -> &'static str {
+        "npm-install"
+    }
+
+    /// Detect npm/pnpm/yarn install output via byte scanning — no regex.
+    fn detect(&self, sample: &str) -> DetectResult {
+        let bytes = sample.as_bytes();
+
+        // npm summary: "added N packages"
+        let added = memmem::Finder::new("added ");
+        let packages = memmem::Finder::new("packages");
+        if added.find(bytes).is_some() && packages.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        // npm diagnostics
+        let npm_warn = memmem::Finder::new("npm warn");
+        let npm_error = memmem::Finder::new("npm error");
+        let npm_err_bang = memmem::Finder::new("npm ERR!");
+        if npm_warn.find(bytes).is_some()
+            || npm_error.find(bytes).is_some()
+            || npm_err_bang.find(bytes).is_some()
+        {
+            return DetectResult::Text;
+        }
+
+        // pnpm fingerprints
+        let pnpm_ready = memmem::Finder::new("packages are ready");
+        let pnpm_progress = memmem::Finder::new("Progress:");
+        if pnpm_ready.find(bytes).is_some() || pnpm_progress.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        // yarn fingerprints
+        let yarn_lockfile = memmem::Finder::new("success Saved lockfile");
+        let yarn_yn = memmem::Finder::new("YN0000");
+        if yarn_lockfile.find(bytes).is_some() || yarn_yn.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
+    }
+
+    fn parse(&self, input: &str, _hint: DetectResult) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        let mut summary_line: Option<String> = None;
+        let mut audit_note: Option<String> = None;
+
+        // Finders for line classification.
+        let err_finder = memmem::Finder::new("npm ERR!");
+        let warn_finder = memmem::Finder::new("npm warn");
+        let warn_upper_finder = memmem::Finder::new("npm WARN");
+        let added_finder = memmem::Finder::new("added ");
+        let vuln_finder = memmem::Finder::new("vulnerabilit");
+
+        let mut err_block: Vec<String> = Vec::new();
+
+        let flush_err_block = |block: &mut Vec<String>, diags: &mut Vec<Diagnostic>| {
+            if block.is_empty() {
+                return;
+            }
+            let joined = block.join("\n");
+            let message = block.first().map_or_else(
+                || "npm error".to_string(),
+                |s| s.trim_start_matches("npm ERR!").trim().to_string(),
+            );
+            let detail = truncate_detail(&joined);
+            diags.push(Diagnostic {
+                severity: Severity::Error,
+                location: None,
+                name: "npm ERR!".to_string(),
+                message,
+                detail,
+            });
+            block.clear();
+        };
+
+        for line in input.lines() {
+            let bytes = line.as_bytes();
+
+            // Flush error block when we exit ERR! lines.
+            let is_err_line = err_finder.find(bytes).is_some();
+            if !is_err_line && !err_block.is_empty() {
+                flush_err_block(&mut err_block, &mut diagnostics);
+            }
+
+            if is_err_line {
+                err_block.push(line.to_string());
+                continue;
+            }
+
+            // npm warn / npm WARN — keep as warnings.
+            if warn_finder.find(bytes).is_some() || warn_upper_finder.find(bytes).is_some() {
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Warning,
+                    location: None,
+                    name: "npm warn".to_string(),
+                    message: line.trim().to_string(),
+                    detail: None,
+                });
+                continue;
+            }
+
+            // Audit summary line: "found N vulnerabilities"
+            if vuln_finder.find(bytes).is_some() {
+                audit_note = Some(line.trim().to_string());
+                continue;
+            }
+
+            // Install summary line: "added N packages in Xs"
+            if added_finder.find(bytes).is_some() && line.contains("package") {
+                summary_line = Some(line.trim().to_string());
+                continue;
+            }
+
+            // pnpm/yarn summary lines.
+            if line.contains("packages are ready")
+                || line.contains("success Saved lockfile")
+                || line.contains("Done in ")
+            {
+                summary_line = Some(line.trim().to_string());
+            }
+
+            // Everything else is noise (progress, resolution lines, etc.) — drop.
+        }
+
+        // Flush any trailing error block.
+        flush_err_block(&mut err_block, &mut diagnostics);
+
+        // Build summary.
+        let errors = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .count() as u32;
+        let warnings = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Warning)
+            .count() as u32;
+
+        let summary = if let Some(s) = summary_line {
+            let base = if errors > 0 || warnings > 0 {
+                format!("{s}; {}", build_lint_summary(errors, warnings))
+            } else {
+                s
+            };
+            if let Some(audit) = audit_note {
+                format!("{base}; {audit}")
+            } else {
+                base
+            }
+        } else if errors > 0 || warnings > 0 {
+            build_lint_summary(errors, warnings)
+        } else {
+            "install complete".to_string()
+        };
+
+        ParsedOutput {
+            tool: "npm-install",
+            summary,
+            diagnostics,
+            counts: Counts {
+                warnings,
+                errors,
+                ..Counts::default()
+            },
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_npm_summary() {
+        let sample = "added 150 packages in 5s\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_npm_err_bang() {
+        let sample = "npm ERR! code ERESOLVE\nnpm ERR! could not resolve\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_pnpm() {
+        let sample = "Progress: resolved 200, reused 150, downloaded 10\npackages are ready\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_yarn() {
+        let sample = "[YN0000]: Done in 3s\nsuccess Saved lockfile.\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building project...\nCompiling foo\nDone!\n";
+        assert!(!PARSER.detect(sample).matched());
+    }
+
+    // -- Parse ---------------------------------------------------------------
+
+    #[test]
+    fn parse_clean_install() {
+        let input = concat!(
+            "added 150 packages, and audited 151 packages in 5s\n",
+            "\n",
+            "29 packages are looking for funding\n",
+            "  run `npm fund` for details\n",
+            "\n",
+            "found 0 vulnerabilities\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.tool, "npm-install");
+        assert_eq!(out.counts.errors, 0);
+        assert_eq!(out.counts.warnings, 0);
+        assert!(out.diagnostics.is_empty());
+        assert!(
+            out.summary.contains("added 150 packages"),
+            "summary: {}",
+            out.summary
+        );
+    }
+
+    #[test]
+    fn parse_with_warnings() {
+        let input = concat!(
+            "npm warn deprecated inflight@1.0.6: This module is not supported\n",
+            "npm warn deprecated rimraf@2.7.1: Rimraf versions prior to v4 are no longer supported\n",
+            "added 200 packages in 8s\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.counts.warnings, 2);
+        assert_eq!(out.counts.errors, 0);
+        assert_eq!(out.diagnostics.len(), 2);
+        assert!(out
+            .diagnostics
+            .iter()
+            .all(|d| d.severity == Severity::Warning));
+        assert!(
+            out.summary.contains("added 200 packages"),
+            "summary: {}",
+            out.summary
+        );
+    }
+
+    #[test]
+    fn parse_with_errors() {
+        let input = concat!(
+            "npm ERR! code ERESOLVE\n",
+            "npm ERR! ERESOLVE unable to resolve dependency tree\n",
+            "npm ERR!\n",
+            "npm ERR! While resolving: my-app@1.0.0\n",
+            "npm ERR! Found: react@18.0.0\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(diag.detail.is_some());
+        let detail = diag.detail.as_ref().unwrap();
+        assert!(detail.contains("ERESOLVE"));
+    }
+
+    #[test]
+    fn parse_audit_vulnerabilities() {
+        let input = concat!(
+            "added 100 packages in 3s\n",
+            "\n",
+            "3 vulnerabilities (1 moderate, 2 high)\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert!(
+            out.summary.contains("3 vulnerabilit"),
+            "summary: {}",
+            out.summary
+        );
+    }
+}

--- a/src/run/parsers/pip.rs
+++ b/src/run/parsers/pip.rs
@@ -1,0 +1,314 @@
+use memchr::memmem;
+
+use crate::run::types::{
+    build_lint_summary, truncate_detail, Counts, DetectResult, Diagnostic, ParsedOutput, Severity,
+};
+
+use super::Parser;
+
+pub static PARSER: PipParser = PipParser;
+
+pub struct PipParser;
+
+impl Parser for PipParser {
+    fn name(&self) -> &'static str {
+        "pip-install"
+    }
+
+    /// Detect pip install output via byte scanning — no regex.
+    fn detect(&self, sample: &str) -> DetectResult {
+        let bytes = sample.as_bytes();
+
+        // Successful install summary
+        let success = memmem::Finder::new("Successfully installed");
+        if success.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        // Already satisfied (common in incremental installs)
+        let satisfied = memmem::Finder::new("Requirement already satisfied");
+        if satisfied.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        // Download progress — pip-specific prefix before a package name
+        let collecting = memmem::Finder::new("Collecting ");
+        let downloading = memmem::Finder::new("Downloading ");
+        let cached = memmem::Finder::new("Using cached ");
+        if collecting.find(bytes).is_some()
+            && (downloading.find(bytes).is_some() || cached.find(bytes).is_some())
+        {
+            return DetectResult::Text;
+        }
+
+        // pip error prefix
+        let error = memmem::Finder::new("ERROR: ");
+        if error.find(bytes).is_some() {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
+    }
+
+    fn parse(&self, input: &str, _hint: DetectResult) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        let mut installed_packages: Vec<&str> = Vec::new();
+        let mut collecting_count: u32 = 0;
+        let mut already_satisfied_count: u32 = 0;
+
+        // Finders for line classification.
+        let success_finder = memmem::Finder::new("Successfully installed");
+        let satisfied_finder = memmem::Finder::new("Requirement already satisfied");
+        let collecting_finder = memmem::Finder::new("Collecting ");
+        let error_finder = memmem::Finder::new("ERROR: ");
+
+        let mut err_block: Vec<String> = Vec::new();
+
+        let flush_err_block = |block: &mut Vec<String>, diags: &mut Vec<Diagnostic>| {
+            if block.is_empty() {
+                return;
+            }
+            let joined = block.join("\n");
+            let message = block.first().map_or_else(
+                || "pip error".to_string(),
+                |s| s.trim_start_matches("ERROR:").trim().to_string(),
+            );
+            let detail = if block.len() > 1 {
+                truncate_detail(&joined)
+            } else {
+                None
+            };
+            diags.push(Diagnostic {
+                severity: Severity::Error,
+                location: None,
+                name: "ERROR".to_string(),
+                message,
+                detail,
+            });
+            block.clear();
+        };
+
+        for line in input.lines() {
+            let bytes = line.as_bytes();
+
+            // Flush error block when we leave ERROR lines.
+            let is_error_line = error_finder.find(bytes).is_some();
+            if !is_error_line && !err_block.is_empty() {
+                flush_err_block(&mut err_block, &mut diagnostics);
+            }
+
+            if is_error_line {
+                err_block.push(line.to_string());
+                continue;
+            }
+
+            // "Successfully installed pkg1-1.0 pkg2-2.0 ..."
+            if success_finder.find(bytes).is_some() {
+                if let Some(rest) = line.find("Successfully installed").map(|i| &line[i + 22..]) {
+                    installed_packages = rest.split_whitespace().collect();
+                }
+                continue;
+            }
+
+            // "Requirement already satisfied: ..." — count only, don't keep lines.
+            if satisfied_finder.find(bytes).is_some() {
+                already_satisfied_count += 1;
+                continue;
+            }
+
+            // "Collecting <pkg>" — count only; rest are noise — drop.
+            if collecting_finder.find(bytes).is_some() {
+                collecting_count += 1;
+            }
+        }
+
+        // Flush trailing error block.
+        flush_err_block(&mut err_block, &mut diagnostics);
+
+        // Build summary.
+        let errors = diagnostics
+            .iter()
+            .filter(|d| d.severity == Severity::Error)
+            .count() as u32;
+
+        let summary = build_install_summary(
+            &installed_packages,
+            already_satisfied_count,
+            collecting_count,
+            errors,
+        );
+
+        ParsedOutput {
+            tool: "pip-install",
+            summary,
+            diagnostics,
+            counts: Counts {
+                errors,
+                ..Counts::default()
+            },
+            duration_secs: None,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn build_install_summary(
+    installed: &[&str],
+    already_satisfied: u32,
+    collected: u32,
+    errors: u32,
+) -> String {
+    let mut parts: Vec<String> = Vec::new();
+
+    if !installed.is_empty() {
+        parts.push(format!("installed {} package(s)", installed.len()));
+    } else if collected > 0 {
+        parts.push(format!("collected {collected} package(s)"));
+    }
+
+    if already_satisfied > 0 {
+        parts.push(format!("{already_satisfied} already satisfied"));
+    }
+
+    if errors > 0 {
+        parts.push(build_lint_summary(errors, 0));
+    }
+
+    if parts.is_empty() {
+        "install complete".to_string()
+    } else {
+        parts.join("; ")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_successfully_installed() {
+        let sample = "Successfully installed requests-2.28.0 certifi-2022.12.7\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_requirement_satisfied() {
+        let sample = "Requirement already satisfied: pip in /usr/lib/python3/dist-packages\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_collecting_and_downloading() {
+        let sample = concat!(
+            "Collecting requests==2.28.0\n",
+            "  Downloading requests-2.28.0-py3-none-any.whl (62 kB)\n",
+        );
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_pip_error() {
+        let sample =
+            "ERROR: Could not find a version that satisfies the requirement nonexistent==0.0.0\n";
+        assert!(PARSER.detect(sample).matched());
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building project...\nCompiling foo\nDone!\n";
+        assert!(!PARSER.detect(sample).matched());
+    }
+
+    // -- Parse ---------------------------------------------------------------
+
+    #[test]
+    fn parse_clean_install() {
+        let input = concat!(
+            "Collecting requests==2.28.0\n",
+            "  Downloading requests-2.28.0-py3-none-any.whl (62 kB)\n",
+            "Collecting certifi>=2017.4.17\n",
+            "  Using cached certifi-2022.12.7-py3-none-any.whl (155 kB)\n",
+            "Installing collected packages: certifi, requests\n",
+            "Successfully installed certifi-2022.12.7 requests-2.28.0\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.tool, "pip-install");
+        assert_eq!(out.counts.errors, 0);
+        assert!(out.diagnostics.is_empty());
+        assert!(
+            out.summary.contains("installed 2 package(s)"),
+            "summary: {}",
+            out.summary
+        );
+    }
+
+    #[test]
+    fn parse_already_satisfied() {
+        let input = concat!(
+            "Requirement already satisfied: requests in /usr/lib/python3/dist-packages\n",
+            "Requirement already satisfied: certifi in /usr/lib/python3/dist-packages\n",
+            "Requirement already satisfied: urllib3 in /usr/lib/python3/dist-packages\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.counts.errors, 0);
+        assert!(out.diagnostics.is_empty());
+        assert!(
+            out.summary.contains("3 already satisfied"),
+            "summary: {}",
+            out.summary
+        );
+    }
+
+    #[test]
+    fn parse_with_error() {
+        let input = concat!(
+            "Collecting nonexistent==0.0.0\n",
+            "ERROR: No matching distribution found for nonexistent==0.0.0\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(
+            diag.message.contains("No matching distribution"),
+            "message: {}",
+            diag.message
+        );
+    }
+
+    #[test]
+    fn parse_dependency_conflict() {
+        let input = concat!(
+            "Collecting package-a==1.0\n",
+            "ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.\n",
+            "package-b 2.0 requires package-a>=2.0, but you have package-a 1.0 which is incompatible.\n",
+            "Successfully installed package-a-1.0\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // Should have one error for the dependency conflict.
+        assert_eq!(out.counts.errors, 1);
+        assert_eq!(out.diagnostics.len(), 1);
+        assert_eq!(out.diagnostics[0].severity, Severity::Error);
+        // And still report the successful install.
+        assert!(
+            out.summary.contains("installed 1 package(s)"),
+            "summary: {}",
+            out.summary
+        );
+    }
+}

--- a/src/run/parsers/pytest.rs
+++ b/src/run/parsers/pytest.rs
@@ -37,14 +37,6 @@ impl Parser for PytestParser {
         false
     }
 
-    /// Append `--tb=short -q` when no `--tb=` flag is already present.
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--tb=") {
-            return None;
-        }
-        Some(format!("{command} --tb=short -q"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         // JSON is only available with the pytest-json-report plugin — very rare.
         // Attempt it opportunistically; fall through to text parsing otherwise.
@@ -483,20 +475,6 @@ mod tests {
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo\nDone in 1.2s";
         assert!(!PARSER.detect(sample));
-    }
-
-    // -- Rewrite -------------------------------------------------------------
-
-    #[test]
-    fn rewrite_appends_tb_short() {
-        let result = PARSER.rewrite("pytest tests/");
-        assert_eq!(result, Some("pytest tests/ --tb=short -q".to_string()));
-    }
-
-    #[test]
-    fn rewrite_skips_if_present() {
-        let result = PARSER.rewrite("pytest tests/ --tb=long");
-        assert!(result.is_none());
     }
 
     // -- Text parse ----------------------------------------------------------

--- a/src/run/parsers/pytest.rs
+++ b/src/run/parsers/pytest.rs
@@ -114,12 +114,14 @@ impl PytestParser {
             }
         }
 
-        let summary_str = build_summary(passed, failed, skipped, errors);
+        // pytest "errors" (collection/fixture errors) are test-runner failures,
+        // not compilation errors. Fold them into `failed` per Counts convention.
+        let failed = failed + errors;
+        let summary_str = build_summary(passed, failed, skipped);
         let counts = Counts {
             passed,
             failed,
             skipped,
-            errors,
             ..Counts::default()
         };
 
@@ -247,15 +249,13 @@ impl PytestParser {
             finish_block(name, &failure_block_lines, &mut diagnostics);
         }
 
-        let summary_str = build_summary(passed, failed, skipped, 0);
+        let summary_str = build_summary(passed, failed, skipped);
+        // pytest is a test runner — leave `errors` at 0. All pytest "errors"
+        // (collection/fixture errors) are folded into `failed` via the banner parser.
         let counts = Counts {
             passed,
             failed,
             skipped,
-            errors: diagnostics
-                .iter()
-                .filter(|d| d.severity == Severity::Error)
-                .count() as u32,
             ..Counts::default()
         };
 
@@ -334,6 +334,10 @@ fn parse_summary_line(line: &str) -> Option<Diagnostic> {
 /// Parse the pytest final summary banner, returning (passed, failed, skipped, duration).
 ///
 /// Example: `====== 2 failed, 5 passed, 1 skipped in 0.42s ======`
+/// Example: `====== 1 failed, 2 passed, 1 error in 0.5s ======`
+///
+/// pytest "errors" (collection/fixture errors) are folded into `failed` per the
+/// `Counts` convention: test runners use `failed`, not `errors`.
 fn parse_summary_banner(line: &str) -> Option<(u32, u32, u32, Option<f64>)> {
     // Only process lines that look like summary banners — they must contain
     // at least one of these result keywords.
@@ -343,12 +347,14 @@ fn parse_summary_banner(line: &str) -> Option<(u32, u32, u32, Option<f64>)> {
 
     let passed = extract_count(line, "passed").unwrap_or(0);
     let failed = extract_count(line, "failed").unwrap_or(0);
+    // "error" in the banner means collection/fixture errors — fold into failed.
+    let errors = extract_count(line, "error").unwrap_or(0);
     let skipped = extract_count(line, "skipped")
         .or_else(|| extract_count(line, "deselected"))
         .unwrap_or(0);
     let duration = extract_duration(line);
 
-    Some((passed, failed, skipped, duration))
+    Some((passed, failed + errors, skipped, duration))
 }
 
 /// Extract the duration value from a string like `in 0.42s`.
@@ -418,7 +424,7 @@ fn parse_nodeid_location(_nodeid: &str) -> Option<Location> {
 }
 
 /// Build a human-readable summary, omitting zero categories except `passed`.
-fn build_summary(passed: u32, failed: u32, skipped: u32, errors: u32) -> String {
+fn build_summary(passed: u32, failed: u32, skipped: u32) -> String {
     let mut parts: Vec<String> = Vec::new();
     parts.push(format!("{passed} passed"));
     if failed > 0 {
@@ -426,9 +432,6 @@ fn build_summary(passed: u32, failed: u32, skipped: u32, errors: u32) -> String 
     }
     if skipped > 0 {
         parts.push(format!("{skipped} skipped"));
-    }
-    if errors > 0 {
-        parts.push(format!("{errors} errors"));
     }
     parts.join(", ")
 }
@@ -545,6 +548,34 @@ mod tests {
     // for node IDs that have no line info. Now it returns None, and the summary-line
     // parser gets no location (which is honest), while the block parser correctly
     // extracts the real line number from block content.
+    // Bug 12 regression: pytest "errors" (collection/fixture errors) must be folded
+    // into `failed`, not placed in `counts.errors`. Test runners leave `errors` at 0.
+    #[test]
+    fn parse_text_errors_fold_into_failed() {
+        // Banner with both `failed` and `error` counts.
+        let input = concat!(
+            "collected 3 items\n",
+            "\n",
+            "=========================== short test summary info ============================\n",
+            "FAILED tests/test_foo.py::test_one - AssertionError: 1 != 2\n",
+            "ERROR tests/test_bar.py::test_setup - fixture 'missing_fixture' not found\n",
+            "=================== 1 failed, 1 passed, 1 error in 0.15s ===================\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        // The banner has 1 failed + 1 error → both fold into failed = 2.
+        assert_eq!(
+            out.counts.failed, 2,
+            "pytest errors should fold into failed"
+        );
+        assert_eq!(out.counts.errors, 0, "test runner must leave errors at 0");
+        assert_eq!(out.counts.passed, 1);
+        assert!(
+            out.summary.contains("2 failed"),
+            "summary should reflect folded count; got: {}",
+            out.summary
+        );
+    }
+
     #[test]
     fn parse_nodeid_location_returns_none() {
         // Calling parse_nodeid_location directly should return None — not line 0.

--- a/src/run/parsers/pytest.rs
+++ b/src/run/parsers/pytest.rs
@@ -1,7 +1,8 @@
 use memchr::memmem;
 
 use crate::run::types::{
-    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    extract_count, truncate_detail, Counts, DetectResult, Diagnostic, Location, ParsedOutput,
+    Severity,
 };
 
 use super::Parser;
@@ -19,13 +20,13 @@ impl Parser for PytestParser {
     ///
     /// Accepts the short test summary section header, or the pytest summary
     /// banner line (`=====` with `passed`/`failed`).
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
         // Unambiguous: pytest's short test summary info section header.
         let short_summary = memmem::Finder::new("short test summary info");
         if short_summary.find(bytes).is_some() {
-            return true;
+            return DetectResult::Text;
         }
 
         // Banner line fingerprint: `=====` AND (`passed` OR `failed`).
@@ -33,36 +34,47 @@ impl Parser for PytestParser {
         if equals.find(bytes).is_some() {
             let passed = memmem::Finder::new("passed");
             let failed = memmem::Finder::new("failed");
-            return passed.find(bytes).is_some() || failed.find(bytes).is_some();
+            if passed.find(bytes).is_some() || failed.find(bytes).is_some() {
+                return DetectResult::Text;
+            }
         }
 
-        false
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
-        // JSON is only available with the pytest-json-report plugin — very rare.
-        // Attempt it opportunistically; fall through to text parsing otherwise.
-        let trimmed = input.trim_start();
-        if trimmed.starts_with('{') {
-            if let Some(parsed) = self.try_json(input) {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
+        if hint.is_json() {
+            if let Some(parsed) = PytestParser::try_json(input) {
                 return parsed;
             }
         }
-        self.parse_text(input)
+        PytestParser::parse_text(input)
     }
 }
 
 impl PytestParser {
     /// Opportunistic JSON parse for pytest-json-report output.
-    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+    fn try_json(input: &str) -> Option<ParsedOutput> {
         let value: serde_json::Value = serde_json::from_str(input).ok()?;
         let summary = value.get("summary")?;
 
-        let passed = summary.get("passed").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-        let failed = summary.get("failed").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-        let skipped = summary.get("skipped").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-        let errors = summary.get("error").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
-        let duration_secs = value.get("duration").and_then(|v| v.as_f64());
+        let passed = summary
+            .get("passed")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32;
+        let failed = summary
+            .get("failed")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32;
+        let skipped = summary
+            .get("skipped")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32;
+        let errors = summary
+            .get("error")
+            .and_then(serde_json::Value::as_u64)
+            .unwrap_or(0) as u32;
+        let duration_secs = value.get("duration").and_then(serde_json::Value::as_f64);
 
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
         if let Some(tests) = value.get("tests").and_then(|v| v.as_array()) {
@@ -122,7 +134,7 @@ impl PytestParser {
         })
     }
 
-    fn parse_text(&self, input: &str) -> ParsedOutput {
+    fn parse_text(input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
         let lines: Vec<&str> = input.lines().collect();
@@ -386,28 +398,23 @@ fn extract_error_message(block: &str) -> String {
     // Fallback: first non-empty, non-separator line.
     block
         .lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .find(|l| !l.is_empty() && !l.starts_with('>') && !l.starts_with('-'))
         .unwrap_or("test failed")
         .to_string()
 }
 
-/// Parse a pytest node id like `tests/test_foo.py::test_bar` into a Location.
-fn parse_nodeid_location(nodeid: &str) -> Option<Location> {
-    // Strip the `::test_name` suffix, leaving just the file path.
-    let file = if let Some(pos) = nodeid.find("::") {
-        &nodeid[..pos]
-    } else {
-        nodeid
-    };
-    if file.is_empty() || !file.ends_with(".py") {
-        return None;
-    }
-    Some(Location {
-        file: file.to_string(),
-        line: 0,
-        column: None,
-    })
+/// Extract the file path from a pytest node id like `tests/test_foo.py::test_bar`.
+///
+/// Returns `None` — node IDs contain no line number information. Callers that
+/// need a location should use `Location::scan_text` on the failure block content
+/// instead. This function intentionally returns `None` rather than creating a
+/// `Location { line: 0 }` which would be misleading.
+fn parse_nodeid_location(_nodeid: &str) -> Option<Location> {
+    // Node IDs have the form `path/to/file.py::ClassName::test_method`.
+    // They do NOT carry line numbers. We return None so callers fall back to
+    // Location::scan_text on block content (which has real line info).
+    None
 }
 
 /// Build a human-readable summary, omitting zero categories except `passed`.
@@ -439,19 +446,19 @@ mod tests {
     #[test]
     fn detect_summary_with_equals() {
         let sample = "collected 3 items\n\n============================== 2 passed, 1 failed in 0.12s ==============================";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_short_test_summary() {
         let sample = "=========================== short test summary info ============================\nFAILED tests/test_foo.py::test_bar - AssertionError: 1 != 2";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects_generic() {
         let sample = "Building project...\nCompiling foo\nDone in 1.2s";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // -- Text parse ----------------------------------------------------------
@@ -465,7 +472,7 @@ mod tests {
             "\n",
             "============================== 5 passed in 0.23s ==============================\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.tool, "pytest");
         assert_eq!(out.counts.passed, 5);
         assert_eq!(out.counts.failed, 0);
@@ -486,7 +493,7 @@ mod tests {
             "FAILED tests/test_foo.py::test_mul - AssertionError: 3 != 4\n",
             "========================= 2 failed, 1 passed in 0.05s =========================\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.passed, 1);
         assert_eq!(out.counts.failed, 2);
         assert_eq!(out.diagnostics.len(), 2);
@@ -513,7 +520,7 @@ mod tests {
             "FAILED tests/test_foo.py::test_add - AssertionError: assert 3 == 4\n",
             "============================== 1 failed in 0.07s ==============================\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.failed, 1);
         // The block-based diagnostic is preferred over the summary line.
         assert_eq!(out.diagnostics.len(), 1);
@@ -532,5 +539,45 @@ mod tests {
             .expect("location should be extracted");
         assert_eq!(loc.file, "tests/test_foo.py");
         assert_eq!(loc.line, 10);
+    }
+
+    // Bug 4 regression: parse_nodeid_location used to return Location { line: 0 }
+    // for node IDs that have no line info. Now it returns None, and the summary-line
+    // parser gets no location (which is honest), while the block parser correctly
+    // extracts the real line number from block content.
+    #[test]
+    fn parse_nodeid_location_returns_none() {
+        // Calling parse_nodeid_location directly should return None — not line 0.
+        assert!(
+            parse_nodeid_location("tests/test_foo.py::TestClass::test_method").is_none(),
+            "node ID with no line number should return None, not Location {{ line: 0 }}"
+        );
+        assert!(
+            parse_nodeid_location("tests/test_foo.py::test_method").is_none(),
+            "simple node ID should also return None"
+        );
+    }
+
+    #[test]
+    fn parse_summary_line_has_no_line_number() {
+        // A FAILED summary line without a block produces a diagnostic with no location
+        // (since node IDs have no line info and there is no block content to scan).
+        let input = concat!(
+            "=========================== short test summary info ============================\n",
+            "FAILED tests/test_foo.py::test_bar - AssertionError: assert 1 == 2\n",
+            "============================== 1 failed in 0.01s ==============================\n",
+        );
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        // location is None (no block content) — NOT Some(Location { line: 0 })
+        if let Some(loc) = &diag.location {
+            assert_ne!(
+                loc.line, 0,
+                "location line should not be 0; use None instead"
+            );
+        }
+        // name is the full node id
+        assert_eq!(diag.name, "tests/test_foo.py::test_bar");
     }
 }

--- a/src/run/parsers/pytest.rs
+++ b/src/run/parsers/pytest.rs
@@ -1,0 +1,578 @@
+use memchr::memmem;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+
+use super::Parser;
+
+pub static PARSER: PytestParser = PytestParser;
+
+pub struct PytestParser;
+
+impl Parser for PytestParser {
+    fn name(&self) -> &'static str {
+        "pytest"
+    }
+
+    /// Detect pytest output via byte scanning — no regex.
+    ///
+    /// Accepts the short test summary section header, or the pytest summary
+    /// banner line (`=====` with `passed`/`failed`).
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // Unambiguous: pytest's short test summary info section header.
+        let short_summary = memmem::Finder::new("short test summary info");
+        if short_summary.find(bytes).is_some() {
+            return true;
+        }
+
+        // Banner line fingerprint: `=====` AND (`passed` OR `failed`).
+        let equals = memmem::Finder::new("=====");
+        if equals.find(bytes).is_some() {
+            let passed = memmem::Finder::new("passed");
+            let failed = memmem::Finder::new("failed");
+            return passed.find(bytes).is_some() || failed.find(bytes).is_some();
+        }
+
+        false
+    }
+
+    /// Append `--tb=short -q` when no `--tb=` flag is already present.
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--tb=") {
+            return None;
+        }
+        Some(format!("{command} --tb=short -q"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        // JSON is only available with the pytest-json-report plugin — very rare.
+        // Attempt it opportunistically; fall through to text parsing otherwise.
+        let trimmed = input.trim_start();
+        if trimmed.starts_with('{') {
+            if let Some(parsed) = self.try_json(input) {
+                return parsed;
+            }
+        }
+        self.parse_text(input)
+    }
+}
+
+impl PytestParser {
+    /// Opportunistic JSON parse for pytest-json-report output.
+    fn try_json(&self, input: &str) -> Option<ParsedOutput> {
+        let value: serde_json::Value = serde_json::from_str(input).ok()?;
+        let summary = value.get("summary")?;
+
+        let passed = summary
+            .get("passed")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let failed = summary
+            .get("failed")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let skipped = summary
+            .get("skipped")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let errors = summary
+            .get("error")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0) as u32;
+        let duration_secs = value
+            .get("duration")
+            .and_then(|v| v.as_f64());
+
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+        if let Some(tests) = value.get("tests").and_then(|v| v.as_array()) {
+            for test in tests {
+                let outcome = test
+                    .get("outcome")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                if outcome != "failed" && outcome != "error" {
+                    continue;
+                }
+                let name = test
+                    .get("nodeid")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("<unknown>")
+                    .to_string();
+                let call = test.get("call");
+                let message = call
+                    .and_then(|c| c.get("longrepr"))
+                    .and_then(|v| v.as_str())
+                    .and_then(|s| s.lines().next())
+                    .unwrap_or("test failed")
+                    .to_string();
+                let location = test
+                    .get("nodeid")
+                    .and_then(|v| v.as_str())
+                    .and_then(parse_nodeid_location);
+                let raw_detail = call
+                    .and_then(|c| c.get("longrepr"))
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("");
+                let detail = truncate_detail(raw_detail);
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    location,
+                    name,
+                    message,
+                    detail,
+                });
+            }
+        }
+
+        let summary_str = build_summary(passed, failed, skipped, errors);
+        let counts = Counts {
+            passed,
+            failed,
+            skipped,
+            errors,
+            ..Counts::default()
+        };
+
+        Some(ParsedOutput {
+            tool: "pytest",
+            summary: summary_str,
+            diagnostics,
+            counts,
+            duration_secs,
+            raw_lines: input.lines().count(),
+            raw_bytes: input.len(),
+        })
+    }
+
+    fn parse_text(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+        let lines: Vec<&str> = input.lines().collect();
+
+        let mut passed: u32 = 0;
+        let mut failed: u32 = 0;
+        let mut skipped: u32 = 0;
+        let mut duration_secs: Option<f64> = None;
+        let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+        // Single pass: classify each line by state.
+        let mut in_short_summary = false;
+        let mut failure_block_name: Option<String> = None;
+        let mut failure_block_lines: Vec<&str> = Vec::new();
+
+        let finish_block =
+            |name: &str, block_lines: &[&str], diagnostics: &mut Vec<Diagnostic>| {
+                let block = block_lines.join("\n");
+                let message = extract_error_message(&block);
+                let location = Location::scan_text(&block);
+                let detail = truncate_detail(&block);
+                diagnostics.push(Diagnostic {
+                    severity: Severity::Error,
+                    location,
+                    name: name.to_string(),
+                    message,
+                    detail,
+                });
+            };
+
+        for line in &lines {
+            // Detect `___ test_name ___` failure block headers.
+            if let Some(block_name) = parse_pytest_block_header(line) {
+                // Finish any open block first.
+                if let Some(ref name) = failure_block_name {
+                    finish_block(name, &failure_block_lines, &mut diagnostics);
+                }
+                failure_block_name = Some(block_name);
+                failure_block_lines = Vec::new();
+                in_short_summary = false;
+                continue;
+            }
+
+            // Detect the short test summary section header.
+            // e.g. `========= short test summary info =========`
+            if line.contains("short test summary info") {
+                // Close any open block.
+                if let Some(ref name) = failure_block_name {
+                    finish_block(name, &failure_block_lines, &mut diagnostics);
+                    failure_block_name = None;
+                    failure_block_lines = Vec::new();
+                }
+                in_short_summary = true;
+                continue;
+            }
+
+            // A banner line (`====...====`) that isn't the summary section header
+            // ends the short summary section (or ends a block).
+            if is_banner_line(line) {
+                if let Some(ref name) = failure_block_name {
+                    finish_block(name, &failure_block_lines, &mut diagnostics);
+                    failure_block_name = None;
+                    failure_block_lines = Vec::new();
+                }
+                in_short_summary = false;
+
+                // Try to parse the overall summary from this banner line.
+                // e.g. `======= 2 failed, 5 passed, 1 skipped in 0.42s =======`
+                if let Some(result) = parse_summary_banner(line) {
+                    passed = result.0;
+                    failed = result.1;
+                    skipped = result.2;
+                    duration_secs = result.3;
+                }
+                continue;
+            }
+
+            // Accumulate failure block content.
+            if failure_block_name.is_some() {
+                failure_block_lines.push(line);
+                continue;
+            }
+
+            // Parse short test summary lines.
+            // e.g. `FAILED tests/test_foo.py::test_bar - AssertionError: x != y`
+            // e.g. `ERROR tests/test_foo.py::test_bar`
+            if in_short_summary {
+                if let Some(diag) = parse_summary_line(line) {
+                    // Only add if we haven't already captured this test via a block.
+                    // Prefer block-based diagnostics (richer detail); the summary
+                    // line is used as fallback if there was no block.
+                    //
+                    // Block names come from `___ test_name ___` headers (just the
+                    // function name), while summary names are full node ids like
+                    // `tests/foo.py::test_name`.  Match on the trailing component.
+                    let fn_name = diag
+                        .name
+                        .rsplit("::")
+                        .next()
+                        .unwrap_or(&diag.name);
+                    let already_captured = diagnostics
+                        .iter()
+                        .any(|d| d.name == diag.name || d.name == fn_name || diag.name.ends_with(&format!("::{}", d.name)));
+                    if !already_captured {
+                        diagnostics.push(diag);
+                    }
+                }
+            }
+        }
+
+        // Close any trailing open block.
+        if let Some(ref name) = failure_block_name {
+            finish_block(name, &failure_block_lines, &mut diagnostics);
+        }
+
+        let summary_str = build_summary(passed, failed, skipped, 0);
+        let counts = Counts {
+            passed,
+            failed,
+            skipped,
+            errors: diagnostics
+                .iter()
+                .filter(|d| d.severity == Severity::Error)
+                .count() as u32,
+            ..Counts::default()
+        };
+
+        ParsedOutput {
+            tool: "pytest",
+            summary: summary_str,
+            diagnostics,
+            counts,
+            duration_secs,
+            raw_lines,
+            raw_bytes,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true if a line is a pytest banner (`=====...=====`).
+fn is_banner_line(line: &str) -> bool {
+    let trimmed = line.trim();
+    trimmed.starts_with("====") && trimmed.ends_with("====") && trimmed.len() >= 8
+}
+
+/// Parse a pytest failure/section block header of the form `___ name ___`.
+///
+/// Returns the name between the underscores, or `None` if the line doesn't
+/// match.
+fn parse_pytest_block_header(line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    if !trimmed.starts_with("___") || !trimmed.ends_with("___") || trimmed.len() < 7 {
+        return None;
+    }
+    let inner = trimmed
+        .trim_start_matches('_')
+        .trim_end_matches('_')
+        .trim();
+    if inner.is_empty() {
+        return None;
+    }
+    Some(inner.to_string())
+}
+
+/// Parse a short test summary line.
+///
+/// Handled formats:
+/// - `FAILED tests/foo.py::test_bar - AssertionError: something`
+/// - `ERROR tests/foo.py::test_bar`
+fn parse_summary_line(line: &str) -> Option<Diagnostic> {
+    let trimmed = line.trim();
+
+    let (severity, rest) = if let Some(r) = trimmed.strip_prefix("FAILED ") {
+        (Severity::Error, r)
+    } else if let Some(r) = trimmed.strip_prefix("ERROR ") {
+        (Severity::Error, r)
+    } else {
+        return None;
+    };
+
+    // Split on ` - ` to separate node id from message.
+    let (nodeid, message) = if let Some(dash_pos) = rest.find(" - ") {
+        (&rest[..dash_pos], rest[dash_pos + 3..].trim())
+    } else {
+        (rest, "test failed")
+    };
+
+    let location = parse_nodeid_location(nodeid);
+
+    Some(Diagnostic {
+        severity,
+        location,
+        name: nodeid.trim().to_string(),
+        message: message.to_string(),
+        detail: None,
+    })
+}
+
+/// Parse the pytest final summary banner, returning (passed, failed, skipped, duration).
+///
+/// Example: `====== 2 failed, 5 passed, 1 skipped in 0.42s ======`
+fn parse_summary_banner(line: &str) -> Option<(u32, u32, u32, Option<f64>)> {
+    // Only process lines that look like summary banners — they must contain
+    // at least one of these result keywords.
+    if !line.contains("passed") && !line.contains("failed") && !line.contains("error") {
+        return None;
+    }
+
+    let passed = extract_count(line, "passed").unwrap_or(0);
+    let failed = extract_count(line, "failed").unwrap_or(0);
+    let skipped = extract_count(line, "skipped")
+        .or_else(|| extract_count(line, "deselected"))
+        .unwrap_or(0);
+    let duration = extract_duration(line);
+
+    Some((passed, failed, skipped, duration))
+}
+
+/// Extract the duration value from a string like `in 0.42s`.
+fn extract_duration(s: &str) -> Option<f64> {
+    let in_pos = s.find(" in ")?;
+    let after = s[in_pos + 4..].trim();
+    // Collect digits and the decimal point, stop at non-numeric characters.
+    let num: String = after
+        .chars()
+        .take_while(|c| c.is_ascii_digit() || *c == '.')
+        .collect();
+    num.parse().ok()
+}
+
+/// Extract the most useful error message from a failure block.
+///
+/// Priority:
+/// 1. Lines starting with `E ` (pytest error detail lines)
+/// 2. Lines matching `path:N: ErrorType`
+/// 3. First non-empty, non-`>` line as fallback
+fn extract_error_message(block: &str) -> String {
+    // Collect all `E ` lines — they carry the assertion/error detail.
+    let e_lines: Vec<&str> = block
+        .lines()
+        .filter(|l| {
+            let t = l.trim_start();
+            t.starts_with("E ") || t.starts_with("E\t")
+        })
+        .map(|l| l.trim_start().trim_start_matches('E').trim())
+        .collect();
+
+    if !e_lines.is_empty() {
+        return e_lines.join(" ").trim().to_string();
+    }
+
+    // Look for a `path:N: ErrorType` line.
+    for line in block.lines() {
+        let trimmed = line.trim();
+        if trimmed.contains(':') && !trimmed.starts_with('>') {
+            // Heuristic: contains a colon after a `.py` path segment.
+            if trimmed.contains(".py:") {
+                return trimmed.to_string();
+            }
+        }
+    }
+
+    // Fallback: first non-empty, non-separator line.
+    block
+        .lines()
+        .map(|l| l.trim())
+        .find(|l| !l.is_empty() && !l.starts_with('>') && !l.starts_with('-'))
+        .unwrap_or("test failed")
+        .to_string()
+}
+
+/// Parse a pytest node id like `tests/test_foo.py::test_bar` into a Location.
+fn parse_nodeid_location(nodeid: &str) -> Option<Location> {
+    // Strip the `::test_name` suffix, leaving just the file path.
+    let file = if let Some(pos) = nodeid.find("::") {
+        &nodeid[..pos]
+    } else {
+        nodeid
+    };
+    if file.is_empty() || !file.ends_with(".py") {
+        return None;
+    }
+    Some(Location {
+        file: file.to_string(),
+        line: 0,
+        column: None,
+    })
+}
+
+/// Build a human-readable summary, omitting zero categories except `passed`.
+fn build_summary(passed: u32, failed: u32, skipped: u32, errors: u32) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("{passed} passed"));
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if skipped > 0 {
+        parts.push(format!("{skipped} skipped"));
+    }
+    if errors > 0 {
+        parts.push(format!("{errors} errors"));
+    }
+    parts.join(", ")
+}
+
+
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- Detection -----------------------------------------------------------
+
+    #[test]
+    fn detect_summary_with_equals() {
+        let sample = "collected 3 items\n\n============================== 2 passed, 1 failed in 0.12s ==============================";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_short_test_summary() {
+        let sample = "=========================== short test summary info ============================\nFAILED tests/test_foo.py::test_bar - AssertionError: 1 != 2";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects_generic() {
+        let sample = "Building project...\nCompiling foo\nDone in 1.2s";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // -- Rewrite -------------------------------------------------------------
+
+    #[test]
+    fn rewrite_appends_tb_short() {
+        let result = PARSER.rewrite("pytest tests/");
+        assert_eq!(result, Some("pytest tests/ --tb=short -q".to_string()));
+    }
+
+    #[test]
+    fn rewrite_skips_if_present() {
+        let result = PARSER.rewrite("pytest tests/ --tb=long");
+        assert!(result.is_none());
+    }
+
+    // -- Text parse ----------------------------------------------------------
+
+    #[test]
+    fn parse_text_all_pass() {
+        let input = concat!(
+            "collected 5 items\n",
+            "\n",
+            "tests/test_foo.py .....                                                  [100%]\n",
+            "\n",
+            "============================== 5 passed in 0.23s ==============================\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.tool, "pytest");
+        assert_eq!(out.counts.passed, 5);
+        assert_eq!(out.counts.failed, 0);
+        assert_eq!(out.counts.skipped, 0);
+        assert!(out.diagnostics.is_empty());
+        assert_eq!(out.duration_secs, Some(0.23));
+        assert!(out.summary.contains("5 passed"));
+        assert!(!out.summary.contains("failed"));
+    }
+
+    #[test]
+    fn parse_text_with_failures() {
+        let input = concat!(
+            "collected 3 items\n",
+            "\n",
+            "=========================== short test summary info ============================\n",
+            "FAILED tests/test_foo.py::test_add - AssertionError: 1 != 2\n",
+            "FAILED tests/test_foo.py::test_mul - AssertionError: 3 != 4\n",
+            "========================= 2 failed, 1 passed in 0.05s =========================\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.passed, 1);
+        assert_eq!(out.counts.failed, 2);
+        assert_eq!(out.diagnostics.len(), 2);
+        assert_eq!(out.diagnostics[0].name, "tests/test_foo.py::test_add");
+        assert_eq!(out.diagnostics[0].message, "AssertionError: 1 != 2");
+        assert_eq!(out.diagnostics[0].severity, Severity::Error);
+        assert!(out.summary.contains("2 failed"));
+        assert!(out.summary.contains("1 passed"));
+    }
+
+    #[test]
+    fn parse_text_failure_detail() {
+        let input = concat!(
+            "collected 1 item\n",
+            "\n",
+            "________________________________ test_add _________________________________\n",
+            "\n",
+            "    def test_add():\n",
+            ">       assert add(1, 2) == 4\n",
+            "E       AssertionError: assert 3 == 4\n",
+            "\n",
+            "tests/test_foo.py:10: AssertionError\n",
+            "=========================== short test summary info ============================\n",
+            "FAILED tests/test_foo.py::test_add - AssertionError: assert 3 == 4\n",
+            "============================== 1 failed in 0.07s ==============================\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.failed, 1);
+        // The block-based diagnostic is preferred over the summary line.
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "test_add");
+        assert_eq!(diag.severity, Severity::Error);
+        assert!(
+            diag.detail.is_some(),
+            "detail should be populated from block"
+        );
+        let detail = diag.detail.as_ref().unwrap();
+        assert!(detail.contains("assert add(1, 2) == 4"));
+        let loc = diag.location.as_ref().expect("location should be extracted");
+        assert_eq!(loc.file, "tests/test_foo.py");
+        assert_eq!(loc.line, 10);
+    }
+}

--- a/src/run/parsers/pytest.rs
+++ b/src/run/parsers/pytest.rs
@@ -1,6 +1,8 @@
 use memchr::memmem;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity, extract_count, truncate_detail};
+use crate::run::types::{
+    extract_count, truncate_detail, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -56,33 +58,16 @@ impl PytestParser {
         let value: serde_json::Value = serde_json::from_str(input).ok()?;
         let summary = value.get("summary")?;
 
-        let passed = summary
-            .get("passed")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let failed = summary
-            .get("failed")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let skipped = summary
-            .get("skipped")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let errors = summary
-            .get("error")
-            .and_then(|v| v.as_u64())
-            .unwrap_or(0) as u32;
-        let duration_secs = value
-            .get("duration")
-            .and_then(|v| v.as_f64());
+        let passed = summary.get("passed").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let failed = summary.get("failed").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let skipped = summary.get("skipped").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let errors = summary.get("error").and_then(|v| v.as_u64()).unwrap_or(0) as u32;
+        let duration_secs = value.get("duration").and_then(|v| v.as_f64());
 
         let mut diagnostics: Vec<Diagnostic> = Vec::new();
         if let Some(tests) = value.get("tests").and_then(|v| v.as_array()) {
             for test in tests {
-                let outcome = test
-                    .get("outcome")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("");
+                let outcome = test.get("outcome").and_then(|v| v.as_str()).unwrap_or("");
                 if outcome != "failed" && outcome != "error" {
                     continue;
                 }
@@ -153,20 +138,19 @@ impl PytestParser {
         let mut failure_block_name: Option<String> = None;
         let mut failure_block_lines: Vec<&str> = Vec::new();
 
-        let finish_block =
-            |name: &str, block_lines: &[&str], diagnostics: &mut Vec<Diagnostic>| {
-                let block = block_lines.join("\n");
-                let message = extract_error_message(&block);
-                let location = Location::scan_text(&block);
-                let detail = truncate_detail(&block);
-                diagnostics.push(Diagnostic {
-                    severity: Severity::Error,
-                    location,
-                    name: name.to_string(),
-                    message,
-                    detail,
-                });
-            };
+        let finish_block = |name: &str, block_lines: &[&str], diagnostics: &mut Vec<Diagnostic>| {
+            let block = block_lines.join("\n");
+            let message = extract_error_message(&block);
+            let location = Location::scan_text(&block);
+            let detail = truncate_detail(&block);
+            diagnostics.push(Diagnostic {
+                severity: Severity::Error,
+                location,
+                name: name.to_string(),
+                message,
+                detail,
+            });
+        };
 
         for line in &lines {
             // Detect `___ test_name ___` failure block headers.
@@ -233,14 +217,12 @@ impl PytestParser {
                     // Block names come from `___ test_name ___` headers (just the
                     // function name), while summary names are full node ids like
                     // `tests/foo.py::test_name`.  Match on the trailing component.
-                    let fn_name = diag
-                        .name
-                        .rsplit("::")
-                        .next()
-                        .unwrap_or(&diag.name);
-                    let already_captured = diagnostics
-                        .iter()
-                        .any(|d| d.name == diag.name || d.name == fn_name || diag.name.ends_with(&format!("::{}", d.name)));
+                    let fn_name = diag.name.rsplit("::").next().unwrap_or(&diag.name);
+                    let already_captured = diagnostics.iter().any(|d| {
+                        d.name == diag.name
+                            || d.name == fn_name
+                            || diag.name.ends_with(&format!("::{}", d.name))
+                    });
                     if !already_captured {
                         diagnostics.push(diag);
                     }
@@ -296,10 +278,7 @@ fn parse_pytest_block_header(line: &str) -> Option<String> {
     if !trimmed.starts_with("___") || !trimmed.ends_with("___") || trimmed.len() < 7 {
         return None;
     }
-    let inner = trimmed
-        .trim_start_matches('_')
-        .trim_end_matches('_')
-        .trim();
+    let inner = trimmed.trim_start_matches('_').trim_end_matches('_').trim();
     if inner.is_empty() {
         return None;
     }
@@ -447,8 +426,6 @@ fn build_summary(passed: u32, failed: u32, skipped: u32, errors: u32) -> String 
     parts.join(", ")
 }
 
-
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -549,7 +526,10 @@ mod tests {
         );
         let detail = diag.detail.as_ref().unwrap();
         assert!(detail.contains("assert add(1, 2) == 4"));
-        let loc = diag.location.as_ref().expect("location should be extracted");
+        let loc = diag
+            .location
+            .as_ref()
+            .expect("location should be extracted");
         assert_eq!(loc.file, "tests/test_foo.py");
         assert_eq!(loc.line, 10);
     }

--- a/src/run/parsers/ruff.rs
+++ b/src/run/parsers/ruff.rs
@@ -32,13 +32,6 @@ impl Parser for RuffParser {
         sample.lines().any(looks_like_ruff_text_line)
     }
 
-    fn rewrite(&self, command: &str) -> Option<String> {
-        if command.contains("--output-format") {
-            return None;
-        }
-        Some(format!("{command} --output-format json"))
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -312,23 +305,6 @@ mod tests {
     fn detect_rejects() {
         let sample = "some random\noutput with no ruff markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_appends() {
-        let result = PARSER.rewrite("ruff check src/");
-        assert_eq!(
-            result,
-            Some("ruff check src/ --output-format json".to_string())
-        );
-    }
-
-    #[test]
-    fn rewrite_skips() {
-        let result = PARSER.rewrite("ruff check src/ --output-format json");
-        assert!(result.is_none());
     }
 
     // --- JSON path ---

--- a/src/run/parsers/ruff.rs
+++ b/src/run/parsers/ruff.rs
@@ -73,9 +73,7 @@ fn looks_like_ruff_text_line(line: &str) -> bool {
     }
     // After `: ` the next token should be a Ruff rule code: letters then digits.
     let after = line[colon_space + 2..].trim_start();
-    let code_end = after
-        .find([' ', '\t'])
-        .unwrap_or(after.len());
+    let code_end = after.find([' ', '\t']).unwrap_or(after.len());
     let code = &after[..code_end];
     is_ruff_code(code)
 }
@@ -89,7 +87,10 @@ fn is_ruff_code(s: &str) -> bool {
     if letters == 0 {
         return false;
     }
-    let digits: usize = s[letters..].chars().take_while(|c| c.is_ascii_digit()).count();
+    let digits: usize = s[letters..]
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .count();
     if digits == 0 {
         return false;
     }
@@ -374,10 +375,7 @@ mod tests {
         let second = &out.diagnostics[1];
         assert_eq!(second.name, "E501");
         assert_eq!(second.message, "Line too long (120 > 88)");
-        assert_eq!(
-            second.location.as_ref().map(|l| l.line),
-            Some(12)
-        );
+        assert_eq!(second.location.as_ref().map(|l| l.line), Some(12));
 
         assert_eq!(out.counts.warnings, 2);
         assert_eq!(out.summary, "2 issue(s)");

--- a/src/run/parsers/ruff.rs
+++ b/src/run/parsers/ruff.rs
@@ -1,7 +1,7 @@
 use memchr::memmem;
 use serde_json::Value;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{Counts, DetectResult, Diagnostic, Location, ParsedOutput, Severity};
 
 use super::Parser;
 
@@ -14,30 +14,44 @@ impl Parser for RuffParser {
         "ruff"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
 
-        // JSON fingerprint: array (or NDJSON lines) with "code" and "filename".
+        // JSON fingerprint: ruff JSON always has "code", "filename", AND "location"/"row".
+        // Checking only "code"+"filename" is too weak — e.g. GitHub API errors match.
+        // Adding "location" + "row" makes this specific to ruff's schema.
         let code_finder = memmem::Finder::new(b"\"code\"");
         let filename_finder = memmem::Finder::new(b"\"filename\"");
-        if code_finder.find(bytes).is_some() && filename_finder.find(bytes).is_some() {
+        let location_finder = memmem::Finder::new(b"\"location\"");
+        let row_finder = memmem::Finder::new(b"\"row\"");
+        if code_finder.find(bytes).is_some()
+            && filename_finder.find(bytes).is_some()
+            && location_finder.find(bytes).is_some()
+            && row_finder.find(bytes).is_some()
+        {
             // Accept both `[` (JSON array) and NDJSON (each line is a `{`).
             let trimmed = sample.trim_start();
-            if trimmed.starts_with('[') || trimmed.starts_with('{') {
-                return true;
+            if trimmed.starts_with('[') {
+                return DetectResult::SingleJson;
+            }
+            if trimmed.starts_with('{') {
+                return DetectResult::NdJson;
             }
         }
 
         // Text fingerprint: `path.py:N:M: CODE message` where CODE is letter(s) + digits.
-        sample.lines().any(looks_like_ruff_text_line)
+        if sample.lines().any(looks_like_ruff_text_line) {
+            return DetectResult::Text;
+        }
+
+        DetectResult::NoMatch
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
 
-        let trimmed = input.trim_start();
-        if trimmed.starts_with('[') || trimmed.starts_with('{') {
+        if hint.is_json() {
             parse_json(input, raw_lines, raw_bytes)
         } else {
             parse_text(input, raw_lines, raw_bytes)
@@ -51,7 +65,7 @@ impl Parser for RuffParser {
 
 /// Returns true if `line` looks like a Ruff text-format diagnostic line.
 ///
-/// Format: `path/to/file.py:5:1: F401 [*] \`os\` imported but unused`
+/// Format: `path/to/file.py:5:1: F401 [*] 'os' imported but unused`
 /// The rule code is letter(s) followed by digits, e.g. `E501`, `F401`, `UP006`, `I001`.
 fn looks_like_ruff_text_line(line: &str) -> bool {
     // Quick reject: must contain `: ` with a code-looking token after a `col:` prefix.
@@ -83,13 +97,13 @@ fn is_ruff_code(s: &str) -> bool {
     if s.is_empty() {
         return false;
     }
-    let letters: usize = s.chars().take_while(|c| c.is_ascii_alphabetic()).count();
+    let letters: usize = s.chars().take_while(char::is_ascii_alphabetic).count();
     if letters == 0 {
         return false;
     }
     let digits: usize = s[letters..]
         .chars()
-        .take_while(|c| c.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
         .count();
     if digits == 0 {
         return false;
@@ -215,7 +229,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
 
 /// Parse a single Ruff text diagnostic line.
 ///
-/// Format: `src/main.py:5:1: F401 [*] \`os\` imported but unused`
+/// Format: `src/main.py:5:1: F401 [*] 'os' imported but unused`
 ///
 /// The `[*]` fix-availability marker is optional; it is stripped from the message.
 fn parse_text_line(line: &str) -> Option<Diagnostic> {
@@ -276,7 +290,7 @@ fn build_summary(count: u32) -> String {
     if count == 0 {
         "no issues found".to_string()
     } else {
-        format!("{} issue(s)", count)
+        format!("{count} issue(s)")
     }
 }
 
@@ -293,19 +307,42 @@ mod tests {
     #[test]
     fn detect_json() {
         let sample = r#"[{"code":"F401","filename":"src/main.py","message":"unused","location":{"row":5,"column":1},"url":""}]"#;
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_text() {
         let sample = "src/main.py:5:1: F401 `os` imported but unused\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects() {
         let sample = "some random\noutput with no ruff markers\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
+    }
+
+    // Bug 3 regression: ruff JSON fingerprint was too weak — only checked "code"+"filename".
+    // A response like {"code": 404, "filename": "..."} would false-match.
+    #[test]
+    fn detect_rejects_generic_json_with_code_and_filename() {
+        // Has "code" and "filename" but no "location"/"row" — NOT ruff output.
+        let sample = r#"{"code": 404, "filename": "not_found.py", "message": "File not found"}"#;
+        assert!(
+            !PARSER.detect(sample).matched(),
+            "should not match generic JSON that has code+filename but no location/row"
+        );
+    }
+
+    #[test]
+    fn detect_rejects_github_api_style_json() {
+        // GitHub API error that happens to have "code" and "filename" but no location.
+        let sample =
+            r#"[{"code":"not_found","filename":"src/foo.py","resource":"File","field":"path"}]"#;
+        assert!(
+            !PARSER.detect(sample).matched(),
+            "should not match GitHub API JSON lacking location/row"
+        );
     }
 
     // --- JSON path ---
@@ -330,7 +367,7 @@ mod tests {
     "url": "https://docs.astral.sh/ruff/rules/line-too-long"
   }
 ]"#;
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::SingleJson);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -359,7 +396,7 @@ mod tests {
     #[test]
     fn parse_text() {
         let input = "src/main.py:5:1: F401 [*] `os` imported but unused\nsrc/utils.py:12:89: E501 Line too long (120 > 88)\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];

--- a/src/run/parsers/ruff.rs
+++ b/src/run/parsers/ruff.rs
@@ -1,0 +1,409 @@
+use memchr::memmem;
+use serde_json::Value;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: RuffParser = RuffParser;
+
+pub struct RuffParser;
+
+impl Parser for RuffParser {
+    fn name(&self) -> &'static str {
+        "ruff"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+
+        // JSON fingerprint: array (or NDJSON lines) with "code" and "filename".
+        let code_finder = memmem::Finder::new(b"\"code\"");
+        let filename_finder = memmem::Finder::new(b"\"filename\"");
+        if code_finder.find(bytes).is_some() && filename_finder.find(bytes).is_some() {
+            // Accept both `[` (JSON array) and NDJSON (each line is a `{`).
+            let trimmed = sample.trim_start();
+            if trimmed.starts_with('[') || trimmed.starts_with('{') {
+                return true;
+            }
+        }
+
+        // Text fingerprint: `path.py:N:M: CODE message` where CODE is letter(s) + digits.
+        sample.lines().any(looks_like_ruff_text_line)
+    }
+
+    fn rewrite(&self, command: &str) -> Option<String> {
+        if command.contains("--output-format") {
+            return None;
+        }
+        Some(format!("{command} --output-format json"))
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+
+        let trimmed = input.trim_start();
+        if trimmed.starts_with('[') || trimmed.starts_with('{') {
+            parse_json(input, raw_lines, raw_bytes)
+        } else {
+            parse_text(input, raw_lines, raw_bytes)
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection helpers
+// ---------------------------------------------------------------------------
+
+/// Returns true if `line` looks like a Ruff text-format diagnostic line.
+///
+/// Format: `path/to/file.py:5:1: F401 [*] \`os\` imported but unused`
+/// The rule code is letter(s) followed by digits, e.g. `E501`, `F401`, `UP006`, `I001`.
+fn looks_like_ruff_text_line(line: &str) -> bool {
+    // Quick reject: must contain `: ` with a code-looking token after a `col:` prefix.
+    let Some(colon_space) = line.find(": ") else {
+        return false;
+    };
+    // The part before `: ` must look like `path:line:col`.
+    let prefix = &line[..colon_space];
+    let parts: Vec<&str> = prefix.rsplitn(3, ':').collect();
+    // parts[0] = col, parts[1] = line, parts[2] = path (in rsplitn order)
+    if parts.len() < 3 {
+        return false;
+    }
+    if !parts[0].chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    if !parts[1].chars().all(|c| c.is_ascii_digit()) {
+        return false;
+    }
+    // After `: ` the next token should be a Ruff rule code: letters then digits.
+    let after = line[colon_space + 2..].trim_start();
+    let code_end = after
+        .find([' ', '\t'])
+        .unwrap_or(after.len());
+    let code = &after[..code_end];
+    is_ruff_code(code)
+}
+
+/// Returns true if `s` looks like a Ruff rule code such as `E501`, `F401`, `UP006`, `I001`.
+fn is_ruff_code(s: &str) -> bool {
+    if s.is_empty() {
+        return false;
+    }
+    let letters: usize = s.chars().take_while(|c| c.is_ascii_alphabetic()).count();
+    if letters == 0 {
+        return false;
+    }
+    let digits: usize = s[letters..].chars().take_while(|c| c.is_ascii_digit()).count();
+    if digits == 0 {
+        return false;
+    }
+    // Code must be entirely letters + digits (nothing else).
+    letters + digits == s.len()
+}
+
+// ---------------------------------------------------------------------------
+// JSON path
+// ---------------------------------------------------------------------------
+
+fn parse_json(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    let trimmed = input.trim();
+
+    // Try as a JSON array first.
+    if trimmed.starts_with('[') {
+        if let Ok(Value::Array(items)) = serde_json::from_str::<Value>(trimmed) {
+            for item in &items {
+                if let Some(diag) = extract_json_item(item) {
+                    diagnostics.push(diag);
+                }
+            }
+        }
+    } else {
+        // NDJSON: one JSON object per line.
+        for line in input.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+            let Ok(value) = serde_json::from_str::<Value>(line) else {
+                continue;
+            };
+            if let Some(diag) = extract_json_item(&value) {
+                diagnostics.push(diag);
+            }
+        }
+    }
+
+    let issue_count = diagnostics.len() as u32;
+    let summary = build_summary(issue_count);
+
+    ParsedOutput {
+        tool: "ruff",
+        summary,
+        diagnostics,
+        counts: Counts {
+            warnings: issue_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+fn extract_json_item(item: &Value) -> Option<Diagnostic> {
+    let code = item
+        .get("code")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown")
+        .to_string();
+
+    let message = item.get("message").and_then(Value::as_str)?.to_string();
+
+    let filename = item
+        .get("filename")
+        .and_then(Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let location = item.get("location").and_then(|loc| {
+        let row = loc.get("row").and_then(Value::as_u64)? as u32;
+        let column = loc.get("column").and_then(Value::as_u64).map(|c| c as u32);
+        Some(Location {
+            file: filename.clone(),
+            line: row,
+            column,
+        })
+    });
+
+    Some(Diagnostic {
+        severity: Severity::Warning,
+        location,
+        name: code,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+
+    for line in input.lines() {
+        if let Some(diag) = parse_text_line(line) {
+            diagnostics.push(diag);
+        }
+    }
+
+    let issue_count = diagnostics.len() as u32;
+    let summary = build_summary(issue_count);
+
+    ParsedOutput {
+        tool: "ruff",
+        summary,
+        diagnostics,
+        counts: Counts {
+            warnings: issue_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Parse a single Ruff text diagnostic line.
+///
+/// Format: `src/main.py:5:1: F401 [*] \`os\` imported but unused`
+///
+/// The `[*]` fix-availability marker is optional; it is stripped from the message.
+fn parse_text_line(line: &str) -> Option<Diagnostic> {
+    if !looks_like_ruff_text_line(line) {
+        return None;
+    }
+
+    // Split `path:line:col` from `: CODE message`.
+    let colon_space = line.find(": ")?;
+    let location_part = &line[..colon_space];
+    let rest = &line[colon_space + 2..];
+
+    // Parse location: rsplitn to handle paths that contain colons on Windows.
+    let parts: Vec<&str> = location_part.rsplitn(3, ':').collect();
+    // parts[0]=col, parts[1]=line_num, parts[2]=file
+    if parts.len() < 3 {
+        return None;
+    }
+    let column: u32 = parts[0].trim().parse().ok()?;
+    let line_num: u32 = parts[1].trim().parse().ok()?;
+    let file = parts[2].trim().to_string();
+
+    // Split code from message.
+    let (code_str, message_raw) = rest.split_once(' ')?;
+    let code = code_str.trim().to_string();
+
+    // Strip optional fix-availability marker `[*]` or `[x]` at the start of the message.
+    let message = if message_raw.trim_start().starts_with('[') {
+        // Find the closing `]` and skip past it plus any whitespace.
+        let s = message_raw.trim_start();
+        if let Some(end) = s.find(']') {
+            s[end + 1..].trim().to_string()
+        } else {
+            message_raw.trim().to_string()
+        }
+    } else {
+        message_raw.trim().to_string()
+    };
+
+    Some(Diagnostic {
+        severity: Severity::Warning,
+        location: Some(Location {
+            file,
+            line: line_num,
+            column: Some(column),
+        }),
+        name: code,
+        message,
+        detail: None,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn build_summary(count: u32) -> String {
+    if count == 0 {
+        "no issues found".to_string()
+    } else {
+        format!("{} issue(s)", count)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_json() {
+        let sample = r#"[{"code":"F401","filename":"src/main.py","message":"unused","location":{"row":5,"column":1},"url":""}]"#;
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_text() {
+        let sample = "src/main.py:5:1: F401 `os` imported but unused\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects() {
+        let sample = "some random\noutput with no ruff markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_appends() {
+        let result = PARSER.rewrite("ruff check src/");
+        assert_eq!(
+            result,
+            Some("ruff check src/ --output-format json".to_string())
+        );
+    }
+
+    #[test]
+    fn rewrite_skips() {
+        let result = PARSER.rewrite("ruff check src/ --output-format json");
+        assert!(result.is_none());
+    }
+
+    // --- JSON path ---
+
+    #[test]
+    fn parse_json() {
+        let input = r#"[
+  {
+    "cell": null,
+    "code": "F401",
+    "filename": "src/main.py",
+    "location": {"column": 1, "row": 5},
+    "message": "`os` imported but unused",
+    "url": "https://docs.astral.sh/ruff/rules/unused-import"
+  },
+  {
+    "cell": null,
+    "code": "E501",
+    "filename": "src/utils.py",
+    "location": {"column": 89, "row": 12},
+    "message": "Line too long (120 > 88)",
+    "url": "https://docs.astral.sh/ruff/rules/line-too-long"
+  }
+]"#;
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.name, "F401");
+        assert_eq!(first.message, "`os` imported but unused");
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/main.py")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(5));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(1));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.name, "E501");
+        assert_eq!(
+            second.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/utils.py")
+        );
+
+        assert_eq!(out.counts.warnings, 2);
+        assert_eq!(out.summary, "2 issue(s)");
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text() {
+        let input = "src/main.py:5:1: F401 [*] `os` imported but unused\nsrc/utils.py:12:89: E501 Line too long (120 > 88)\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.name, "F401");
+        assert_eq!(first.message, "`os` imported but unused");
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/main.py")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(5));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(1));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.name, "E501");
+        assert_eq!(second.message, "Line too long (120 > 88)");
+        assert_eq!(
+            second.location.as_ref().map(|l| l.line),
+            Some(12)
+        );
+
+        assert_eq!(out.counts.warnings, 2);
+        assert_eq!(out.summary, "2 issue(s)");
+    }
+}

--- a/src/run/parsers/tsc.rs
+++ b/src/run/parsers/tsc.rs
@@ -1,6 +1,8 @@
 use memchr::memmem;
 
-use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+use crate::run::types::{
+    build_lint_summary, parse_found_count, Counts, Diagnostic, Location, ParsedOutput, Severity,
+};
 
 use super::Parser;
 
@@ -54,7 +56,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
             continue;
         }
 
-        if let Some(n) = parse_summary_line(line) {
+        if let Some(n) = parse_found_count(line) {
             found_summary_errors = Some(n);
         }
     }
@@ -66,7 +68,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
         }
     }
 
-    let summary = build_summary(error_count, warning_count);
+    let summary = build_lint_summary(error_count, warning_count);
 
     ParsedOutput {
         tool: "tsc",
@@ -88,7 +90,7 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
 /// Format: `path/to/file.ts(line,col): error TS2322: message text`
 fn parse_text_line(line: &str) -> Option<Diagnostic> {
     // Find the `(line,col): ` location suffix — look for `):` after a `(`
-    let paren_open = line.find('(')?;
+    let paren_open = line.rfind('(')?;
     let paren_close = line[paren_open..].find("):")?;
     let paren_close = paren_open + paren_close;
 
@@ -141,25 +143,6 @@ fn parse_coords(coords: &str) -> Option<(u32, u32)> {
     let line_num: u32 = coords[..comma].trim().parse().ok()?;
     let col: u32 = coords[comma + 1..].trim().parse().ok()?;
     Some((line_num, col))
-}
-
-/// Extract error count from `Found N errors in M files.` summary lines.
-fn parse_summary_line(line: &str) -> Option<u32> {
-    let rest = line.trim().strip_prefix("Found ")?;
-    let space = rest.find(' ')?;
-    rest[..space].parse().ok()
-}
-
-// ---------------------------------------------------------------------------
-// Shared helpers
-// ---------------------------------------------------------------------------
-
-fn build_summary(errors: u32, warnings: u32) -> String {
-    if errors == 0 && warnings == 0 {
-        "no issues found".to_string()
-    } else {
-        format!("{errors} error(s), {warnings} warning(s)")
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -225,7 +208,7 @@ mod tests {
 
         assert_eq!(out.counts.errors, 2);
         assert_eq!(out.counts.warnings, 0);
-        assert_eq!(out.summary, "2 error(s), 0 warning(s)");
+        assert_eq!(out.summary, "2 error(s)");
     }
 
     #[test]
@@ -243,7 +226,7 @@ mod tests {
 
         assert_eq!(out.counts.warnings, 1);
         assert_eq!(out.counts.errors, 0);
-        assert_eq!(out.summary, "0 error(s), 1 warning(s)");
+        assert_eq!(out.summary, "1 warning(s)");
     }
 
     #[test]
@@ -251,6 +234,6 @@ mod tests {
         let input = "Found 2 errors in 2 files.\n";
         let out = PARSER.parse(input);
         assert_eq!(out.counts.errors, 2);
-        assert_eq!(out.summary, "2 error(s), 0 warning(s)");
+        assert_eq!(out.summary, "2 error(s)");
     }
 }

--- a/src/run/parsers/tsc.rs
+++ b/src/run/parsers/tsc.rs
@@ -21,11 +21,6 @@ impl Parser for TscParser {
         error_finder.find(bytes).is_some() || warning_finder.find(bytes).is_some()
     }
 
-    /// tsc has no JSON output mode; nothing to rewrite.
-    fn rewrite(&self, _command: &str) -> Option<String> {
-        None
-    }
-
     fn parse(&self, input: &str) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
@@ -193,14 +188,6 @@ mod tests {
     fn detect_rejects() {
         let sample = "some random\noutput with no tsc markers\n";
         assert!(!PARSER.detect(sample));
-    }
-
-    // --- rewrite ---
-
-    #[test]
-    fn rewrite_none() {
-        assert!(PARSER.rewrite("tsc --noEmit").is_none());
-        assert!(PARSER.rewrite("npx tsc").is_none());
     }
 
     // --- Text path ---

--- a/src/run/parsers/tsc.rs
+++ b/src/run/parsers/tsc.rs
@@ -1,0 +1,272 @@
+use memchr::memmem;
+
+use crate::run::types::{Counts, Diagnostic, Location, ParsedOutput, Severity};
+
+use super::Parser;
+
+pub static PARSER: TscParser = TscParser;
+
+pub struct TscParser;
+
+impl Parser for TscParser {
+    fn name(&self) -> &'static str {
+        "tsc"
+    }
+
+    fn detect(&self, sample: &str) -> bool {
+        let bytes = sample.as_bytes();
+        // tsc text fingerprint: `): error TS` or `): warning TS`
+        let error_finder = memmem::Finder::new(b"): error TS");
+        let warning_finder = memmem::Finder::new(b"): warning TS");
+        error_finder.find(bytes).is_some() || warning_finder.find(bytes).is_some()
+    }
+
+    /// tsc has no JSON output mode; nothing to rewrite.
+    fn rewrite(&self, _command: &str) -> Option<String> {
+        None
+    }
+
+    fn parse(&self, input: &str) -> ParsedOutput {
+        let raw_bytes = input.len();
+        let raw_lines = input.lines().count();
+        parse_text(input, raw_lines, raw_bytes)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Text path
+// ---------------------------------------------------------------------------
+
+/// Parse tsc text output.
+///
+/// Diagnostic format: `src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.`
+/// Summary format: `Found 2 errors in 2 files.`
+fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
+    let mut diagnostics: Vec<Diagnostic> = Vec::new();
+    let mut error_count: u32 = 0;
+    let mut warning_count: u32 = 0;
+
+    let mut found_summary_errors: Option<u32> = None;
+
+    for line in input.lines() {
+        if let Some(diag) = parse_text_line(line) {
+            match diag.severity {
+                Severity::Error => error_count += 1,
+                Severity::Warning => warning_count += 1,
+                Severity::Info => {}
+            }
+            diagnostics.push(diag);
+            continue;
+        }
+
+        if let Some(n) = parse_summary_line(line) {
+            found_summary_errors = Some(n);
+        }
+    }
+
+    // If we got a summary but no diagnostics, use summary counts
+    if diagnostics.is_empty() {
+        if let Some(n) = found_summary_errors {
+            error_count = n;
+        }
+    }
+
+    let summary = build_summary(error_count, warning_count);
+
+    ParsedOutput {
+        tool: "tsc",
+        summary,
+        diagnostics,
+        counts: Counts {
+            errors: error_count,
+            warnings: warning_count,
+            ..Counts::default()
+        },
+        duration_secs: None,
+        raw_lines,
+        raw_bytes,
+    }
+}
+
+/// Parse a single tsc diagnostic line.
+///
+/// Format: `path/to/file.ts(line,col): error TS2322: message text`
+fn parse_text_line(line: &str) -> Option<Diagnostic> {
+    // Find the `(line,col): ` location suffix — look for `):` after a `(`
+    let paren_open = line.find('(')?;
+    let paren_close = line[paren_open..].find("):")?;
+    let paren_close = paren_open + paren_close;
+
+    let file = line[..paren_open].to_string();
+    if file.is_empty() {
+        return None;
+    }
+
+    // Parse `line,col` inside the parens
+    let coords = &line[paren_open + 1..paren_close];
+    let (line_num, column) = parse_coords(coords)?;
+
+    // After `):` we expect ` error TSxxxx:` or ` warning TSxxxx:`
+    let after_paren = line[paren_close + 2..].trim_start();
+
+    let (severity, after_severity) = if let Some(r) = after_paren.strip_prefix("error ") {
+        (Severity::Error, r)
+    } else if let Some(r) = after_paren.strip_prefix("warning ") {
+        (Severity::Warning, r)
+    } else {
+        return None;
+    };
+
+    // `after_severity` should be `TSxxxx: message`
+    let colon_pos = after_severity.find(": ")?;
+    let ts_code = after_severity[..colon_pos].to_string();
+    let message = after_severity[colon_pos + 2..].trim().to_string();
+
+    // Validate the code looks like `TSdddd`
+    if !ts_code.starts_with("TS") {
+        return None;
+    }
+
+    Some(Diagnostic {
+        severity,
+        location: Some(Location {
+            file,
+            line: line_num,
+            column: Some(column),
+        }),
+        name: ts_code,
+        message,
+        detail: None,
+    })
+}
+
+/// Parse `line,col` from the parenthesized location portion.
+fn parse_coords(coords: &str) -> Option<(u32, u32)> {
+    let comma = coords.find(',')?;
+    let line_num: u32 = coords[..comma].trim().parse().ok()?;
+    let col: u32 = coords[comma + 1..].trim().parse().ok()?;
+    Some((line_num, col))
+}
+
+/// Extract error count from `Found N errors in M files.` summary lines.
+fn parse_summary_line(line: &str) -> Option<u32> {
+    let rest = line.trim().strip_prefix("Found ")?;
+    let space = rest.find(' ')?;
+    rest[..space].parse().ok()
+}
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+fn build_summary(errors: u32, warnings: u32) -> String {
+    if errors == 0 && warnings == 0 {
+        "no issues found".to_string()
+    } else {
+        format!("{errors} error(s), {warnings} warning(s)")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- detect ---
+
+    #[test]
+    fn detect_error_ts() {
+        let sample = "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_warning_ts() {
+        let sample = "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
+        assert!(PARSER.detect(sample));
+    }
+
+    #[test]
+    fn detect_rejects() {
+        let sample = "some random\noutput with no tsc markers\n";
+        assert!(!PARSER.detect(sample));
+    }
+
+    // --- rewrite ---
+
+    #[test]
+    fn rewrite_none() {
+        assert!(PARSER.rewrite("tsc --noEmit").is_none());
+        assert!(PARSER.rewrite("npx tsc").is_none());
+    }
+
+    // --- Text path ---
+
+    #[test]
+    fn parse_text_errors() {
+        let input = concat!(
+            "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n",
+            "src/utils.ts(20,1): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.\n",
+        );
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 2);
+
+        let first = &out.diagnostics[0];
+        assert_eq!(first.severity, Severity::Error);
+        assert_eq!(first.name, "TS2322");
+        assert_eq!(
+            first.message,
+            "Type 'string' is not assignable to type 'number'."
+        );
+        assert_eq!(
+            first.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/index.ts")
+        );
+        assert_eq!(first.location.as_ref().map(|l| l.line), Some(10));
+        assert_eq!(first.location.as_ref().and_then(|l| l.column), Some(5));
+
+        let second = &out.diagnostics[1];
+        assert_eq!(second.name, "TS2345");
+        assert_eq!(
+            second.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/utils.ts")
+        );
+
+        assert_eq!(out.counts.errors, 2);
+        assert_eq!(out.counts.warnings, 0);
+        assert_eq!(out.summary, "2 error(s), 0 warning(s)");
+    }
+
+    #[test]
+    fn parse_text_warnings() {
+        let input =
+            "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.diagnostics.len(), 1);
+
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.severity, Severity::Warning);
+        assert_eq!(diag.name, "TS6133");
+        assert_eq!(diag.message, "'unused' is declared but never used.");
+        assert_eq!(
+            diag.location.as_ref().map(|l| l.line),
+            Some(15)
+        );
+        assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(3));
+
+        assert_eq!(out.counts.warnings, 1);
+        assert_eq!(out.counts.errors, 0);
+        assert_eq!(out.summary, "0 error(s), 1 warning(s)");
+    }
+
+    #[test]
+    fn parse_text_summary() {
+        let input = "Found 2 errors in 2 files.\n";
+        let out = PARSER.parse(input);
+        assert_eq!(out.counts.errors, 2);
+        assert_eq!(out.summary, "2 error(s), 0 warning(s)");
+    }
+}

--- a/src/run/parsers/tsc.rs
+++ b/src/run/parsers/tsc.rs
@@ -1,7 +1,8 @@
 use memchr::memmem;
 
 use crate::run::types::{
-    build_lint_summary, parse_found_count, Counts, Diagnostic, Location, ParsedOutput, Severity,
+    build_lint_summary, parse_found_count, Counts, DetectResult, Diagnostic, Location,
+    ParsedOutput, Severity,
 };
 
 use super::Parser;
@@ -15,15 +16,19 @@ impl Parser for TscParser {
         "tsc"
     }
 
-    fn detect(&self, sample: &str) -> bool {
+    fn detect(&self, sample: &str) -> DetectResult {
         let bytes = sample.as_bytes();
         // tsc text fingerprint: `): error TS` or `): warning TS`
         let error_finder = memmem::Finder::new(b"): error TS");
         let warning_finder = memmem::Finder::new(b"): warning TS");
-        error_finder.find(bytes).is_some() || warning_finder.find(bytes).is_some()
+        if error_finder.find(bytes).is_some() || warning_finder.find(bytes).is_some() {
+            DetectResult::Text
+        } else {
+            DetectResult::NoMatch
+        }
     }
 
-    fn parse(&self, input: &str) -> ParsedOutput {
+    fn parse(&self, input: &str, _hint: DetectResult) -> ParsedOutput {
         let raw_bytes = input.len();
         let raw_lines = input.lines().count();
         parse_text(input, raw_lines, raw_bytes)
@@ -85,14 +90,62 @@ fn parse_text(input: &str, raw_lines: usize, raw_bytes: usize) -> ParsedOutput {
     }
 }
 
+/// Scan `bytes` forward for the tsc location pattern `(<digits>,<digits>):`.
+///
+/// Returns `(paren_open, paren_close)` byte indices on success.
+/// Using `rfind('(')` is incorrect because tsc error messages often contain
+/// parentheses in type signatures, e.g. `(a: number) => void`.
+fn find_location_parens(bytes: &[u8], len: usize) -> Option<(usize, usize)> {
+    let mut i = 0;
+    while i < len {
+        if bytes[i] != b'(' {
+            i += 1;
+            continue;
+        }
+        let open = i;
+        let inner_start = open + 1;
+
+        // Collect digits for line number.
+        let mut j = inner_start;
+        while j < len && bytes[j].is_ascii_digit() {
+            j += 1;
+        }
+        if j == inner_start || j >= len || bytes[j] != b',' {
+            i += 1;
+            continue;
+        }
+
+        // Collect digits for column number.
+        let mut k = j + 1;
+        while k < len && bytes[k].is_ascii_digit() {
+            k += 1;
+        }
+        if k == j + 1 || k >= len || bytes[k] != b')' {
+            i += 1;
+            continue;
+        }
+
+        // Verify `):` follows so we know this is the location, not an inner paren.
+        if k + 1 >= len || bytes[k + 1] != b':' {
+            i += 1;
+            continue;
+        }
+
+        return Some((open, k));
+    }
+    None
+}
+
 /// Parse a single tsc diagnostic line.
 ///
 /// Format: `path/to/file.ts(line,col): error TS2322: message text`
 fn parse_text_line(line: &str) -> Option<Diagnostic> {
-    // Find the `(line,col): ` location suffix — look for `):` after a `(`
-    let paren_open = line.rfind('(')?;
-    let paren_close = line[paren_open..].find("):")?;
-    let paren_close = paren_open + paren_close;
+    // Scan forward for `(<digits>,<digits>):` — do NOT use rfind('(') which
+    // breaks when the error message itself contains parentheses, e.g. type
+    // signatures like `(a: number) => void`.
+    let bytes = line.as_bytes();
+    let len = bytes.len();
+    let (paren_open, paren_close) = find_location_parens(bytes, len)?;
 
     let file = line[..paren_open].to_string();
     if file.is_empty() {
@@ -159,19 +212,19 @@ mod tests {
     fn detect_error_ts() {
         let sample =
             "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_warning_ts() {
         let sample = "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
-        assert!(PARSER.detect(sample));
+        assert!(PARSER.detect(sample).matched());
     }
 
     #[test]
     fn detect_rejects() {
         let sample = "some random\noutput with no tsc markers\n";
-        assert!(!PARSER.detect(sample));
+        assert!(!PARSER.detect(sample).matched());
     }
 
     // --- Text path ---
@@ -182,7 +235,7 @@ mod tests {
             "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n",
             "src/utils.ts(20,1): error TS2345: Argument of type 'number' is not assignable to parameter of type 'string'.\n",
         );
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 2);
 
         let first = &out.diagnostics[0];
@@ -214,7 +267,7 @@ mod tests {
     #[test]
     fn parse_text_warnings() {
         let input = "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.diagnostics.len(), 1);
 
         let diag = &out.diagnostics[0];
@@ -232,8 +285,31 @@ mod tests {
     #[test]
     fn parse_text_summary() {
         let input = "Found 2 errors in 2 files.\n";
-        let out = PARSER.parse(input);
+        let out = PARSER.parse(input, DetectResult::Text);
         assert_eq!(out.counts.errors, 2);
         assert_eq!(out.summary, "2 error(s)");
+    }
+
+    // --- Bug 1 regression: rfind('(') breaks on messages with parentheses ---
+
+    #[test]
+    fn parse_text_message_with_parens_in_type() {
+        // The message contains a function type `(a: number) => void` with parens.
+        // rfind('(') would wrongly find the `(a:` paren instead of the location paren.
+        let input = "src/index.ts(10,5): error TS2322: Type '(a: number) => void' is not assignable to type 'string'.\n";
+        let out = PARSER.parse(input, DetectResult::Text);
+        assert_eq!(out.diagnostics.len(), 1);
+        let diag = &out.diagnostics[0];
+        assert_eq!(diag.name, "TS2322");
+        assert_eq!(
+            diag.location.as_ref().map(|l| l.file.as_str()),
+            Some("src/index.ts")
+        );
+        assert_eq!(diag.location.as_ref().map(|l| l.line), Some(10));
+        assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(5));
+        assert!(
+            diag.message.contains("(a: number) => void"),
+            "message should contain the function type signature"
+        );
     }
 }

--- a/src/run/parsers/tsc.rs
+++ b/src/run/parsers/tsc.rs
@@ -174,7 +174,8 @@ mod tests {
 
     #[test]
     fn detect_error_ts() {
-        let sample = "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n";
+        let sample =
+            "src/index.ts(10,5): error TS2322: Type 'string' is not assignable to type 'number'.\n";
         assert!(PARSER.detect(sample));
     }
 
@@ -229,8 +230,7 @@ mod tests {
 
     #[test]
     fn parse_text_warnings() {
-        let input =
-            "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
+        let input = "src/utils.ts(15,3): warning TS6133: 'unused' is declared but never used.\n";
         let out = PARSER.parse(input);
         assert_eq!(out.diagnostics.len(), 1);
 
@@ -238,10 +238,7 @@ mod tests {
         assert_eq!(diag.severity, Severity::Warning);
         assert_eq!(diag.name, "TS6133");
         assert_eq!(diag.message, "'unused' is declared but never used.");
-        assert_eq!(
-            diag.location.as_ref().map(|l| l.line),
-            Some(15)
-        );
+        assert_eq!(diag.location.as_ref().map(|l| l.line), Some(15));
         assert_eq!(diag.location.as_ref().and_then(|l| l.column), Some(3));
 
         assert_eq!(out.counts.warnings, 1);

--- a/src/run/types.rs
+++ b/src/run/types.rs
@@ -1,0 +1,210 @@
+use std::fmt;
+
+pub struct ParsedOutput {
+    pub tool: &'static str,
+    pub summary: String,
+    pub diagnostics: Vec<Diagnostic>,
+    pub counts: Counts,
+    pub duration_secs: Option<f64>,
+    pub raw_lines: usize,
+    pub raw_bytes: usize,
+}
+
+/// Aggregate counts from parsed output.
+///
+/// Field semantics:
+/// - `passed` / `failed` / `skipped`: test outcome counts (test runners only).
+/// - `errors`: compilation errors, lint violations, or type-check errors (compilers/linters).
+/// - `warnings`: compiler or lint warnings.
+///
+/// Test runners use `failed` for test failures and leave `errors` at 0.
+/// Linters/compilers use `errors`/`warnings` and leave test fields at 0.
+#[derive(Default)]
+pub struct Counts {
+    pub passed: u32,
+    pub failed: u32,
+    pub skipped: u32,
+    pub warnings: u32,
+    pub errors: u32,
+}
+
+pub struct Diagnostic {
+    pub severity: Severity,
+    pub location: Option<Location>,
+    pub name: String,
+    pub message: String,
+    pub detail: Option<String>,
+}
+
+pub struct DiagnosticGroup {
+    pub severity: Severity,
+    pub signature: String,
+    pub locations: Vec<Location>,
+    pub total: usize,
+    pub representative: Diagnostic,
+    pub cascading: bool,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
+pub enum Severity {
+    Error,
+    Warning,
+    Info,
+}
+
+#[derive(Clone, Debug)]
+pub struct Location {
+    pub file: String,
+    pub line: u32,
+    pub column: Option<u32>,
+}
+
+impl fmt::Display for Severity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Severity::Error => f.write_str("ERROR"),
+            Severity::Warning => f.write_str("WARN"),
+            Severity::Info => f.write_str("INFO"),
+        }
+    }
+}
+
+impl fmt::Display for Location {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.column {
+            Some(col) => write!(f, "{}:{}:{}", self.file, self.line, col),
+            None => write!(f, "{}:{}", self.file, self.line),
+        }
+    }
+}
+
+impl Location {
+    /// Byte-walk a single line looking for a `path:digits` or `path:digits:digits` pattern.
+    ///
+    /// This is the shared location extractor used by multiple parsers. It looks for
+    /// `file.ext:line` or `file.ext:line:col` patterns, walking backwards from the
+    /// colon to find the path start (delimited by whitespace or quote chars).
+    pub fn scan_line(line: &str) -> Option<Location> {
+        let bytes = line.as_bytes();
+        let len = bytes.len();
+        let mut i = 0;
+
+        while i < len {
+            if bytes[i] != b':' {
+                i += 1;
+                continue;
+            }
+
+            let num_start = i + 1;
+            let mut num_end = num_start;
+            while num_end < len && bytes[num_end].is_ascii_digit() {
+                num_end += 1;
+            }
+            if num_end == num_start {
+                i += 1;
+                continue;
+            }
+
+            let line_num: u32 = match std::str::from_utf8(&bytes[num_start..num_end])
+                .ok()
+                .and_then(|s| s.parse().ok())
+            {
+                Some(n) => n,
+                None => { i += 1; continue; }
+            };
+
+            // Optional column after another colon.
+            let col = if num_end < len && bytes[num_end] == b':' {
+                let col_start = num_end + 1;
+                let mut col_end = col_start;
+                while col_end < len && bytes[col_end].is_ascii_digit() {
+                    col_end += 1;
+                }
+                if col_end > col_start {
+                    std::str::from_utf8(&bytes[col_start..col_end])
+                        .ok()
+                        .and_then(|s| s.parse::<u32>().ok())
+                } else {
+                    None
+                }
+            } else {
+                None
+            };
+
+            let path_end = i;
+            let path_start = bytes[..path_end]
+                .iter()
+                .rposition(|&b| b == b' ' || b == b'\t' || b == b'\'' || b == b'"' || b == b'(')
+                .map(|pos| pos + 1)
+                .unwrap_or(0);
+
+            let path_bytes = &bytes[path_start..path_end];
+            let looks_like_path = path_bytes.iter().any(|&b| b == b'.' || b == b'/');
+            let all_digits = path_bytes.iter().all(|&b| b.is_ascii_digit());
+
+            if looks_like_path && !all_digits && !path_bytes.is_empty() {
+                if let Ok(file) = std::str::from_utf8(path_bytes) {
+                    return Some(Location {
+                        file: file.to_string(),
+                        line: line_num,
+                        column: col,
+                    });
+                }
+            }
+
+            i += 1;
+        }
+
+        None
+    }
+
+    /// Scan multi-line text for the first location match.
+    pub fn scan_text(text: &str) -> Option<Location> {
+        for line in text.lines() {
+            if let Some(loc) = Location::scan_line(line.trim()) {
+                return Some(loc);
+            }
+        }
+        None
+    }
+}
+/// Maximum byte length for diagnostic detail fields.
+pub const MAX_DETAIL_BYTES: usize = 2048;
+
+/// Truncate a string to [`MAX_DETAIL_BYTES`], respecting UTF-8 char boundaries.
+///
+/// Returns `None` if the input is empty/whitespace-only.
+pub fn truncate_detail(s: &str) -> Option<String> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed.len() > MAX_DETAIL_BYTES {
+        let mut boundary = MAX_DETAIL_BYTES;
+        // Walk back to a UTF-8 char boundary (leading bytes start with 0xxxxxxx or 11xxxxxx).
+        while boundary > 0 && !trimmed.is_char_boundary(boundary) {
+            boundary -= 1;
+        }
+        Some(format!("{}…", &trimmed[..boundary]))
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+/// Extract a leading integer from a fragment like `"5 passed"`.
+///
+/// Searches `haystack` for `label`, then walks backwards from the match position
+/// to collect consecutive digits, producing the count.
+pub fn extract_count(haystack: &str, label: &str) -> Option<u32> {
+    let pos = haystack.find(label)?;
+    let before = haystack[..pos].trim_end();
+    let digits: String = before
+        .chars()
+        .rev()
+        .take_while(|c| c.is_ascii_digit())
+        .collect::<String>()
+        .chars()
+        .rev()
+        .collect();
+    digits.parse().ok()
+}

--- a/src/run/types.rs
+++ b/src/run/types.rs
@@ -110,7 +110,10 @@ impl Location {
                 .and_then(|s| s.parse().ok())
             {
                 Some(n) => n,
-                None => { i += 1; continue; }
+                None => {
+                    i += 1;
+                    continue;
+                }
             };
 
             // Optional column after another colon.

--- a/src/run/types.rs
+++ b/src/run/types.rs
@@ -1,5 +1,6 @@
 use std::fmt;
 
+#[allow(dead_code)] // fields read in format.rs + tests, clippy can't trace pub(crate) API
 pub struct ParsedOutput {
     pub tool: &'static str,
     pub summary: String,
@@ -20,6 +21,7 @@ pub struct ParsedOutput {
 /// Test runners use `failed` for test failures and leave `errors` at 0.
 /// Linters/compilers use `errors`/`warnings` and leave test fields at 0.
 #[derive(Default)]
+#[allow(dead_code)] // fields read in tests, clippy can't trace pub(crate) API
 pub struct Counts {
     pub passed: u32,
     pub failed: u32,
@@ -210,4 +212,34 @@ pub fn extract_count(haystack: &str, label: &str) -> Option<u32> {
         .rev()
         .collect();
     digits.parse().ok()
+}
+
+/// Build a human-readable test summary, omitting zero categories except `passed`.
+pub fn build_test_summary(passed: u32, failed: u32, skipped: u32) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("{passed} passed"));
+    if failed > 0 {
+        parts.push(format!("{failed} failed"));
+    }
+    if skipped > 0 {
+        parts.push(format!("{skipped} skipped"));
+    }
+    parts.join(", ")
+}
+
+/// Parse "Found N ..." lines (used by tsc and mypy).
+pub fn parse_found_count(line: &str) -> Option<u32> {
+    let rest = line.trim().strip_prefix("Found ")?;
+    let space = rest.find(' ')?;
+    rest[..space].parse().ok()
+}
+
+/// Build summary for linter/compiler output.
+pub fn build_lint_summary(errors: u32, warnings: u32) -> String {
+    match (errors, warnings) {
+        (0, 0) => "no issues".to_string(),
+        (0, w) => format!("{w} warning(s)"),
+        (e, 0) => format!("{e} error(s)"),
+        (e, w) => format!("{e} error(s), {w} warning(s)"),
+    }
 }

--- a/src/run/types.rs
+++ b/src/run/types.rs
@@ -1,7 +1,102 @@
 use std::fmt;
 
+use crate::run::format;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DetectResult {
+    NoMatch,
+    NdJson,
+    SingleJson,
+    Text,
+}
+
+impl DetectResult {
+    #[must_use]
+    pub fn matched(self) -> bool {
+        self != DetectResult::NoMatch
+    }
+
+    #[must_use]
+    pub fn is_json(self) -> bool {
+        matches!(self, DetectResult::NdJson | DetectResult::SingleJson)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OutputFormat {
+    Markdown,
+    Plain,
+    Json,
+}
+
+pub struct CompressResult {
+    pub tool: &'static str,
+    pub summary: String,
+    pub groups: Vec<DiagnosticGroup>,
+    pub counts: Counts,
+    pub duration_secs: Option<f64>,
+    pub input_stats: InputStats,
+    pub passthrough: bool,
+    /// Cleaned text for generic head/tail formatting. Only populated for unknown tools.
+    pub(crate) cleaned: Option<String>,
+}
+
+impl CompressResult {
+    #[must_use]
+    pub fn format(&self, fmt: OutputFormat) -> String {
+        match fmt {
+            OutputFormat::Markdown => match &self.cleaned {
+                Some(cleaned) => format::format_markdown_with_raw(self, cleaned),
+                None => format::format_markdown(self),
+            },
+            OutputFormat::Plain => match &self.cleaned {
+                Some(cleaned) => format::format_plain_with_raw(self, cleaned),
+                None => format::format_plain(self),
+            },
+            OutputFormat::Json => match &self.cleaned {
+                Some(cleaned) => format::format_json_with_raw(self, cleaned),
+                None => format::format_json(self),
+            },
+        }
+    }
+
+    #[must_use]
+    pub fn format_checked(&self, fmt: OutputFormat, original_len: usize) -> Option<String> {
+        let formatted = self.format(fmt);
+        if formatted.len() >= original_len {
+            None
+        } else {
+            Some(formatted)
+        }
+    }
+
+    #[must_use]
+    pub fn has_errors(&self) -> bool {
+        self.counts.errors > 0 || self.counts.failed > 0
+    }
+
+    #[must_use]
+    pub fn is_clean(&self) -> bool {
+        self.counts.errors == 0 && self.counts.failed == 0 && self.counts.warnings == 0
+    }
+}
+
+pub struct InputStats {
+    pub lines: usize,
+    pub bytes: usize,
+}
+
+pub struct DiagnosticGroup {
+    pub severity: Severity,
+    pub signature: String,
+    pub locations: Vec<Location>,
+    pub total: usize,
+    pub representative: Diagnostic,
+    pub cascading: bool,
+}
+
 #[allow(dead_code)] // fields read in format.rs + tests, clippy can't trace pub(crate) API
-pub struct ParsedOutput {
+pub(crate) struct ParsedOutput {
     pub tool: &'static str,
     pub summary: String,
     pub diagnostics: Vec<Diagnostic>,
@@ -20,7 +115,7 @@ pub struct ParsedOutput {
 ///
 /// Test runners use `failed` for test failures and leave `errors` at 0.
 /// Linters/compilers use `errors`/`warnings` and leave test fields at 0.
-#[derive(Default)]
+#[derive(Default, serde::Serialize)]
 #[allow(dead_code)] // fields read in tests, clippy can't trace pub(crate) API
 pub struct Counts {
     pub passed: u32,
@@ -36,15 +131,6 @@ pub struct Diagnostic {
     pub name: String,
     pub message: String,
     pub detail: Option<String>,
-}
-
-pub struct DiagnosticGroup {
-    pub severity: Severity,
-    pub signature: String,
-    pub locations: Vec<Location>,
-    pub total: usize,
-    pub representative: Diagnostic,
-    pub cascading: bool,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Hash)]
@@ -86,6 +172,7 @@ impl Location {
     /// This is the shared location extractor used by multiple parsers. It looks for
     /// `file.ext:line` or `file.ext:line:col` patterns, walking backwards from the
     /// colon to find the path start (delimited by whitespace or quote chars).
+    #[must_use]
     pub fn scan_line(line: &str) -> Option<Location> {
         let bytes = line.as_bytes();
         let len = bytes.len();
@@ -107,15 +194,12 @@ impl Location {
                 continue;
             }
 
-            let line_num: u32 = match std::str::from_utf8(&bytes[num_start..num_end])
+            let Some(line_num) = std::str::from_utf8(&bytes[num_start..num_end])
                 .ok()
-                .and_then(|s| s.parse().ok())
-            {
-                Some(n) => n,
-                None => {
-                    i += 1;
-                    continue;
-                }
+                .and_then(|s| s.parse::<u32>().ok())
+            else {
+                i += 1;
+                continue;
             };
 
             // Optional column after another colon.
@@ -140,8 +224,7 @@ impl Location {
             let path_start = bytes[..path_end]
                 .iter()
                 .rposition(|&b| b == b' ' || b == b'\t' || b == b'\'' || b == b'"' || b == b'(')
-                .map(|pos| pos + 1)
-                .unwrap_or(0);
+                .map_or(0, |pos| pos + 1);
 
             let path_bytes = &bytes[path_start..path_end];
             let looks_like_path = path_bytes.iter().any(|&b| b == b'.' || b == b'/');
@@ -164,6 +247,7 @@ impl Location {
     }
 
     /// Scan multi-line text for the first location match.
+    #[must_use]
     pub fn scan_text(text: &str) -> Option<Location> {
         for line in text.lines() {
             if let Some(loc) = Location::scan_line(line.trim()) {
@@ -179,6 +263,7 @@ pub const MAX_DETAIL_BYTES: usize = 2048;
 /// Truncate a string to [`MAX_DETAIL_BYTES`], respecting UTF-8 char boundaries.
 ///
 /// Returns `None` if the input is empty/whitespace-only.
+#[must_use]
 pub fn truncate_detail(s: &str) -> Option<String> {
     let trimmed = s.trim();
     if trimmed.is_empty() {
@@ -200,13 +285,14 @@ pub fn truncate_detail(s: &str) -> Option<String> {
 ///
 /// Searches `haystack` for `label`, then walks backwards from the match position
 /// to collect consecutive digits, producing the count.
+#[must_use]
 pub fn extract_count(haystack: &str, label: &str) -> Option<u32> {
     let pos = haystack.find(label)?;
     let before = haystack[..pos].trim_end();
     let digits: String = before
         .chars()
         .rev()
-        .take_while(|c| c.is_ascii_digit())
+        .take_while(char::is_ascii_digit)
         .collect::<String>()
         .chars()
         .rev()
@@ -215,6 +301,7 @@ pub fn extract_count(haystack: &str, label: &str) -> Option<u32> {
 }
 
 /// Build a human-readable test summary, omitting zero categories except `passed`.
+#[must_use]
 pub fn build_test_summary(passed: u32, failed: u32, skipped: u32) -> String {
     let mut parts: Vec<String> = Vec::new();
     parts.push(format!("{passed} passed"));
@@ -227,7 +314,8 @@ pub fn build_test_summary(passed: u32, failed: u32, skipped: u32) -> String {
     parts.join(", ")
 }
 
-/// Parse "Found N ..." lines (used by tsc and mypy).
+/// Parse "Found N ..." lines (used by `tsc` and `mypy`).
+#[must_use]
 pub fn parse_found_count(line: &str) -> Option<u32> {
     let rest = line.trim().strip_prefix("Found ")?;
     let space = rest.find(' ')?;
@@ -235,6 +323,7 @@ pub fn parse_found_count(line: &str) -> Option<u32> {
 }
 
 /// Build summary for linter/compiler output.
+#[must_use]
 pub fn build_lint_summary(errors: u32, warnings: u32) -> String {
     match (errors, warnings) {
         (0, 0) => "no issues".to_string(),


### PR DESCRIPTION
## Summary

Adds `tilth_run` — a command execution + output compression engine for the tilth MCP server and CLI. Parses verbose CLI output (cargo, npm, pytest, jest, eslint, go test, mypy, ruff, tsc) into structured diagnostics with never-worse compression guarantee.

### What's included

- **Structured API**: `process_structured()` returns `CompressResult` with lazy formatting (Markdown, Plain, JSON)
- **Command execution** (`exec.rs`): Process group killing via `setpgid(0,0)` + `killpg()`, bounded reads, lossy UTF-8, timeout handling
- **9 parsers**: cargo build/test, npm, jest, eslint, pytest, go test, mypy, ruff, tsc — each with AST-aware diagnostic extraction
- **CLI subcommand**: `tilth run <command>` with `--format`, `--timeout`, `--cwd` options
- **Hook integration**: `tilth hook-rewrite` for Claude Code PreToolUse hooks — transparently compresses Bash tool output
- **3 output formats**: Markdown (MCP), Plain (terminal/hook), JSON (machine consumption)

### Safety & correctness (3-round audit, 250 tests)

- Process group killing ensures entire command trees die on timeout (not just `sh`)
- `killpg(0)` guard prevents killing the MCP server's own process group
- Lossy UTF-8 reads — no panics on binary command output
- POSIX shell quoting with `'\''` escaping for hook paths
- Single-arg passthrough avoids re-quoting compound commands from hooks
- `extract_base_command()` skips env vars and wrappers (sudo, env, time, etc.)
- Never-worse guarantee: compressed output is always <= original size

## Test plan

- [x] 250 unit + integration tests pass (`cargo test`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] 3 full audit rounds with test-first bug fixing
- [ ] Manual test: `tilth run "cargo build"` on a real project
- [ ] Manual test: hook rewrite integration with Claude Code

🤖 Generated with [Claude Code](https://claude.com/claude-code)