### PR TITLE
fix: map silently drops entire directory subtrees (critical)

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -76,11 +76,21 @@ pub fn generate(scope: &Path, depth: usize, budget: Option<u64>, cache: &Outline
             _ => None,
         };
 
-        tree.entry(parent).or_default().push(FileEntry {
+        tree.entry(parent.clone()).or_default().push(FileEntry {
             name,
             symbols,
             tokens,
         });
+
+        // Ensure all ancestor directories exist in the tree so format_tree can find them.
+        let mut ancestor = parent.parent();
+        while let Some(a) = ancestor {
+            tree.entry(a.to_path_buf()).or_default();
+            if a == Path::new("") {
+                break;
+            }
+            ancestor = a.parent();
+        }
     }
 
     let mut out = format!("# Map: {} (depth {})\n", scope.display(), depth);


### PR DESCRIPTION
## Critical Bug

`--map` silently drops entire directory subtrees, producing incomplete and misleading output. Users see a map that looks correct but is missing major parts of their codebase with no warning.

## Root Cause

`format_tree` renders a directory only if it exists as a key in the tree BTreeMap. But keys are only created when a file is inserted — intermediate directories that contain only subdirectories (no direct files) never get a key. This breaks the parent→child chain and makes the entire subtree invisible.

Example: `cmd/server/main.go` inserts key `cmd/server` into the tree. But `cmd/` has no direct files, so key `cmd` is never created. `format_tree` starts at root, looks for children with `parent == ""` — `cmd/server` has parent `cmd`, not `""` — so the whole branch vanishes.

## Impact

- Affects **all languages and project structures** with organizational parent directories (not just Go)
- Go: `cmd/`, `internal/` — standard layout, almost always hit
- Java: `src/main/java/com/...` — always hit
- Any monorepo or deeply nested structure
- Rust projects like tilth itself happen to not trigger it because `src/` contains files directly (`lib.rs`, `main.rs`), masking the bug
- Real-world test: a Go project went from 101 lines (broken) to 560 lines (correct) — over 80% of the codebase was invisible

## Fix

One-liner: when inserting a file, walk up and ensure all ancestor directories exist as (possibly empty) entries in the tree.

## Verification

`cargo fmt --check && cargo clippy -- -D warnings && cargo test` all pass.
