### PR TITLE
Add Elixir language support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,6 +712,7 @@ dependencies = [
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
+ "tree-sitter-elixir",
  "tree-sitter-go",
  "tree-sitter-java",
  "tree-sitter-javascript",
@@ -805,6 +806,16 @@ name = "tree-sitter-cpp"
 version = "0.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df2196ea9d47b4ab4a31b9297eaa5a5d19a0b121dceb9f118f6790ad0ab94743"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-elixir"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66dd064a762ed95bfc29857fa3cb7403bb1e5cb88112de0f6341b7e47284ba40"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ tree-sitter-scala = "0.24"
 tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-ng = "1.1"
+tree-sitter-elixir = "0.3"
 
 # Search (ripgrep internals)
 grep-regex = "0.1"

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -310,6 +310,12 @@ fn walk_definitions(
                 symbols.push((Arc::from(iface.as_str()), line, true));
             }
         }
+    } else if crate::lang::treesitter::is_elixir_definition(node, lines) {
+        // Elixir: all definitions are `call` nodes — handle separately
+        if let Some(name) = crate::lang::treesitter::extract_elixir_definition_name(node, lines) {
+            let line = node.start_position().row as u32 + 1;
+            symbols.push((Arc::from(name.as_str()), line, true));
+        }
     }
 
     // Recurse into children for nested definitions (impl blocks, class bodies, modules)

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -260,7 +260,7 @@ fn extract_symbols(path: &Path, content: &str) -> Vec<(Arc<str>, u32, bool)> {
     let lines: Vec<&str> = content.lines().collect();
     let mut symbols = Vec::new();
 
-    walk_definitions(tree.root_node(), &lines, &mut symbols, 0);
+    walk_definitions(tree.root_node(), &lines, &mut symbols, lang, 0);
 
     symbols
 }
@@ -275,6 +275,7 @@ fn walk_definitions(
     node: tree_sitter::Node,
     lines: &[&str],
     symbols: &mut Vec<(Arc<str>, u32, bool)>,
+    lang: crate::types::Lang,
     depth: usize,
 ) {
     if depth > 3 {
@@ -310,7 +311,9 @@ fn walk_definitions(
                 symbols.push((Arc::from(iface.as_str()), line, true));
             }
         }
-    } else if crate::lang::treesitter::is_elixir_definition(node, lines) {
+    } else if lang == crate::types::Lang::Elixir
+        && crate::lang::treesitter::is_elixir_definition(node, lines)
+    {
         // Elixir: all definitions are `call` nodes — handle separately
         if let Some(name) = crate::lang::treesitter::extract_elixir_definition_name(node, lines) {
             let line = node.start_position().row as u32 + 1;
@@ -321,7 +324,7 @@ fn walk_definitions(
     // Recurse into children for nested definitions (impl blocks, class bodies, modules)
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
-        walk_definitions(child, lines, symbols, depth + 1);
+        walk_definitions(child, lines, symbols, lang, depth + 1);
     }
 }
 

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -24,6 +24,7 @@ pub fn detect_file_type(path: &Path) -> FileType {
         Some("swift") => FileType::Code(Lang::Swift),
         Some("kt" | "kts") => FileType::Code(Lang::Kotlin),
         Some("cs") => FileType::Code(Lang::CSharp),
+        Some("ex" | "exs") => FileType::Code(Lang::Elixir),
 
         Some("md" | "mdx" | "rst") => FileType::Markdown,
         Some("json" | "yaml" | "yml" | "toml" | "xml" | "ini") => FileType::StructuredData,
@@ -56,6 +57,7 @@ pub(crate) fn package_root(path: &Path) -> Option<&Path> {
         "pom.xml",
         "build.gradle",
         "build.sbt",
+        "mix.exs",
     ];
     let mut dir = path;
     loop {

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -514,32 +514,9 @@ fn elixir_func_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
         if !child.is_named() {
             continue;
         }
-        return elixir_func_head_name(child, lines);
+        return super::treesitter::elixir_extract_func_head_name(child, lines);
     }
     None
-}
-
-/// Extract function name from a function head node.
-///
-/// Handles three shapes:
-/// - `call`: `greet(name)` → target is `greet`
-/// - `identifier`: `bar` (no-arg, no-parens)
-/// - `binary_operator[when]`: `foo(x) when x > 0` → unwrap left, recurse
-fn elixir_func_head_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
-    match node.kind() {
-        "call" => {
-            if let Some(target) = node.child_by_field_name("target") {
-                return Some(node_text(target, lines));
-            }
-            None
-        }
-        "identifier" => Some(node_text(node, lines)),
-        "binary_operator" => {
-            let left = node.child_by_field_name("left")?;
-            elixir_func_head_name(left, lines)
-        }
-        _ => None,
-    }
 }
 
 /// Extract type name from an Elixir `@type` call.
@@ -586,11 +563,11 @@ fn elixir_callback_name(call: tree_sitter::Node, lines: &[&str]) -> Option<Strin
         if child.kind() == "binary_operator" {
             // `handle_event(...) :: return_type` → left is the function head
             if let Some(left) = child.child_by_field_name("left") {
-                return elixir_func_head_name(left, lines);
+                return super::treesitter::elixir_extract_func_head_name(left, lines);
             }
         }
         // Bare callback without return type spec (unlikely but handle it)
-        return elixir_func_head_name(child, lines);
+        return super::treesitter::elixir_extract_func_head_name(child, lines);
     }
     None
 }

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -375,7 +375,11 @@ fn extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
 // Elixir-specific outline helpers
 // ---------------------------------------------------------------------------
 
-/// Elixir definition keywords that correspond to outline entries.
+/// Elixir function-like definition keywords that produce `OutlineKind::Function`.
+/// This is the subset of definition keywords handled uniformly (extract function
+/// name from arguments). Container keywords (`defmodule`, `defprotocol`, `defimpl`,
+/// `defstruct`, `defexception`) have their own match arms in `elixir_call_to_entry`.
+/// See also `ELIXIR_DEFINITION_TARGETS` in `treesitter.rs` for the complete set.
 const ELIXIR_DEF_KEYWORDS: &[&str] = &[
     "def",
     "defp",
@@ -573,6 +577,11 @@ fn elixir_callback_name(call: tree_sitter::Node, lines: &[&str]) -> Option<Strin
 }
 
 /// Collect child entries from an Elixir module/protocol/impl `do_block`.
+///
+/// This intentionally includes `use`/`alias`/`import`/`require` as import entries
+/// inside module outlines. In Elixir these are structural — `use GenServer` injects
+/// callbacks, `alias Foo.Bar` affects name resolution — so they provide useful
+/// context alongside function definitions.
 fn elixir_collect_children(
     node: tree_sitter::Node,
     lines: &[&str],

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -269,7 +269,9 @@ fn extract_signature(node: tree_sitter::Node, lines: &[&str]) -> String {
                 return line[..pos].trim().to_string();
             }
         }
-        // Elixir — truncate at ` do` (block form) or `, do:` (keyword form)
+        // Elixir — truncate at ` do` (block form) or `, do:` (keyword form).
+        // Safe for other languages: C/Java/Go/Rust hit the `{` branch above,
+        // Python hits the `:` branch. Only Elixir uses ` do` as a block delimiter.
         if let Some(pos) = line.rfind(" do") {
             let after = &line[pos + 3..];
             if after.is_empty() || after.starts_with('\n') {

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -660,8 +660,12 @@ fn elixir_extract_doc_string(node: tree_sitter::Node, lines: &[&str]) -> Option<
     let end_row = node.end_position().row;
 
     if start_row == end_row {
-        // Single-line: `"text"` — strip delimiters
-        let text = node_text(node, lines);
+        // Single-line: `"text"` or `~s"text"` — strip delimiters and sigil prefix
+        let mut text = node_text(node, lines);
+        // Strip sigil prefix (~s, ~S, etc.) if present
+        if text.starts_with('~') && text.len() >= 2 {
+            text = text[2..].to_string();
+        }
         let trimmed = text.trim_matches('"').trim();
         if trimmed.is_empty() {
             return None;

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -637,8 +637,22 @@ fn elixir_extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String>
 /// Extract the source module name from an import statement text.
 /// Handles: `use std::fs;` → `std::fs`, `import X from "react"` → `react`,
 /// `from collections import X` → `collections`
-pub(crate) fn extract_import_source(text: &str) -> String {
+///
+/// The `lang` parameter is needed to disambiguate `use` (Rust path vs Elixir module)
+/// and `import` (JS/TS `from` syntax vs Elixir/Python/Go bare module name).
+pub(crate) fn extract_import_source(text: &str, lang: Option<crate::types::Lang>) -> String {
     let trimmed = text.trim().trim_end_matches(';');
+
+    // Elixir: `use GenServer`, `import Kernel`, `alias Foo.Bar`, `require Logger`
+    // Must be checked before the Rust `use` and JS `import` branches.
+    if lang == Some(crate::types::Lang::Elixir) {
+        for prefix in &["use ", "import ", "alias ", "require "] {
+            if let Some(rest) = trimmed.strip_prefix(prefix) {
+                return rest.split(',').next().unwrap_or(rest).trim().to_string();
+            }
+        }
+        return trimmed.to_string();
+    }
 
     // Rust: `use foo::bar` → `foo::bar`
     if let Some(rest) = trimmed.strip_prefix("use ") {
@@ -679,13 +693,6 @@ pub(crate) fn extract_import_source(text: &str) -> String {
     // C/C++: #include "file.h" or #include <header>
     if let Some(rest) = trimmed.strip_prefix("#include") {
         return rest.trim().to_string(); // preserves quotes/angles for external detection
-    }
-
-    // Elixir: `alias Foo.Bar`, `use GenServer`, `require Logger`
-    for prefix in &["alias ", "require "] {
-        if let Some(rest) = trimmed.strip_prefix(prefix) {
-            return rest.split(',').next().unwrap_or(rest).trim().to_string();
-        }
     }
 
     // Go: `import "source"` — already handled above via "import"

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -19,6 +19,7 @@ pub fn outline_language(lang: Lang) -> Option<tree_sitter::Language> {
         Lang::CSharp => tree_sitter_c_sharp::LANGUAGE,
         Lang::Swift => tree_sitter_swift::LANGUAGE,
         Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE,
+        Lang::Elixir => tree_sitter_elixir::LANGUAGE,
         Lang::Dockerfile | Lang::Make => {
             return None;
         }
@@ -180,6 +181,16 @@ fn node_to_entry(
             (OutlineKind::Module, name, None)
         }
 
+        // Elixir: all definitions are `call` nodes distinguished by target identifier
+        "call" if lang == Lang::Elixir => {
+            return elixir_call_to_entry(node, lines, lang, depth);
+        }
+
+        // Elixir: @type, @typep, @opaque are unary_operator nodes
+        "unary_operator" if lang == Lang::Elixir => {
+            return elixir_attr_to_entry(node, lines);
+        }
+
         _ => return None,
     };
 
@@ -257,6 +268,16 @@ fn extract_signature(node: tree_sitter::Node, lines: &[&str]) -> String {
             if let Some(pos) = line.rfind(':') {
                 return line[..pos].trim().to_string();
             }
+        }
+        // Elixir — truncate at ` do` (block form) or `, do:` (keyword form)
+        if let Some(pos) = line.rfind(" do") {
+            let after = &line[pos + 3..];
+            if after.is_empty() || after.starts_with('\n') {
+                return line[..pos].trim().to_string();
+            }
+        }
+        if let Some(pos) = line.find(", do:") {
+            return line[..pos].trim().to_string();
         }
         // Full first line, truncated
         if line.len() > 120 {
@@ -350,6 +371,292 @@ fn extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Elixir-specific outline helpers
+// ---------------------------------------------------------------------------
+
+/// Elixir definition keywords that correspond to outline entries.
+const ELIXIR_DEF_KEYWORDS: &[&str] = &[
+    "def",
+    "defp",
+    "defmacro",
+    "defmacrop",
+    "defguard",
+    "defguardp",
+    "defdelegate",
+];
+
+/// Convert an Elixir `call` node to an outline entry.
+///
+/// In the Elixir tree-sitter grammar, `defmodule`, `def`, `defp`, `defstruct`,
+/// etc. are all `call` nodes whose `target` field is an identifier like `"def"`.
+fn elixir_call_to_entry(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    lang: Lang,
+    depth: usize,
+) -> Option<OutlineEntry> {
+    let target = node.child_by_field_name("target")?;
+    let keyword = node_text(target, lines);
+    let start_line = node.start_position().row as u32 + 1;
+    let end_line = node.end_position().row as u32 + 1;
+
+    let (kind, name, signature) = match keyword.as_str() {
+        "defmodule" => {
+            let name = elixir_first_arg_text(node, lines)?;
+            (OutlineKind::Module, name, None)
+        }
+        kw if ELIXIR_DEF_KEYWORDS.contains(&kw) => {
+            let name = elixir_func_name(node, lines)?;
+            let sig = extract_signature(node, lines);
+            (OutlineKind::Function, name, Some(sig))
+        }
+        "defstruct" | "defexception" => (OutlineKind::Struct, keyword.clone(), None),
+        "defprotocol" => {
+            let name = elixir_first_arg_text(node, lines)?;
+            (OutlineKind::Interface, name, None)
+        }
+        "defimpl" => {
+            let name = elixir_first_arg_text(node, lines)?;
+            (OutlineKind::Module, format!("impl {name}"), None)
+        }
+        "use" | "import" | "alias" | "require" => {
+            let text = node_text(node, lines);
+            (OutlineKind::Import, text, None)
+        }
+        _ => return None,
+    };
+
+    // Collect children for modules, protocols, impls
+    let children = if matches!(kind, OutlineKind::Module | OutlineKind::Interface) && depth < 1 {
+        elixir_collect_children(node, lines, lang, depth + 1)
+    } else {
+        Vec::new()
+    };
+
+    // Extract @doc / @moduledoc from previous sibling
+    let doc = elixir_extract_doc(node, lines);
+
+    Some(OutlineEntry {
+        kind,
+        name,
+        start_line,
+        end_line,
+        signature,
+        children,
+        doc,
+    })
+}
+
+/// Convert an Elixir `unary_operator` node (`@type`, `@typep`, `@opaque`) to an outline entry.
+fn elixir_attr_to_entry(node: tree_sitter::Node, lines: &[&str]) -> Option<OutlineEntry> {
+    let operand = node.child_by_field_name("operand")?;
+    if operand.kind() != "call" {
+        return None;
+    }
+    let target = operand.child_by_field_name("target")?;
+    let attr_name = node_text(target, lines);
+    let start_line = node.start_position().row as u32 + 1;
+    let end_line = node.end_position().row as u32 + 1;
+    match attr_name.as_str() {
+        "type" | "typep" | "opaque" => {
+            let name = elixir_type_name(operand, lines)?;
+            let sig = node_text(node, lines);
+            Some(OutlineEntry {
+                kind: OutlineKind::TypeAlias,
+                name,
+                start_line,
+                end_line,
+                signature: Some(sig),
+                children: Vec::new(),
+                doc: None,
+            })
+        }
+        "callback" | "macrocallback" => {
+            let name = elixir_callback_name(operand, lines)?;
+            let sig = node_text(node, lines);
+            Some(OutlineEntry {
+                kind: OutlineKind::Function,
+                name,
+                start_line,
+                end_line,
+                signature: Some(sig),
+                children: Vec::new(),
+                doc: None,
+            })
+        }
+        _ => None,
+    }
+}
+
+/// Extract the first argument text from an Elixir call node.
+/// For `defmodule Foo.Bar do ... end`, returns `"Foo.Bar"`.
+fn elixir_first_arg_text(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let args = super::treesitter::elixir_arguments(node)?;
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if child.is_named() {
+            return Some(node_text(child, lines));
+        }
+    }
+    None
+}
+
+/// Extract function name from an Elixir `def`/`defp` call node.
+///
+/// For `def greet(name) do ... end`, the AST is:
+///   call[target=def] → arguments → call[target=greet] → arguments → ...
+/// For `def greet(name), do: ...` (keyword form), same structure.
+fn elixir_func_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let args = super::treesitter::elixir_arguments(node)?;
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+        return elixir_func_head_name(child, lines);
+    }
+    None
+}
+
+/// Extract function name from a function head node.
+///
+/// Handles three shapes:
+/// - `call`: `greet(name)` → target is `greet`
+/// - `identifier`: `bar` (no-arg, no-parens)
+/// - `binary_operator[when]`: `foo(x) when x > 0` → unwrap left, recurse
+fn elixir_func_head_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    match node.kind() {
+        "call" => {
+            if let Some(target) = node.child_by_field_name("target") {
+                return Some(node_text(target, lines));
+            }
+            None
+        }
+        "identifier" => Some(node_text(node, lines)),
+        "binary_operator" => {
+            let left = node.child_by_field_name("left")?;
+            elixir_func_head_name(left, lines)
+        }
+        _ => None,
+    }
+}
+
+/// Extract type name from an Elixir `@type` call.
+/// For `@type t :: %{...}`, the call operand is `type t :: %{...}`,
+/// and we extract `t` from the first argument.
+fn elixir_type_name(call: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let args = super::treesitter::elixir_arguments(call)?;
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+        // `type t :: ...` → binary_operator with left=identifier
+        if child.kind() == "binary_operator" {
+            if let Some(left) = child.child_by_field_name("left") {
+                // left may be a call like `t()` or an identifier `t`
+                if left.kind() == "call" {
+                    if let Some(target) = left.child_by_field_name("target") {
+                        return Some(node_text(target, lines));
+                    }
+                }
+                return Some(node_text(left, lines));
+            }
+        }
+        // Bare identifier
+        if child.kind() == "identifier" {
+            return Some(node_text(child, lines));
+        }
+    }
+    None
+}
+
+/// Extract callback name from an Elixir `@callback` call.
+/// For `@callback handle_event(event :: term()) :: :ok`, the call operand is
+/// `callback handle_event(...) :: :ok`. The arguments contain a `binary_operator`
+/// with `::`, whose left side is a `call` with target = the callback name.
+fn elixir_callback_name(call: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let args = super::treesitter::elixir_arguments(call)?;
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if !child.is_named() {
+            continue;
+        }
+        if child.kind() == "binary_operator" {
+            // `handle_event(...) :: return_type` → left is the function head
+            if let Some(left) = child.child_by_field_name("left") {
+                return elixir_func_head_name(left, lines);
+            }
+        }
+        // Bare callback without return type spec (unlikely but handle it)
+        return elixir_func_head_name(child, lines);
+    }
+    None
+}
+
+/// Collect child entries from an Elixir module/protocol/impl `do_block`.
+fn elixir_collect_children(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    lang: Lang,
+    depth: usize,
+) -> Vec<OutlineEntry> {
+    let mut children = Vec::new();
+    let mut cursor = node.walk();
+
+    // Find the do_block child
+    let Some(do_block) = node.children(&mut cursor).find(|c| c.kind() == "do_block") else {
+        return children;
+    };
+
+    let mut cursor2 = do_block.walk();
+    for child in do_block.children(&mut cursor2) {
+        if let Some(entry) = node_to_entry(child, lines, lang, depth) {
+            children.push(entry);
+        }
+    }
+
+    children
+}
+
+/// Extract @doc or @moduledoc text from the previous sibling of an Elixir definition.
+///
+/// In Elixir, `@doc "text"` is a `unary_operator` node. We check if the
+/// previous sibling is such a node and extract the string content.
+fn elixir_extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let prev = node.prev_sibling()?;
+    if prev.kind() != "unary_operator" {
+        return None;
+    }
+    let operand = prev.child_by_field_name("operand")?;
+    if operand.kind() != "call" {
+        return None;
+    }
+    let target = operand.child_by_field_name("target")?;
+    let attr = node_text(target, lines);
+    if attr != "doc" && attr != "moduledoc" {
+        return None;
+    }
+    // Get the string argument
+    let args = super::treesitter::elixir_arguments(operand)?;
+    let mut cursor = args.walk();
+    for child in args.children(&mut cursor) {
+        if child.is_named() {
+            let text = node_text(child, lines);
+            let trimmed = text
+                .trim_matches('"')
+                .trim_start_matches("~S\"\"\"")
+                .trim_end_matches("\"\"\"")
+                .trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+    }
+    None
+}
+
 /// Extract the source module name from an import statement text.
 /// Handles: `use std::fs;` → `std::fs`, `import X from "react"` → `react`,
 /// `from collections import X` → `collections`
@@ -395,6 +702,13 @@ pub(crate) fn extract_import_source(text: &str) -> String {
     // C/C++: #include "file.h" or #include <header>
     if let Some(rest) = trimmed.strip_prefix("#include") {
         return rest.trim().to_string(); // preserves quotes/angles for external detection
+    }
+
+    // Elixir: `alias Foo.Bar`, `use GenServer`, `require Logger`
+    for prefix in &["alias ", "require "] {
+        if let Some(rest) = trimmed.strip_prefix(prefix) {
+            return rest.split(',').next().unwrap_or(rest).trim().to_string();
+        }
     }
 
     // Go: `import "source"` — already handled above via "import"

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -615,20 +615,59 @@ fn elixir_extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String>
     if attr != "doc" && attr != "moduledoc" {
         return None;
     }
-    // Get the string argument
+    // Get the doc argument — use tree-sitter node types to handle all forms:
+    //   `@doc "text"`           → string node
+    //   `@doc """heredoc"""`    → string node (multi-line)
+    //   `@doc ~S"""sigil"""`    → sigil node
+    //   `@doc ~s"""sigil"""`    → sigil node
+    //   `@doc false`            → boolean node (suppress docs)
     let args = super::treesitter::elixir_arguments(operand)?;
     let mut cursor = args.walk();
     for child in args.children(&mut cursor) {
-        if child.is_named() {
-            let text = node_text(child, lines);
-            let trimmed = text
-                .trim_matches('"')
-                .trim_start_matches("~S\"\"\"")
-                .trim_end_matches("\"\"\"")
-                .trim();
-            if !trimmed.is_empty() {
-                return Some(trimmed.to_string());
+        if !child.is_named() {
+            continue;
+        }
+        match child.kind() {
+            // `@doc false` suppresses documentation
+            "boolean" => return None,
+            // Regular string (`"text"`, `"""heredoc"""`) or sigil (`~S"""..."""`, `~s"""..."""`)
+            "string" | "sigil" => {
+                return elixir_extract_doc_string(child, lines);
             }
+            _ => {}
+        }
+    }
+    None
+}
+
+/// Extract the first meaningful line from an Elixir doc string or sigil node.
+///
+/// For single-line strings (`"text"`), returns the content without quotes.
+/// For heredocs/sigils (`"""..."""`, `~S"""..."""`), returns the first
+/// non-empty content line. Uses tree-sitter source lines rather than
+/// fragile string trimming.
+fn elixir_extract_doc_string(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let start_row = node.start_position().row;
+    let end_row = node.end_position().row;
+
+    if start_row == end_row {
+        // Single-line: `"text"` — strip delimiters
+        let text = node_text(node, lines);
+        let trimmed = text.trim_matches('"').trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+        return Some(trimmed.to_string());
+    }
+
+    // Multi-line (heredoc or sigil): scan interior lines for first non-empty content
+    for row in (start_row + 1)..end_row {
+        if row >= lines.len() {
+            break;
+        }
+        let line = lines[row].trim();
+        if !line.is_empty() && line != "\"\"\"" {
+            return Some(line.to_string());
         }
     }
     None

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -130,6 +130,128 @@ pub(crate) fn extract_implemented_interfaces(
     interfaces
 }
 
+// ---------------------------------------------------------------------------
+// Elixir-specific definition helpers
+// ---------------------------------------------------------------------------
+
+/// Elixir call-node target identifiers that define named symbols.
+const ELIXIR_DEFINITION_TARGETS: &[&str] = &[
+    "defmodule",
+    "def",
+    "defp",
+    "defmacro",
+    "defmacrop",
+    "defguard",
+    "defguardp",
+    "defdelegate",
+    "defstruct",
+    "defexception",
+    "defprotocol",
+    "defimpl",
+];
+
+/// Find the `arguments` child of an Elixir `call` node.
+/// In tree-sitter-elixir, `arguments` is a node kind, not a named field,
+/// so `child_by_field_name("arguments")` doesn't work.
+pub(crate) fn elixir_arguments(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
+    let mut cursor = node.walk();
+    let result = node.children(&mut cursor).find(|c| c.kind() == "arguments");
+    result
+}
+
+/// Check if a tree-sitter node is an Elixir definition.
+/// In Elixir all definitions are `call` nodes whose `target` identifier
+/// is one of `defmodule`, `def`, `defp`, etc.
+pub(crate) fn is_elixir_definition(node: tree_sitter::Node, lines: &[&str]) -> bool {
+    if node.kind() != "call" {
+        return false;
+    }
+    let Some(target) = node.child_by_field_name("target") else {
+        return false;
+    };
+    let kw = node_text_simple(target, lines);
+    ELIXIR_DEFINITION_TARGETS.contains(&kw.as_str())
+}
+
+/// Extract the defined name from an Elixir definition `call` node.
+///
+/// - `defmodule Foo.Bar do...end` → `"Foo.Bar"`
+/// - `def greet(name) do...end`  → `"greet"`
+/// - `defstruct [:a, :b]`       → `"defstruct"`
+pub(crate) fn extract_elixir_definition_name(
+    node: tree_sitter::Node,
+    lines: &[&str],
+) -> Option<String> {
+    let target = node.child_by_field_name("target")?;
+    let kw = node_text_simple(target, lines);
+    let args = elixir_arguments(node)?;
+
+    match kw.as_str() {
+        "defmodule" | "defprotocol" | "defimpl" => {
+            // First named child of arguments is the module/protocol alias
+            let mut cursor = args.walk();
+            for child in args.children(&mut cursor) {
+                if child.is_named() {
+                    return Some(node_text_simple(child, lines));
+                }
+            }
+            None
+        }
+        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
+            // First named child is:
+            //   `call`              — normal: `def greet(name)`
+            //   `identifier`        — no-arg: `def bar, do: :ok`
+            //   `binary_operator`   — guard:  `def foo(x) when x > 0`
+            let mut cursor = args.walk();
+            for child in args.children(&mut cursor) {
+                if !child.is_named() {
+                    continue;
+                }
+                return elixir_extract_func_head_name(child, lines);
+            }
+            None
+        }
+        "defstruct" | "defexception" => Some(kw.clone()),
+        _ => None,
+    }
+}
+
+/// Extract function name from the first argument of a `def`/`defp`/`defmacro` call.
+///
+/// The first argument can be:
+/// - `call` node: `def greet(name)` → target is `greet`
+/// - `identifier` node: `def bar, do: :ok` → text is `bar`
+/// - `binary_operator` with `when`: `def foo(x) when x > 0` → unwrap left, then recurse
+fn elixir_extract_func_head_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    match node.kind() {
+        "call" => node
+            .child_by_field_name("target")
+            .map(|t| node_text_simple(t, lines)),
+        "identifier" => Some(node_text_simple(node, lines)),
+        "binary_operator" => {
+            // Guard clause: `foo(x) when x > 0` → left is the function head
+            let left = node.child_by_field_name("left")?;
+            elixir_extract_func_head_name(left, lines)
+        }
+        _ => None,
+    }
+}
+
+/// Semantic weight for Elixir definition keywords.
+pub(crate) fn elixir_definition_weight(node: tree_sitter::Node, lines: &[&str]) -> u16 {
+    let Some(target) = node.child_by_field_name("target") else {
+        return 50;
+    };
+    let kw = node_text_simple(target, lines);
+    match kw.as_str() {
+        "defmodule" | "defprotocol" | "def" | "defp" | "defmacro" | "defmacrop" | "defguard"
+        | "defguardp" | "defdelegate" => 100,
+        "defimpl" => 90,
+        "defstruct" | "defexception" => 80,
+        _ => 50,
+    }
+}
+
 /// Semantic weight for definition kinds. Primary declarations rank highest.
 pub(crate) fn definition_weight(kind: &str) -> u16 {
     match kind {

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -135,6 +135,11 @@ pub(crate) fn extract_implemented_interfaces(
 // ---------------------------------------------------------------------------
 
 /// Elixir call-node target identifiers that define named symbols.
+/// This is the complete set used for definition detection in symbol search/index.
+/// See also `ELIXIR_DEF_KEYWORDS` in `outline.rs` which is the subset of
+/// function-like keywords (excludes container keywords like `defmodule`,
+/// `defprotocol`, `defimpl`, `defstruct`, `defexception` that have their own
+/// outline handling).
 const ELIXIR_DEFINITION_TARGETS: &[&str] = &[
     "defmodule",
     "def",
@@ -155,6 +160,7 @@ const ELIXIR_DEFINITION_TARGETS: &[&str] = &[
 /// so `child_by_field_name("arguments")` doesn't work.
 pub(crate) fn elixir_arguments(node: tree_sitter::Node) -> Option<tree_sitter::Node> {
     let mut cursor = node.walk();
+    // Node is Copy (arena index) — the returned node survives cursor drop.
     let result = node.children(&mut cursor).find(|c| c.kind() == "arguments");
     result
 }
@@ -211,6 +217,10 @@ pub(crate) fn extract_elixir_definition_name(
             }
             None
         }
+        // In Elixir, a struct IS its enclosing module (`%MyModule{}`), and only
+        // one struct per module is allowed. There's no standalone struct name to
+        // extract, so we index the keyword itself. Search for the struct by its
+        // module name instead.
         "defstruct" | "defexception" => Some(kw.clone()),
         _ => None,
     }

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -222,7 +222,10 @@ pub(crate) fn extract_elixir_definition_name(
 /// - `call` node: `def greet(name)` → target is `greet`
 /// - `identifier` node: `def bar, do: :ok` → text is `bar`
 /// - `binary_operator` with `when`: `def foo(x) when x > 0` → unwrap left, then recurse
-fn elixir_extract_func_head_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+pub(crate) fn elixir_extract_func_head_name(
+    node: tree_sitter::Node,
+    lines: &[&str],
+) -> Option<String> {
     match node.kind() {
         "call" => node
             .child_by_field_name("target")

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -194,7 +194,10 @@ pub(crate) fn extract_elixir_definition_name(
 
     match kw.as_str() {
         "defmodule" | "defprotocol" | "defimpl" => {
-            // First named child of arguments is the module/protocol alias
+            // First named child of arguments is the module/protocol alias.
+            // For `defimpl Printable, for: User`, this returns "Printable" (the
+            // protocol name), not "User" (the implementing type). Searching for
+            // the protocol name will find both the protocol and all its impls.
             let mut cursor = args.walk();
             for child in args.children(&mut cursor) {
                 if child.is_named() {

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -250,6 +250,7 @@ fn lang_display_name(lang: Lang) -> &'static str {
         Lang::Swift => "Swift",
         Lang::Kotlin => "Kotlin",
         Lang::CSharp => "C#",
+        Lang::Elixir => "Elixir",
         Lang::Dockerfile => "Docker",
         Lang::Make => "Make",
     }

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -831,7 +831,7 @@ fn hot_files(root: &Path, walk: &WalkResult, primary_lang: Option<Lang>) -> Opti
         // Collect import source strings for symbol extraction
         for line in content.lines() {
             if is_import_line(line, lang) {
-                let source = crate::lang::outline::extract_import_source(line);
+                let source = crate::lang::outline::extract_import_source(line, Some(lang));
                 if !source.is_empty() && !crate::read::imports::is_external(&source, lang) {
                     all_import_sources.push(source);
                 }

--- a/src/read/imports.rs
+++ b/src/read/imports.rs
@@ -81,7 +81,7 @@ pub(crate) fn is_external(source: &str, lang: Lang) -> bool {
         }
         Lang::Python => !source.starts_with('.'),
         Lang::C | Lang::Cpp => !source.starts_with('"'),
-        // Go, Java, Scala, Kotlin — can't resolve without build system knowledge.
+        // Elixir, Go, Java, Scala, Kotlin — can't resolve without build system knowledge.
         _ => true,
     }
 }
@@ -92,6 +92,7 @@ fn resolve(dir: &Path, source: &str, lang: Lang) -> Option<PathBuf> {
         Lang::TypeScript | Lang::Tsx | Lang::JavaScript => resolve_js(dir, source),
         Lang::Python => resolve_python(dir, source),
         Lang::C | Lang::Cpp => resolve_c_include(dir, source),
+        // Elixir, Go, Java, etc. — module-to-file mapping requires build system conventions.
         _ => None,
     }
 }

--- a/src/read/imports.rs
+++ b/src/read/imports.rs
@@ -59,6 +59,12 @@ pub(crate) fn is_import_line(line: &str, lang: Lang) -> bool {
         Lang::Python => trimmed.starts_with("import ") || trimmed.starts_with("from "),
         Lang::Go | Lang::Java | Lang::Scala | Lang::Kotlin => trimmed.starts_with("import "),
         Lang::C | Lang::Cpp => trimmed.starts_with("#include"),
+        Lang::Elixir => {
+            trimmed.starts_with("alias ")
+                || trimmed.starts_with("import ")
+                || trimmed.starts_with("use ")
+                || trimmed.starts_with("require ")
+        }
         _ => false,
     }
 }

--- a/src/read/imports.rs
+++ b/src/read/imports.rs
@@ -36,7 +36,7 @@ pub fn resolve_related_files_with_content(file_path: &Path, content: &str) -> Ve
         if !is_import_line(line, lang) {
             continue;
         }
-        let source = crate::lang::outline::extract_import_source(line);
+        let source = crate::lang::outline::extract_import_source(line, Some(lang));
         if source.is_empty() || is_external(&source, lang) {
             continue;
         }

--- a/src/read/outline/code.rs
+++ b/src/read/outline/code.rs
@@ -52,7 +52,7 @@ fn format_entries(
             _ => {
                 // Flush any accumulated imports
                 if !import_groups.is_empty() {
-                    out.push(format_imports(&import_groups, import_group_start));
+                    out.push(format_imports(&import_groups, import_group_start, lang));
                     import_groups.clear();
                 }
             }
@@ -87,7 +87,7 @@ fn format_entries(
 
     // Flush trailing imports
     if !import_groups.is_empty() {
-        out.push(format_imports(&import_groups, import_group_start));
+        out.push(format_imports(&import_groups, import_group_start, lang));
     }
 
     out.join("\n")
@@ -95,7 +95,7 @@ fn format_entries(
 
 /// Format a collapsed import summary grouped by source with counts.
 /// Spec format: `imports: react(4), express(2), @/lib(3)`
-fn format_imports(imports: &[&str], start: u32) -> String {
+fn format_imports(imports: &[&str], start: u32, lang: Lang) -> String {
     let count = imports.len();
 
     // Extract source modules and count occurrences
@@ -103,7 +103,7 @@ fn format_imports(imports: &[&str], start: u32) -> String {
     let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
 
     for imp in imports {
-        let source = extract_import_source(imp);
+        let source = extract_import_source(imp, Some(lang));
         *seen.entry(source.clone()).or_insert(0) += 1;
         if !sources.contains(&source) {
             sources.push(source);

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -210,6 +210,8 @@ pub fn extract_callee_names(
 
 /// Keywords that should not appear as callee names in Elixir.
 /// These are definition and import forms that are syntactically `call` nodes.
+/// Superset of `ELIXIR_DEFINITION_TARGETS` (treesitter.rs) plus import keywords
+/// (`use`, `import`, `alias`, `require`) and `defoverridable`.
 fn is_elixir_keyword(name: &str) -> bool {
     matches!(
         name,

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -83,6 +83,10 @@ pub(crate) fn callee_query_str(lang: Lang) -> Option<&'static str> {
             "(call_expression (identifier) @callee)\n",
             "(call_expression (navigation_expression (identifier) @callee .))\n",
         )),
+        Lang::Elixir => Some(concat!(
+            "(call target: (identifier) @callee)\n",
+            "(call target: (dot right: (identifier) @callee))\n",
+        )),
         _ => None,
     }
 }
@@ -512,6 +516,7 @@ mod tests {
             ("csharp", tree_sitter_c_sharp::LANGUAGE.into()),
             ("swift", tree_sitter_swift::LANGUAGE.into()),
             ("kotlin", tree_sitter_kotlin_ng::LANGUAGE.into()),
+            ("elixir", tree_sitter_elixir::LANGUAGE.into()),
         ];
         let mut seen = std::collections::HashMap::new();
         for (name, lang) in &grammars {
@@ -574,5 +579,71 @@ function run($svc): void {
         assert!(names.contains(&"staticCall".to_string()));
         assert!(names.contains(&"methodCall".to_string()));
         assert!(names.contains(&"nullableCall".to_string()));
+    }
+
+    #[test]
+    fn elixir_callee_query_compiles() {
+        let lang: tree_sitter::Language = tree_sitter_elixir::LANGUAGE.into();
+        let query_str = callee_query_str(crate::types::Lang::Elixir).unwrap();
+        tree_sitter::Query::new(&lang, query_str).expect("elixir callee query should compile");
+    }
+
+    #[test]
+    fn extract_elixir_callee_names() {
+        let elixir = r#"defmodule Example do
+  def run(conn) do
+    result = query(conn, "SELECT 1")
+    Enum.map(result, &to_string/1)
+    IO.puts("done")
+    local_func()
+  end
+end
+"#;
+        let names = extract_callee_names(elixir, Lang::Elixir, None);
+
+        assert!(
+            names.contains(&"query".to_string()),
+            "expected query, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"map".to_string()),
+            "expected map (from Enum.map), got: {names:?}"
+        );
+        assert!(
+            names.contains(&"puts".to_string()),
+            "expected puts (from IO.puts), got: {names:?}"
+        );
+        assert!(
+            names.contains(&"local_func".to_string()),
+            "expected local_func, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn extract_elixir_callee_names_pipes() {
+        let elixir = r#"defmodule Pipes do
+  def run(conn) do
+    conn
+    |> prepare("sql")
+    |> execute()
+    |> Enum.map(&transform/1)
+  end
+end
+"#;
+        let names = extract_callee_names(elixir, Lang::Elixir, None);
+
+        // Pipe targets are regular call nodes — the callee query should find them
+        assert!(
+            names.contains(&"prepare".to_string()),
+            "expected prepare from pipe, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"execute".to_string()),
+            "expected execute from pipe, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"map".to_string()),
+            "expected map from Enum.map pipe, got: {names:?}"
+        );
     }
 }

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -197,7 +197,40 @@ pub fn extract_callee_names(
     let mut names = names;
     names.sort();
     names.dedup();
+
+    // Elixir: the callee query `(call target: (identifier) @callee)` also captures
+    // definition keywords (def, defmodule, etc.) and import keywords (use, import,
+    // alias, require) since those are all `call` nodes. Filter them out.
+    if lang == Lang::Elixir {
+        names.retain(|n| !is_elixir_keyword(n));
+    }
+
     names
+}
+
+/// Keywords that should not appear as callee names in Elixir.
+/// These are definition and import forms that are syntactically `call` nodes.
+fn is_elixir_keyword(name: &str) -> bool {
+    matches!(
+        name,
+        "def"
+            | "defp"
+            | "defmodule"
+            | "defmacro"
+            | "defmacrop"
+            | "defguard"
+            | "defguardp"
+            | "defdelegate"
+            | "defstruct"
+            | "defexception"
+            | "defprotocol"
+            | "defimpl"
+            | "defoverridable"
+            | "use"
+            | "import"
+            | "alias"
+            | "require"
+    )
 }
 
 /// Match callee names against outline entries, moving resolved names out of `remaining`.
@@ -616,6 +649,16 @@ end
         assert!(
             names.contains(&"local_func".to_string()),
             "expected local_func, got: {names:?}"
+        );
+
+        // Definition keywords must NOT appear as callees
+        assert!(
+            !names.contains(&"def".to_string()),
+            "definition keyword 'def' should be filtered, got: {names:?}"
+        );
+        assert!(
+            !names.contains(&"defmodule".to_string()),
+            "definition keyword 'defmodule' should be filtered, got: {names:?}"
         );
     }
 

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -442,9 +442,16 @@ fn find_enclosing_function(
     while let Some(n) = current {
         let kind = n.kind();
 
-        if DEFINITION_KINDS.contains(&kind) {
-            let name =
-                extract_definition_name(n, lines).unwrap_or_else(|| "<anonymous>".to_string());
+        // Check standard definition kinds, or Elixir call-node definitions
+        let def_name = if DEFINITION_KINDS.contains(&kind) {
+            extract_definition_name(n, lines)
+        } else if crate::lang::treesitter::is_elixir_definition(n, lines) {
+            crate::lang::treesitter::extract_elixir_definition_name(n, lines)
+        } else {
+            None
+        };
+
+        if let Some(name) = def_name {
             let range = Some((
                 n.start_position().row as u32 + 1,
                 n.end_position().row as u32 + 1,
@@ -455,6 +462,14 @@ fn find_enclosing_function(
             while let Some(p) = parent {
                 if TYPE_KINDS.contains(&p.kind()) {
                     if let Some(type_name) = extract_definition_name(p, lines) {
+                        return (format!("{type_name}.{name}"), range);
+                    }
+                }
+                // Elixir: defmodule is a call node acting as a type container
+                if crate::lang::treesitter::is_elixir_definition(p, lines) {
+                    if let Some(type_name) =
+                        crate::lang::treesitter::extract_elixir_definition_name(p, lines)
+                    {
                         return (format!("{type_name}.{name}"), range);
                     }
                 }

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -199,7 +199,8 @@ fn find_callers_treesitter(
                 };
 
                 // Walk up the tree to find the enclosing function
-                let (calling_function, caller_range) = find_enclosing_function(cap.node, &lines);
+                let (calling_function, caller_range) =
+                    find_enclosing_function(cap.node, &lines, lang);
 
                 callers.push(CallerMatch {
                     path: path.to_path_buf(),
@@ -389,7 +390,8 @@ fn find_callers_treesitter_batch(
                 };
 
                 // Walk up the tree to find the enclosing function
-                let (calling_function, caller_range) = find_enclosing_function(cap.node, &lines);
+                let (calling_function, caller_range) =
+                    find_enclosing_function(cap.node, &lines, lang);
 
                 callers.push((
                     matched_target,
@@ -435,6 +437,7 @@ const TYPE_KINDS: &[&str] = &[
 fn find_enclosing_function(
     node: tree_sitter::Node,
     lines: &[&str],
+    lang: crate::types::Lang,
 ) -> (String, Option<(u32, u32)>) {
     // Walk up the tree until we find a definition node
     let mut current = Some(node);
@@ -445,7 +448,9 @@ fn find_enclosing_function(
         // Check standard definition kinds, or Elixir call-node definitions
         let def_name = if DEFINITION_KINDS.contains(&kind) {
             extract_definition_name(n, lines)
-        } else if crate::lang::treesitter::is_elixir_definition(n, lines) {
+        } else if lang == crate::types::Lang::Elixir
+            && crate::lang::treesitter::is_elixir_definition(n, lines)
+        {
             crate::lang::treesitter::extract_elixir_definition_name(n, lines)
         } else {
             None
@@ -466,7 +471,9 @@ fn find_enclosing_function(
                     }
                 }
                 // Elixir: defmodule is a call node acting as a type container
-                if crate::lang::treesitter::is_elixir_definition(p, lines) {
+                if lang == crate::types::Lang::Elixir
+                    && crate::lang::treesitter::is_elixir_definition(p, lines)
+                {
                     if let Some(type_name) =
                         crate::lang::treesitter::extract_elixir_definition_name(p, lines)
                     {

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -470,7 +470,8 @@ fn find_enclosing_function(
                         return (format!("{type_name}.{name}"), range);
                     }
                 }
-                // Elixir: defmodule is a call node acting as a type container
+                // Elixir: `defmodule` is a `call` node, not in TYPE_KINDS, so it
+                // needs a separate check to qualify function names as Module.func.
                 if lang == crate::types::Lang::Elixir
                     && crate::lang::treesitter::is_elixir_definition(p, lines)
                 {

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -159,7 +159,7 @@ pub fn analyze_deps(
         if !is_import_line(line, lang) {
             continue;
         }
-        let source = extract_import_source(line);
+        let source = extract_import_source(line, Some(lang));
         if source.is_empty() {
             continue;
         }

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -6,8 +6,9 @@ use std::time::SystemTime;
 
 use super::file_metadata;
 use crate::lang::treesitter::{
-    definition_weight, extract_definition_name, extract_impl_trait, extract_impl_type,
-    extract_implemented_interfaces, DEFINITION_KINDS,
+    definition_weight, elixir_definition_weight, extract_definition_name,
+    extract_elixir_definition_name, extract_impl_trait, extract_impl_type,
+    extract_implemented_interfaces, is_elixir_definition, DEFINITION_KINDS,
 };
 
 use crate::error::TilthError;
@@ -220,7 +221,6 @@ fn walk_for_definitions(
     }
 
     let kind = node.kind();
-
     if DEFINITION_KINDS.contains(&kind) {
         // Check if this node defines the queried symbol
         if let Some(name) = extract_definition_name(node, lines) {
@@ -304,6 +304,33 @@ fn walk_for_definitions(
                     def_name: Some(format!("{class_name} implements {query}")),
                     def_weight: 80,
                     impl_target: Some(query.to_string()),
+                });
+            }
+        }
+    } else if is_elixir_definition(node, lines) {
+        // Elixir: definitions are `call` nodes — check separately
+        if let Some(name) = extract_elixir_definition_name(node, lines) {
+            if name == query {
+                let line_num = node.start_position().row as u32 + 1;
+                let line_text = lines
+                    .get(node.start_position().row)
+                    .unwrap_or(&"")
+                    .trim_end();
+                defs.push(Match {
+                    path: path.to_path_buf(),
+                    line: line_num,
+                    text: line_text.to_string(),
+                    is_definition: true,
+                    exact: true,
+                    file_lines,
+                    mtime,
+                    def_range: Some((
+                        node.start_position().row as u32 + 1,
+                        node.end_position().row as u32 + 1,
+                    )),
+                    def_name: Some(query.to_string()),
+                    def_weight: elixir_definition_weight(node, lines),
+                    impl_target: None,
                 });
             }
         }
@@ -534,5 +561,177 @@ pub(crate) fn dispatch_tool(tool: &str) -> Result<String, String> {
             SystemTime::now(),
         );
         assert!(!defs.is_empty(), "should find 'dispatch_tool' definition");
+    }
+
+    /// Helper: search for an Elixir definition by name in a code snippet.
+    fn elixir_find(code: &str, name: &str) -> Vec<Match> {
+        let ts_lang = crate::lang::outline::outline_language(crate::types::Lang::Elixir).unwrap();
+        let lines = code.lines().count() as u32;
+        find_defs_treesitter(
+            std::path::Path::new("test.ex"),
+            name,
+            &ts_lang,
+            code,
+            lines,
+            SystemTime::now(),
+        )
+    }
+
+    #[test]
+    fn elixir_definitions_detected() {
+        let code = r#"defmodule MyApp.Greeter do
+  @type t :: %{name: String.t()}
+
+  def hello(name) do
+    "Hello, #{name}!"
+  end
+
+  defp private_helper(x), do: x + 1
+
+  defmacro my_macro(expr) do
+    quote do: unquote(expr)
+  end
+end
+"#;
+        // Dotted module name
+        let defs = elixir_find(code, "MyApp.Greeter");
+        assert!(!defs.is_empty(), "should find 'MyApp.Greeter' module def");
+        assert!(defs[0].is_definition);
+
+        // Public function (block form with parens)
+        assert!(
+            !elixir_find(code, "hello").is_empty(),
+            "should find 'hello'"
+        );
+
+        // Private function (keyword form: `, do:`)
+        assert!(
+            !elixir_find(code, "private_helper").is_empty(),
+            "should find 'private_helper'"
+        );
+
+        // Macro
+        assert!(
+            !elixir_find(code, "my_macro").is_empty(),
+            "should find 'my_macro'"
+        );
+    }
+
+    #[test]
+    fn elixir_guard_clause_definitions() {
+        let code = r#"defmodule Guards do
+  def safe_div(a, b) when b != 0 do
+    a / b
+  end
+
+  defp checked(x) when is_integer(x), do: x
+
+  defguard is_positive(x) when x > 0
+end
+"#;
+        // Guard clause with `when` — block form
+        assert!(
+            !elixir_find(code, "safe_div").is_empty(),
+            "should find 'safe_div' with guard clause"
+        );
+
+        // Guard clause with `when` — keyword form
+        assert!(
+            !elixir_find(code, "checked").is_empty(),
+            "should find 'checked' with guard clause"
+        );
+
+        // defguard
+        assert!(
+            !elixir_find(code, "is_positive").is_empty(),
+            "should find 'is_positive' defguard"
+        );
+    }
+
+    #[test]
+    fn elixir_multi_clause_and_no_arg() {
+        let code = r#"defmodule Dispatch do
+  def handle(:ok), do: :success
+  def handle(:error), do: :failure
+
+  def version, do: "1.0"
+end
+"#;
+        // Multi-clause: both clauses should be found
+        let defs = elixir_find(code, "handle");
+        assert!(
+            defs.len() >= 2,
+            "should find both 'handle' clauses, got {}: {defs:?}",
+            defs.len()
+        );
+
+        // No-arg function (bare identifier, no parens)
+        assert!(
+            !elixir_find(code, "version").is_empty(),
+            "should find no-arg 'version'"
+        );
+    }
+
+    #[test]
+    fn elixir_protocol_impl_exception() {
+        let code = r#"defprotocol Printable do
+  @callback format(t) :: String.t()
+  def to_string(data)
+end
+
+defimpl Printable, for: User do
+  def to_string(user), do: user.name
+end
+
+defmodule MyError do
+  defexception [:message, :code]
+end
+"#;
+        // Protocol
+        assert!(
+            !elixir_find(code, "Printable").is_empty(),
+            "should find 'Printable' protocol"
+        );
+
+        // defimpl
+        assert!(
+            !elixir_find(code, "Printable").is_empty(),
+            "should find defimpl for 'Printable'"
+        );
+
+        // defexception
+        assert!(
+            !elixir_find(code, "defexception").is_empty(),
+            "should find 'defexception'"
+        );
+
+        // Module containing exception
+        assert!(
+            !elixir_find(code, "MyError").is_empty(),
+            "should find 'MyError' module"
+        );
+    }
+
+    #[test]
+    fn elixir_delegate_and_nested_modules() {
+        let code = r#"defmodule Outer do
+  defdelegate count(list), to: Enum
+
+  defmodule Inner do
+    def nested_func, do: :ok
+  end
+end
+"#;
+        // defdelegate
+        assert!(
+            !elixir_find(code, "count").is_empty(),
+            "should find 'count' defdelegate"
+        );
+
+        // Nested module
+        assert!(
+            !elixir_find(code, "Inner").is_empty(),
+            "should find nested 'Inner' module"
+        );
     }
 }

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -150,7 +150,7 @@ fn find_definitions(
             let ts_language = lang.and_then(outline_language);
 
             let mut file_defs = if let Some(ref ts_lang) = ts_language {
-                find_defs_treesitter(path, query, ts_lang, &content, file_lines, mtime)
+                find_defs_treesitter(path, query, ts_lang, lang, &content, file_lines, mtime)
             } else {
                 Vec::new()
             };
@@ -183,6 +183,7 @@ fn find_defs_treesitter(
     path: &Path,
     query: &str,
     ts_lang: &tree_sitter::Language,
+    lang: Option<crate::types::Lang>,
     content: &str,
     file_lines: u32,
     mtime: SystemTime,
@@ -200,7 +201,9 @@ fn find_defs_treesitter(
     let root = tree.root_node();
     let mut defs = Vec::new();
 
-    walk_for_definitions(root, query, path, &lines, file_lines, mtime, &mut defs, 0);
+    walk_for_definitions(
+        root, query, path, &lines, file_lines, mtime, &mut defs, lang, 0,
+    );
 
     defs
 }
@@ -214,6 +217,7 @@ fn walk_for_definitions(
     file_lines: u32,
     mtime: SystemTime,
     defs: &mut Vec<Match>,
+    lang: Option<crate::types::Lang>,
     depth: usize,
 ) {
     if depth > 3 {
@@ -307,7 +311,7 @@ fn walk_for_definitions(
                 });
             }
         }
-    } else if is_elixir_definition(node, lines) {
+    } else if lang == Some(crate::types::Lang::Elixir) && is_elixir_definition(node, lines) {
         // Elixir: definitions are `call` nodes — check separately
         if let Some(name) = extract_elixir_definition_name(node, lines) {
             if name == query {
@@ -347,6 +351,7 @@ fn walk_for_definitions(
             file_lines,
             mtime,
             defs,
+            lang,
             depth + 1,
         );
     }
@@ -534,6 +539,7 @@ pub(crate) fn dispatch_tool(tool: &str) -> Result<String, String> {
             std::path::Path::new("test.rs"),
             "hello",
             &ts_lang,
+            Some(crate::types::Lang::Rust),
             code,
             15,
             SystemTime::now(),
@@ -546,6 +552,7 @@ pub(crate) fn dispatch_tool(tool: &str) -> Result<String, String> {
             std::path::Path::new("test.rs"),
             "Foo",
             &ts_lang,
+            Some(crate::types::Lang::Rust),
             code,
             15,
             SystemTime::now(),
@@ -556,6 +563,7 @@ pub(crate) fn dispatch_tool(tool: &str) -> Result<String, String> {
             std::path::Path::new("test.rs"),
             "dispatch_tool",
             &ts_lang,
+            Some(crate::types::Lang::Rust),
             code,
             15,
             SystemTime::now(),
@@ -571,6 +579,7 @@ pub(crate) fn dispatch_tool(tool: &str) -> Result<String, String> {
             std::path::Path::new("test.ex"),
             name,
             &ts_lang,
+            Some(crate::types::Lang::Elixir),
             code,
             lines,
             SystemTime::now(),

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -697,16 +697,12 @@ defmodule MyError do
   defexception [:message, :code]
 end
 "#;
-        // Protocol
+        // Protocol + defimpl: both indexed under the protocol name "Printable"
+        let defs = elixir_find(code, "Printable");
         assert!(
-            !elixir_find(code, "Printable").is_empty(),
-            "should find 'Printable' protocol"
-        );
-
-        // defimpl
-        assert!(
-            !elixir_find(code, "Printable").is_empty(),
-            "should find defimpl for 'Printable'"
+            defs.len() >= 2,
+            "should find both defprotocol and defimpl for 'Printable', got {}",
+            defs.len()
         );
 
         // defexception

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -225,6 +225,7 @@ fn walk_for_definitions(
     }
 
     let kind = node.kind();
+
     if DEFINITION_KINDS.contains(&kind) {
         // Check if this node defines the queried symbol
         if let Some(name) = extract_definition_name(node, lines) {

--- a/src/types.rs
+++ b/src/types.rs
@@ -37,6 +37,7 @@ pub enum Lang {
     Swift,
     Kotlin,
     CSharp,
+    Elixir,
     Dockerfile,
     Make,
 }


### PR DESCRIPTION
🤖⚠️ ROBOT DISCLAIMER 🤖⚠️

Done with the help of Claude (max thinking effort). Curated and supervised by me, but not too heavily. I tried my best to guide it well and make sure there are no regressions -- but I make no promises that the code changes are not changing architecture in a way that the authors of this project would disapprove of. Receptive to criticisms on architecture and would iterate on them -- I would love for Tilth to have support for Elixir. If all goes well, I could make a similar PR for adding Erlang support.

## Summary

Adds Elixir language support: outline extraction, symbol search (definitions + usages), callee/caller detection, and import recognition. Uses `tree-sitter-elixir` v0.3. Both `.ex` and `.exs` files are supported.

Supported constructs: `defmodule`, `def`/`defp`, `defmacro`/`defmacrop`, `defguard`/`defguardp`, `defdelegate`, `defstruct`, `defexception`, `defprotocol`, `defimpl`, `@type`/`@typep`/`@opaque`, `@callback`/`@macrocallback`. Guard clauses (`when`), multi-clause functions, no-arg functions, nested modules, and pipe operator callees all work.

## Implementation notes

Elixir's tree-sitter grammar is structurally different from every other supported language. In Rust/Go/Python/etc., definitions have distinct node kinds (`function_declaration`, `struct_item`, `class_definition`). In Elixir, **everything is a `call` node** — `defmodule`, `def`, `defstruct` are all calls whose `target` identifier happens to be a definition keyword.

This means `DEFINITION_KINDS` (the shared list of definition node kinds) cannot include `"call"` without breaking all other languages. Instead, dedicated helpers check whether a `call` node's target is an Elixir definition keyword:

- `is_elixir_definition(node, lines)` — checks `call.target` against `defmodule`, `def`, `defp`, etc.
- `extract_elixir_definition_name(node, lines)` — navigates from `call` → `arguments` → first child to extract the defined name
- `elixir_extract_func_head_name(node, lines)` — handles the three shapes a function head can take: `call` (normal), `identifier` (no-arg), or `binary_operator` (guard clause with `when`)

A second grammar quirk: `arguments` is a node **kind**, not a named **field**. `child_by_field_name("arguments")` returns `None` — you have to find it by walking children and matching the kind. The `elixir_arguments()` helper handles this.

## Files changed

| File | What |
|------|------|
| `Cargo.toml` | Added `tree-sitter-elixir = "0.3"` |
| `src/types.rs` | `Lang::Elixir` variant |
| `src/lang/mod.rs` | `.ex`/`.exs` detection, `mix.exs` in package root manifests |
| `src/lang/outline.rs` | Outline extraction for all Elixir definition forms, `@type`/`@callback` attributes, `@doc`/`@moduledoc` extraction, `do`-block signature truncation |
| `src/lang/treesitter.rs` | `elixir_arguments()`, `is_elixir_definition()`, `extract_elixir_definition_name()`, `elixir_extract_func_head_name()`, `elixir_definition_weight()` |
| `src/index/symbol.rs` | Symbol index recognizes Elixir call-node definitions |
| `src/search/symbol.rs` | Symbol search finds Elixir definitions |
| `src/search/callees.rs` | Callee query for local and remote/dot calls |
| `src/search/callers.rs` | `find_enclosing_function` recognizes Elixir definitions as containers |
| `src/read/imports.rs` | `alias`, `import`, `use`, `require` detection |
| `src/overview.rs` | Display name |

## Test plan

8 new tests covering: dotted module names, `def`/`defp`/`defmacro` (block and keyword forms), guard clauses with `when`, `defguard`, multi-clause functions, no-arg functions, `defdelegate`, `defprotocol`/`defimpl`, `defexception`, nested modules, local calls, remote/dot calls (`Enum.map`), and pipe operator callees.

- [x] `cargo test` — all pass, no regressions
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Verified against a real Elixir project — structured outlines, symbol definitions, and callers work on both `.ex` and `.exs` files
- [x] Side-by-side comparison with Rust and Go output — Elixir on par across all dimensions