### PR TITLE
Usability patches

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -689,6 +689,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
+dependencies = [
+ "rustix",
+ "windows-sys",
+]
+
+[[package]]
 name = "tilth"
 version = "0.7.0"
 dependencies = [
@@ -707,6 +717,7 @@ dependencies = [
  "serde_json",
  "streaming-iterator",
  "tempfile",
+ "terminal_size",
  "toml",
  "tree-sitter",
  "tree-sitter-c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,9 @@ toml = "0.8"
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 
+# Terminal size detection (TIOCGWINSZ ioctl, falls back to env vars)
+terminal_size = "0.4"
+
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/index/symbol.rs
+++ b/src/index/symbol.rs
@@ -72,14 +72,9 @@ impl SymbolIndex {
         // We use WalkBuilder for directory filtering but rayon for parallelism
         // because rayon gives us better work-stealing than ignore's parallel walker
         // for CPU-bound tree-sitter parsing.
-        let files: Vec<PathBuf> = WalkBuilder::new(scope)
-            .follow_links(true)
-            .hidden(false)
-            .git_ignore(false)
-            .git_global(false)
-            .git_exclude(false)
-            .ignore(false)
-            .parents(false)
+        let mut builder = WalkBuilder::new(scope);
+        crate::search::apply_ignore_settings(&mut builder);
+        let files: Vec<PathBuf> = builder
             .filter_entry(|entry| {
                 if entry.file_type().is_some_and(|ft| ft.is_dir()) {
                     if let Some(name) = entry.file_name().to_str() {

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -165,9 +165,32 @@ fn node_to_entry(
             (OutlineKind::Import, text, None)
         }
 
-        // Exports
+        // Exports — `export` is a modifier on a wrapped declaration, not a
+        // peer of `function`/`class`/`const`. Recurse into the inner
+        // declaration so the entry renders with its real kind. Falling back to
+        // `OutlineKind::Export` only when there is no nameable declaration
+        // inside (`export { … }`, `export * from …`, `export default <expr>`).
+        // Without this, `export_statement`'s `name` is the full source span
+        // (already starts with `export `), and the renderer prepends the
+        // `Export` kind_label `"export"` again — producing the doubled-keyword
+        // outline header `export export async function foo(`.
         "export_statement" => {
-            let name = node_text(node, lines);
+            let mut cursor = node.walk();
+            for child in node.children(&mut cursor) {
+                if let Some(mut inner) = node_to_entry(child, lines, lang, depth) {
+                    // Extend the entry's range to cover the `export` keyword
+                    // so the outline byte range still points at the statement.
+                    inner.start_line = start_line;
+                    return Some(inner);
+                }
+            }
+            // No nameable inner declaration; strip leading `export ` so the
+            // rendered name doesn't duplicate the `kind_label`.
+            let raw = node_text(node, lines);
+            let name = raw
+                .strip_prefix("export ")
+                .map(str::to_string)
+                .unwrap_or(raw);
             (OutlineKind::Export, name, None)
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -430,13 +430,19 @@ fn emit_output(output: &str, is_tty: bool) {
 }
 
 fn terminal_height() -> usize {
-    // Try LINES env var first (set by some shells)
+    // ioctl(TIOCGWINSZ) on stdout — the real terminal height. Bash maintains
+    // $LINES as an unexported shell variable, so most subprocesses (us included)
+    // never receive it; relying on it alone made tilth assume 24 rows in any
+    // typical interactive shell and page nearly every result. Fall back to
+    // $LINES then to 24 only if the ioctl is unavailable (tests, exotic TTYs).
+    if let Some((_, terminal_size::Height(h))) = terminal_size::terminal_size() {
+        return h as usize;
+    }
     if let Ok(lines) = std::env::var("LINES") {
         if let Ok(h) = lines.parse::<usize>() {
             return h;
         }
     }
-    // Fallback
     24
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,15 @@ struct Cli {
     #[arg(long)]
     budget: Option<u64>,
 
-    /// Force full output (override smart view).
+    /// Force full output (effect depends on query type — see --help).
+    ///
+    /// File path: return the whole file instead of an outline (bypass smart view).
+    ///
+    /// Symbol / text / regex: inline source for every match (equivalent to
+    /// `--expand=<all>`). Explicit `--expand=N` wins. Output stays bounded
+    /// by `--budget`.
+    ///
+    /// Glob: no effect (glob queries already return a flat file list).
     #[arg(long)]
     full: bool,
 
@@ -54,7 +62,12 @@ struct Cli {
     #[arg(long)]
     no_ignore: bool,
 
-    /// Expand top N search matches with inline source (default: 2 when flag present).
+    /// Inline source for top N search matches (default 2 when flag bare).
+    ///
+    /// Applies to symbol / text / regex queries. Without the flag the
+    /// result is just the outline summary. `--full` upgrades this to
+    /// expand every match (subject to `--budget`); explicit `--expand=N`
+    /// wins over `--full`. No effect on file-path or glob queries.
     #[arg(long, num_args = 0..=1, default_missing_value = "2", require_equals = true)]
     expand: Option<usize>,
 
@@ -264,9 +277,34 @@ fn main() {
     let cache = tilth::cache::OutlineCache::new();
     let scope = cli.scope.canonicalize().unwrap_or(cli.scope);
 
-    // When piped (not a TTY), force full output — scripts expect raw content
+    // When piped (not a TTY), force full output — scripts expect raw content.
+    // This promotion exists for FilePath queries (return full file instead of
+    // outline) and is harmless for Glob (which ignores `full`). Search queries
+    // also receive `full=true` here but stay outline-only — they do not auto-
+    // expand on piping. See the `cli.full` guard on the expand override below.
     let full = cli.full || !is_tty;
-    let expand = cli.expand.unwrap_or(0);
+
+    // Explicit `--full` on a search query means expand every match. Guarded on
+    // `cli.full` (NOT the piped-derived `full` above) so that subprocess /
+    // pipeline callers (Claude Code's Bash tool, CI scripts, `tilth foo | rg`)
+    // still receive the concise outline they want. They opt into expand-all by
+    // adding `--full` themselves. Explicit `--expand=N` still wins because it
+    // produces `expand != 0`. We over-apply to all query types — `run_inner`
+    // only forwards `expand` to search dispatches, so the value is silently
+    // ignored for FilePath and Glob.
+    //
+    // Cap at FULL_EXPAND_CAP rather than `usize::MAX`: `--budget` already
+    // bounds output, but `expand=usize::MAX` makes tilth compute the
+    // expanded source for every match before truncating, wasting parsing
+    // and rendering work on pathological queries. 50 is well above any
+    // practical "show me everything that matters" case (MAX_MATCHES is 10
+    // for symbol search anyway).
+    const FULL_EXPAND_CAP: usize = 50;
+    let expand = match (cli.expand, cli.full) {
+        (Some(n), _) => n,
+        (None, true) => FULL_EXPAND_CAP,
+        (None, false) => 0,
+    };
 
     // Callers mode
     if cli.callers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -425,7 +425,14 @@ fn emit_output(output: &str, is_tty: bool) {
         }
     }
 
+    // Conventional CLI output ends with a newline so the next shell prompt
+    // starts on its own line. Most internal formatters terminate with `\n`,
+    // but the search-result footer (e.g. `(~507 tokens)`) and a few other
+    // paths do not — guard at the sink rather than auditing every formatter.
     print!("{output}");
+    if !output.ends_with('\n') {
+        println!();
+    }
     let _ = io::stdout().flush();
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,12 @@ struct Cli {
     #[arg(long)]
     no_overview: bool,
 
+    /// Walk gitignored files too. By default tilth honors per-repo `.gitignore`
+    /// and `.tilthignore` overrides (gitignore syntax — use `!path` to
+    /// re-include). Equivalent to `TILTH_NO_IGNORE=1`.
+    #[arg(long)]
+    no_ignore: bool,
+
     /// Expand top N search matches with inline source (default: 2 when flag present).
     #[arg(long, num_args = 0..=1, default_missing_value = "2", require_equals = true)]
     expand: Option<usize>,
@@ -134,6 +140,13 @@ enum Command {
 fn main() {
     configure_thread_pools();
     let cli = Cli::parse();
+
+    // Propagate --no-ignore via env so it reaches every WalkBuilder site
+    // (CLI runners, MCP server, indexer, map). Set unconditionally so
+    // subprocess inheritance works the same way for `tilth --mcp`.
+    if cli.no_ignore {
+        std::env::set_var("TILTH_NO_IGNORE", "1");
+    }
 
     // Shell completions
     if let Some(shell) = cli.completions {

--- a/src/map.rs
+++ b/src/map.rs
@@ -16,14 +16,9 @@ use crate::types::{estimate_tokens, FileType};
 pub fn generate(scope: &Path, depth: usize, budget: Option<u64>, cache: &OutlineCache) -> String {
     let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
 
-    let walker = WalkBuilder::new(scope)
-        .follow_links(true)
-        .hidden(false)
-        .git_ignore(false)
-        .git_global(false)
-        .git_exclude(false)
-        .ignore(false)
-        .parents(false)
+    let mut builder = WalkBuilder::new(scope);
+    crate::search::apply_ignore_settings(&mut builder);
+    let walker = builder
         .filter_entry(|entry| {
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
                 if let Some(name) = entry.file_name().to_str() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -44,9 +44,10 @@ DO NOT use Grep, Read, or Glob. Always use the better tools tilth_search (grep),
 tilth_search: Search code — finds definitions, usages, and text. Replaces grep/rg for all code search.\n\
   For multi-symbol lookup, separate each with a comma \"symbol1,symbol2\" (max 5).\n\
   kind: \"symbol\" (default) | \"content\" (strings/comments) | \"callers\" (call sites)\n\
-  expand (default 2): inline full source for top matches.\n\
+  expand (default 2): inline full source for top N matches. Pass a large N (e.g. 999) to inline every match.\n\
   context: path to file being edited — boosts nearby results.\n\
   glob: file pattern filter — \"*.rs\" (whitelist), \"!*.test.ts\" (exclude).\n\
+  Respects per-repo .gitignore — write `!path` lines in `.tilthignore` to re-include, or set `TILTH_NO_IGNORE=1` for a one-off bypass.\n\
   Output per match:\n\
     ## <path>:<start>-<end> [definition|usage|impl]\n\
     <outline context>\n\
@@ -70,6 +71,7 @@ tilth_files: Find files by glob pattern. Replaces find, ls, pwd, and the host Gl
 \n\
 tilth_deps: Blast-radius check — what imports this file and what it imports.\n\
   Use ONLY before renaming, removing, or changing an export's signature.\n\
+  Respects per-repo .gitignore (same overrides as tilth_search / tilth_files: `.tilthignore` / `TILTH_NO_IGNORE`).\n\
 \n\
 tilth_diff: Structural diff — shows what changed at function level. Replaces Bash(git diff).\n\
   Usage: tilth_diff(source: \"HEAD~1\") for last commit. No args = uncommitted changes.\n\
@@ -870,7 +872,7 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
     let mut tools = vec![
         serde_json::json!({
             "name": "tilth_search",
-            "description": "Search for symbols, text, or regex patterns in code. Replaces grep/rg and the host Grep tool — use this for all code search. Symbol search returns definitions first (via tree-sitter AST), then usages, with full source code inlined for top matches. Content search finds literal text. Regex search supports full regex patterns. For cross-file tracing, pass comma-separated symbol names (max 5).",
+            "description": "Search for symbols, text, or regex patterns in code. Replaces grep/rg and the host Grep tool — use this for all code search. Symbol search returns definitions first (via tree-sitter AST), then usages, with full source code inlined for top matches. Content search finds literal text. Regex search supports full regex patterns. For cross-file tracing, pass comma-separated symbol names (max 5). Respects per-repo .gitignore by default; use a `.tilthignore` file (gitignore syntax with `!path` to re-include) or `TILTH_NO_IGNORE=1` to override.",
             "inputSchema": {
                 "type": "object",
                 "required": ["query"],
@@ -892,7 +894,7 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "expand": {
                         "type": "number",
                         "default": 2,
-                        "description": "Number of top matches to expand with full source code. Definitions show the full function/class body. Usages show ±10 context lines."
+                        "description": "Number of top matches to expand with full source code. Definitions show the full function/class body. Usages show ±10 context lines. Default 2; pass a large value (e.g. 999) to inline every match — output stays bounded by `budget`."
                     },
                     "context": {
                         "type": "string",
@@ -964,7 +966,7 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
         }),
         serde_json::json!({
             "name": "tilth_deps",
-            "description": "Blast-radius check before breaking changes. Shows what a file imports (local + external) and what other files call its exports, with symbol-level detail. Use ONLY when your planned edit changes a function signature, removes/renames an export, or modifies behavior that callers rely on. Do NOT use for reading files, adding new code, or internal-only changes — use tilth_read instead.",
+            "description": "Blast-radius check before breaking changes. Shows what a file imports (local + external) and what other files call its exports, with symbol-level detail. Use ONLY when your planned edit changes a function signature, removes/renames an export, or modifies behavior that callers rely on. Do NOT use for reading files, adding new code, or internal-only changes — use tilth_read instead. Respects per-repo .gitignore (override via `.tilthignore` or `TILTH_NO_IGNORE=1`).",
             "inputSchema": {
                 "type": "object",
                 "required": ["path"],

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -66,7 +66,7 @@ tilth_read: Read file content with smart outlining. Replaces cat/head/tail.\n\
     [<start>-<end>]  <symbol name>             ← outline mode\n\
 \n\
 tilth_files: Find files by glob pattern. Replaces find, ls, pwd, and the host Glob tool.\n\
-  Output: <path>  (~<token_count> tokens). Respects .gitignore.\n\
+  Output: <path>  (~<token_count> tokens). Respects .gitignore (use `.tilthignore` with `!path` to re-include).\n\
 \n\
 tilth_deps: Blast-radius check — what imports this file and what it imports.\n\
   Use ONLY before renaming, removing, or changing an export's signature.\n\
@@ -942,7 +942,7 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
         }),
         serde_json::json!({
             "name": "tilth_files",
-            "description": "Find files matching a glob pattern. Replaces find/ls/pwd and the host Glob tool — use this for all file discovery. Returns matched file paths sorted by relevance with token size estimates. Respects .gitignore.",
+            "description": "Find files matching a glob pattern. Replaces find/ls/pwd and the host Glob tool — use this for all file discovery. Returns matched file paths sorted by relevance with token size estimates. Respects per-repo .gitignore by default; use a `.tilthignore` file (gitignore syntax with `!path` to re-include) or `TILTH_NO_IGNORE=1` to override.",
             "inputSchema": {
                 "type": "object",
                 "required": ["pattern"],

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -29,8 +29,8 @@ use crate::types::{estimate_tokens, FileType, Match, SearchResult};
 use crate::format::rel;
 
 // Directories that are always skipped — build artifacts, dependencies, VCS internals.
-// We skip these explicitly instead of relying on .gitignore so that locally-relevant
-// gitignored files (docs/, configs, generated code) are still searchable.
+// Enforced regardless of `.gitignore` so a `TILTH_NO_IGNORE=1` walk still skips
+// universally-noisy dirs.
 pub(crate) const SKIP_DIRS: &[&str] = &[
     ".git",
     "node_modules",
@@ -67,9 +67,40 @@ pub(crate) const SKIP_DIRS: &[&str] = &[
 
 const EXPAND_FULL_FILE_THRESHOLD: u64 = 800;
 
-/// Build a parallel directory walker that searches ALL files except known junk directories.
-/// Does NOT respect .gitignore — ensures gitignored but locally-relevant files are found.
-/// When `glob` is Some, applies a file-pattern override (whitelist or negation).
+/// Apply tilth's standard ignore policy to a `WalkBuilder`.
+///
+/// Default: honor per-repo `.gitignore` plus `.tilthignore` files
+/// (gitignore syntax — write `!path` lines to force-include paths the
+/// repo `.gitignore` would have excluded). Global gitignore and
+/// `.git/info/exclude` are never consulted — those tend to list
+/// per-engineer files (agent state, editor scratch) that we still want
+/// to grep.
+///
+/// Set `TILTH_NO_IGNORE=1` to walk every file (the pre-0.7 behavior),
+/// still respecting `SKIP_DIRS`.
+pub(crate) fn apply_ignore_settings(builder: &mut WalkBuilder) -> &mut WalkBuilder {
+    let no_ignore = std::env::var("TILTH_NO_IGNORE")
+        .map(|v| !v.is_empty() && v != "0")
+        .unwrap_or(false);
+    builder
+        .follow_links(true)
+        .hidden(false)
+        .git_ignore(!no_ignore)
+        .git_global(false)
+        .git_exclude(false)
+        .ignore(false)
+        .parents(false);
+    if !no_ignore {
+        builder.add_custom_ignore_filename(".tilthignore");
+    }
+    builder
+}
+
+/// Build a parallel directory walker.
+///
+/// Honors `.gitignore` + `.tilthignore` by default (see `apply_ignore_settings`).
+/// `SKIP_DIRS` is always enforced. When `glob` is Some, applies a file-pattern
+/// override (whitelist or negation).
 pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkParallel, TilthError> {
     let threads = std::env::var("TILTH_THREADS")
         .ok()
@@ -79,14 +110,7 @@ pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkPar
         });
 
     let mut builder = WalkBuilder::new(scope);
-    builder
-        .follow_links(true)
-        .hidden(false)
-        .git_ignore(false)
-        .git_global(false)
-        .git_exclude(false)
-        .ignore(false)
-        .parents(false)
+    apply_ignore_settings(&mut builder)
         .threads(threads)
         .filter_entry(|entry| {
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -175,9 +175,35 @@ fn find_definitions(
                 Vec::new()
             };
 
-            // Fallback: keyword heuristic for files without grammars
+            // Per-file-type fallback dispatch. The semantics of "definition"
+            // differ by file kind, so handle them separately:
+            //
+            // * Code without a tree-sitter grammar: keyword heuristic (looks
+            //   for lines starting with `function`/`const`/`class`/etc.).
+            // * Markdown / RST: heading-as-definition. A heading whose text
+            //   contains the query (`## parseCitations` in a doc) marks that
+            //   section AS being about the symbol — that is the documentation
+            //   analogue of a code definition. Quoted code blocks inside
+            //   docs are NOT treated as definitions; they're usages, because
+            //   the keyword heuristic would false-positive on every snippet
+            //   that quotes the real source. Heading defs carry a lower
+            //   `def_weight` (30) than code definitions (60-80) so the real
+            //   source still ranks first.
+            // * Structured data / tabular / log / other: no fallback.
+            //   Mentions are config values, data, or noise — not definitions.
+            //   (A future patch could treat top-level config keys matching
+            //   the query as soft definitions, but that's ambiguous enough
+            //   to skip for now.)
             if file_defs.is_empty() && ts_language.is_none() {
-                file_defs = find_defs_heuristic_buf(path, query, &content, file_lines, mtime);
+                file_defs = match file_type {
+                    FileType::Code(_) => {
+                        find_defs_heuristic_buf(path, query, &content, file_lines, mtime)
+                    }
+                    FileType::Markdown => {
+                        find_defs_markdown_buf(path, query, &content, file_lines, mtime)
+                    }
+                    _ => Vec::new(),
+                };
             }
 
             if !file_defs.is_empty() {
@@ -522,6 +548,97 @@ fn find_usages(
         .unwrap_or_else(std::sync::PoisonError::into_inner))
 }
 
+/// Markdown heading definition detector.
+///
+/// A line `^#{1,6}\s+<text>` in a `.md`/`.mdx`/`.rst` file is treated as a
+/// soft definition of the section about <query> when <query> appears in
+/// <text> as a whole identifier (flanked by non-word chars). Setext
+/// headings (`===` underlines) and indented code blocks (4+ spaces) are
+/// intentionally ignored — Setext requires two-line look-ahead, and 4+
+/// space indents are CommonMark indented code blocks, not headings.
+///
+/// Whole-identifier match (not substring-anywhere) prevents false positives
+/// like query `func` matching heading `## refactoring guidelines`. Match is
+/// against the heading TEXT (after stripping `#` markers), so the `#`s
+/// themselves never count as boundary characters.
+fn find_defs_markdown_buf(
+    path: &Path,
+    query: &str,
+    content: &str,
+    file_lines: u32,
+    mtime: SystemTime,
+) -> Vec<Match> {
+    let mut defs = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        let Some(heading_text) = extract_atx_heading_text(line) else {
+            continue;
+        };
+        if !contains_identifier(heading_text, query) {
+            continue;
+        }
+        defs.push(Match {
+            path: path.to_path_buf(),
+            line: (i + 1) as u32,
+            text: line.trim_end().to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines,
+            mtime,
+            def_range: None,
+            def_name: Some(query.to_string()),
+            // Soft definition — code definitions are 60-80, usages 0. Sits
+            // between them so docs headings outrank passing mentions but
+            // never outrank the real source.
+            def_weight: 30,
+            impl_target: None,
+        });
+    }
+
+    defs
+}
+
+/// Extract the text of an ATX-style markdown heading, or `None` if the line
+/// is not a heading. Strips leading `#` markers and optional trailing `#`s.
+/// Per CommonMark: 0-3 spaces of indent allowed; 4+ spaces is a code block.
+fn extract_atx_heading_text(line: &str) -> Option<&str> {
+    let leading_spaces = line.bytes().take_while(|&b| b == b' ').count();
+    if leading_spaces > 3 {
+        return None;
+    }
+    let after_indent = &line[leading_spaces..];
+    let bytes = after_indent.as_bytes();
+    let hashes = bytes.iter().take_while(|&&b| b == b'#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    if !matches!(bytes.get(hashes), Some(b' ' | b'\t')) {
+        return None;
+    }
+    let text = after_indent[hashes..].trim();
+    // ATX allows optional trailing `#`s: `## Foo ##` — strip them.
+    Some(text.trim_end_matches('#').trim_end())
+}
+
+/// True if `query` appears in `text` as a whole identifier — flanked by
+/// non-word characters (anything outside `[A-Za-z0-9_]`) or string ends.
+fn contains_identifier(text: &str, query: &str) -> bool {
+    if query.is_empty() {
+        return false;
+    }
+    text.match_indices(query).any(|(abs, _)| {
+        let bytes = text.as_bytes();
+        let before_ok = abs == 0 || !is_word_byte(bytes[abs - 1]);
+        let end_pos = abs + query.len();
+        let after_ok = end_pos == bytes.len() || !is_word_byte(bytes[end_pos]);
+        before_ok && after_ok
+    })
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
 /// Keyword heuristic fallback — only used when tree-sitter grammar unavailable.
 fn is_definition_line(line: &str) -> bool {
     let trimmed = line.trim();
@@ -786,5 +903,111 @@ end
             !elixir_find(code, "Inner").is_empty(),
             "should find nested 'Inner' module"
         );
+    }
+
+    fn md_find(content: &str, query: &str) -> Vec<Match> {
+        let lines = content.lines().count() as u32;
+        find_defs_markdown_buf(
+            std::path::Path::new("test.md"),
+            query,
+            content,
+            lines,
+            SystemTime::now(),
+        )
+    }
+
+    #[test]
+    fn markdown_heading_named_for_query_matches() {
+        let content = "# Intro\n\n## parseCitations\n\nProse.\n";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 3);
+        assert!(defs[0].is_definition);
+        assert_eq!(defs[0].def_weight, 30);
+    }
+
+    #[test]
+    fn markdown_heading_levels_one_through_six() {
+        for level in 1..=6 {
+            let hashes = "#".repeat(level);
+            let content = format!("{hashes} parseCitations\n");
+            assert_eq!(md_find(&content, "parseCitations").len(), 1, "h{level}");
+        }
+        // h7 is not a heading
+        assert!(md_find("####### parseCitations\n", "parseCitations").is_empty());
+    }
+
+    #[test]
+    fn markdown_heading_without_query_does_not_match() {
+        let content = "## Other section\n\n## Another heading\n";
+        assert!(md_find(content, "parseCitations").is_empty());
+    }
+
+    #[test]
+    fn markdown_substring_inside_word_does_not_match() {
+        // query "func" must not match "function" — that's the maintainer's
+        // word-boundary concern. Same for "factor" inside "refactoring".
+        assert!(md_find("## function pointers\n", "func").is_empty());
+        assert!(md_find("## refactoring guidelines\n", "factor").is_empty());
+        assert!(md_find("## getCitationsBatch\n", "Citations").is_empty());
+    }
+
+    #[test]
+    fn markdown_whole_word_in_phrase_matches() {
+        // Whole-word match anywhere in the heading text is a definition —
+        // a heading like `## How parseCitations works` IS naming the symbol.
+        let defs = md_find("## How parseCitations works\n", "parseCitations");
+        assert_eq!(defs.len(), 1);
+    }
+
+    #[test]
+    fn markdown_query_with_hyphen_matches() {
+        // Tracking-doc identifiers like `GUM-1732` must match. The hyphen
+        // is part of the query; word-boundary check applies only at the ends.
+        let defs = md_find("## GUM-1732: Cost attribution\n", "GUM-1732");
+        assert_eq!(defs.len(), 1);
+    }
+
+    #[test]
+    fn markdown_code_block_lines_do_not_match() {
+        // Fenced code block — line is not an ATX heading, even though
+        // the text contains `function parseCitations`.
+        let content = "## Real heading\n\n```ts\nfunction parseCitations() {}\n```\n";
+        let defs = md_find(content, "parseCitations");
+        assert!(defs.is_empty(), "fenced-code mention is not a definition");
+
+        // Indented code block (4+ space indent) — a `## ...` line indented
+        // 4 spaces is a code block per CommonMark, not a heading.
+        let content = "Intro.\n\n    ## parseCitations\n";
+        assert!(
+            md_find(content, "parseCitations").is_empty(),
+            "4-space-indented `## foo` is a code block, not a heading"
+        );
+    }
+
+    #[test]
+    fn markdown_heading_with_up_to_three_space_indent_matches() {
+        // 0-3 space indents are valid ATX headings per CommonMark.
+        for indent in 0..=3 {
+            let content = format!("{}## parseCitations\n", " ".repeat(indent));
+            assert_eq!(
+                md_find(&content, "parseCitations").len(),
+                1,
+                "indent {indent} should be a heading"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_heading_with_trailing_hashes_matches() {
+        // ATX allows optional trailing `#`s — strip them before matching.
+        assert_eq!(md_find("## parseCitations ##\n", "parseCitations").len(), 1);
+        assert_eq!(md_find("### parseCitations ###\n", "parseCitations").len(), 1);
+    }
+
+    #[test]
+    fn markdown_hashes_without_space_are_not_headings() {
+        // `##foo` (no space after `#`s) is not a heading.
+        assert!(md_find("##parseCitations\n", "parseCitations").is_empty());
     }
 }


### PR DESCRIPTION
Six small patches that improve tilth's behavior under both interactive shell and agent (MCP) use.

1. Respect .gitignore by default; add .tilthignore and `--no-ignore` as escapes.
2. Make `--full` imply expand-all on search queries. It was silently a no-op on non-file-path queries.
3. Detect terminal height via TIOCGWINSZ. `terminal_height()` read only `$LINES` and fell back to 24, so any terminal that doesn't export `$LINES` to children (e.g. VS Code) paged spuriously.
4. Don't tag quoted-code mentions as definitions; recognize markdown headings. The keyword heuristic ran on every non-tree-sitter file, including markdown and structured data, so symbol mentions inside fenced blocks were treated as defs.
5. Ensure CLI output ends with a newline. `emit_output` used `print!`; a few formatters (notably the search-result footer) don't terminate, which left the next prompt mid-line.
6. mcp: thread the `.gitignore` / `.tilthignore` / `TILTH_NO_IGNORE` guidance through `tilth_search` and `tilth_deps` descriptions (follow up to #1).