### PR TITLE
feat: skip minified files in read view and search walkers

### DIFF
--- a/src/lang/detection.rs
+++ b/src/lang/detection.rs
@@ -56,15 +56,17 @@ pub fn is_minified_by_name(name: &str) -> bool {
         return false;
     };
     let stem = &name[..stem_end];
-    // `.min.<ext>` — stem itself ends in `.min`
+    // `.min.<ext>` — stem itself ends in `.min`. The `secondary > 0` guard
+    // skips hidden-file forms like `.min.config` where the leading dot is
+    // a POSIX hidden-file marker, not an extension separator.
     if let Some(secondary) = stem.rfind('.') {
-        if stem[secondary + 1..].eq_ignore_ascii_case("min") {
+        if secondary > 0 && stem[secondary + 1..].eq_ignore_ascii_case("min") {
             return true;
         }
     }
-    // `-min.<ext>` (e.g. `bundle-min.js`)
-    let lower = stem.to_ascii_lowercase();
-    lower.ends_with("-min")
+    // `-min.<ext>` (e.g. `bundle-min.js`). Compare in place to avoid the
+    // per-call lowercase allocation.
+    stem.len() >= 4 && stem[stem.len() - 4..].eq_ignore_ascii_case("-min")
 }
 
 /// Heuristic: does this content look minified? Samples first 2KB and counts
@@ -73,11 +75,14 @@ pub fn is_minified_by_name(name: &str) -> bool {
 ///
 /// Only call this on files >= [`MINIFIED_CHECK_THRESHOLD`] — for small files
 /// the cost of parsing is bounded regardless and false positives are noisier
-/// than just letting them through.
+/// than just letting them through. Threshold of `< 2` newlines (i.e., 0 or 1)
+/// in 2KB is a strong signal: real source has line breaks every ~80 bytes,
+/// while minified bundles routinely have zero. A threshold of `< 4` would
+/// flag legitimate single-block license headers and compact one-line JSON.
 pub fn is_minified_by_content(buf: &[u8]) -> bool {
     let sample = &buf[..buf.len().min(2048)];
     let newlines = memchr::memchr_iter(b'\n', sample).count();
-    newlines < 4
+    newlines < 2
 }
 
 #[cfg(test)]
@@ -105,6 +110,15 @@ mod tests {
         assert!(!is_minified_by_name("admin.js"));
         assert!(!is_minified_by_name("README.md"));
         assert!(!is_minified_by_name("noext"));
+    }
+
+    /// A leading dot is a hidden-file marker, not an extension separator —
+    /// `.min.config` is a config file named `min`, not a minified file.
+    #[test]
+    fn minified_filename_hidden_files_not_flagged() {
+        assert!(!is_minified_by_name(".min.config"));
+        assert!(!is_minified_by_name(".min.env"));
+        assert!(!is_minified_by_name(".min.json"));
     }
 
     #[test]

--- a/src/lang/detection.rs
+++ b/src/lang/detection.rs
@@ -43,3 +43,81 @@ pub fn is_generated_by_content(buf: &[u8]) -> bool {
         .iter()
         .any(|m| memchr::memmem::find(window, m).is_some())
 }
+
+/// Below this size minification doesn't matter — parsing is cheap regardless.
+pub const MINIFIED_CHECK_THRESHOLD: u64 = 100_000;
+
+/// Check filename for the `.min.` / `-min.` minification convention.
+/// Strong, decade-old industry convention — `.min.js`, `app.min.css`,
+/// `bundle-min.js`. Bundler defaults like `vendor.js` or `bundle.js`
+/// are not flagged here; the content heuristic catches those.
+pub fn is_minified_by_name(name: &str) -> bool {
+    let Some(stem_end) = name.rfind('.') else {
+        return false;
+    };
+    let stem = &name[..stem_end];
+    // `.min.<ext>` — stem itself ends in `.min`
+    if let Some(secondary) = stem.rfind('.') {
+        if stem[secondary + 1..].eq_ignore_ascii_case("min") {
+            return true;
+        }
+    }
+    // `-min.<ext>` (e.g. `bundle-min.js`)
+    let lower = stem.to_ascii_lowercase();
+    lower.ends_with("-min")
+}
+
+/// Heuristic: does this content look minified? Samples first 2KB and counts
+/// newlines. Real source code is line-oriented; minified bundles cram
+/// thousands of bytes onto a single line.
+///
+/// Only call this on files >= [`MINIFIED_CHECK_THRESHOLD`] — for small files
+/// the cost of parsing is bounded regardless and false positives are noisier
+/// than just letting them through.
+pub fn is_minified_by_content(buf: &[u8]) -> bool {
+    let sample = &buf[..buf.len().min(2048)];
+    let newlines = memchr::memchr_iter(b'\n', sample).count();
+    newlines < 4
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn minified_filename_dot_min() {
+        assert!(is_minified_by_name("app.min.js"));
+        assert!(is_minified_by_name("vendor.MIN.css"));
+        assert!(is_minified_by_name("foo.bar.min.js"));
+    }
+
+    #[test]
+    fn minified_filename_dash_min() {
+        assert!(is_minified_by_name("bundle-min.js"));
+        assert!(is_minified_by_name("app-MIN.css"));
+    }
+
+    #[test]
+    fn minified_filename_negatives() {
+        assert!(!is_minified_by_name("app.js"));
+        assert!(!is_minified_by_name("vendor.js"));
+        assert!(!is_minified_by_name("bundle.js"));
+        assert!(!is_minified_by_name("admin.js"));
+        assert!(!is_minified_by_name("README.md"));
+        assert!(!is_minified_by_name("noext"));
+    }
+
+    #[test]
+    fn minified_content_dense() {
+        // Single long line — typical minified output.
+        let bundle = "var a=1,b=2,c=3;function f(x){return x+1}var d=4;".repeat(80);
+        assert!(is_minified_by_content(bundle.as_bytes()));
+    }
+
+    #[test]
+    fn minified_content_normal_source() {
+        let src = "fn main() {\n    let x = 1;\n    let y = 2;\n    println!(\"{x} {y}\");\n}\n"
+            .repeat(20);
+        assert!(!is_minified_by_content(src.as_bytes()));
+    }
+}

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -103,6 +103,20 @@ pub fn read_file(
         ));
     }
 
+    // Minified — filename convention or, for big files, newline-density heuristic.
+    if crate::lang::detection::is_minified_by_name(name)
+        || (byte_len >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD
+            && crate::lang::detection::is_minified_by_content(buf))
+    {
+        let line_count = memchr::memchr_iter(b'\n', buf).count() as u32 + 1;
+        return Ok(format::file_header(
+            path,
+            byte_len,
+            line_count,
+            ViewMode::Minified,
+        ));
+    }
+
     let tokens = estimate_tokens(byte_len);
     let content = String::from_utf8_lossy(buf);
     let line_count = memchr::memchr_iter(b'\n', buf).count() as u32 + 1;

--- a/src/search/content.rs
+++ b/src/search/content.rs
@@ -80,13 +80,19 @@ pub fn search(
                 Err(_) => 0,
             };
 
+            // Read the file once. Use `search_slice` instead of `search_path`
+            // so the minified-check (when triggered) and the actual search
+            // share a single kernel read — no double I/O, no TOCTOU window
+            // between the heuristic and the search.
+            let Ok(bytes) = std::fs::read(path) else {
+                return ignore::WalkState::Continue;
+            };
+
             // Catch unmarked minified bundles in the 100KB–500KB range.
-            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD {
-                if let Ok(bytes) = std::fs::read(path) {
-                    if crate::lang::detection::is_minified_by_content(&bytes) {
-                        return ignore::WalkState::Continue;
-                    }
-                }
+            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD
+                && crate::lang::detection::is_minified_by_content(&bytes)
+            {
+                return ignore::WalkState::Continue;
             }
 
             let (file_lines, mtime) = file_metadata(path);
@@ -94,9 +100,9 @@ pub fn search(
             let mut file_matches = Vec::new();
             let mut searcher = Searcher::new();
 
-            let _ = searcher.search_path(
+            let _ = searcher.search_slice(
                 matcher,
-                path,
+                &bytes,
                 UTF8(|line_num, line| {
                     file_matches.push(Match {
                         path: path.to_path_buf(),

--- a/src/search/content.rs
+++ b/src/search/content.rs
@@ -60,10 +60,32 @@ pub fn search(
 
             let path = entry.path();
 
+            // Skip files that look minified by filename — `.min.js`, `app-min.css`.
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(crate::lang::detection::is_minified_by_name)
+            {
+                return ignore::WalkState::Continue;
+            }
+
             // Skip oversized files — tree-sitter and ripgrep shouldn't spend time on minified bundles
-            if let Ok(meta) = std::fs::metadata(path) {
-                if meta.len() > MAX_SEARCH_FILE_SIZE {
-                    return ignore::WalkState::Continue;
+            let file_size = match std::fs::metadata(path) {
+                Ok(meta) => {
+                    if meta.len() > MAX_SEARCH_FILE_SIZE {
+                        return ignore::WalkState::Continue;
+                    }
+                    meta.len()
+                }
+                Err(_) => 0,
+            };
+
+            // Catch unmarked minified bundles in the 100KB–500KB range.
+            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD {
+                if let Ok(bytes) = std::fs::read(path) {
+                    if crate::lang::detection::is_minified_by_content(&bytes) {
+                        return ignore::WalkState::Continue;
+                    }
                 }
             }
 

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -120,12 +120,25 @@ fn find_definitions(
 
             let path = entry.path();
 
-            // Skip oversized files — avoid tree-sitter parsing multi-MB minified bundles
-            if let Ok(meta) = std::fs::metadata(path) {
-                if meta.len() > 500_000 {
-                    return ignore::WalkState::Continue;
-                }
+            // Skip files that look minified by filename — `.min.js`, `app-min.css`.
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(crate::lang::detection::is_minified_by_name)
+            {
+                return ignore::WalkState::Continue;
             }
+
+            // Skip oversized files — avoid tree-sitter parsing multi-MB minified bundles
+            let file_size = match std::fs::metadata(path) {
+                Ok(meta) => {
+                    if meta.len() > 500_000 {
+                        return ignore::WalkState::Continue;
+                    }
+                    meta.len()
+                }
+                Err(_) => 0,
+            };
 
             // Single read: read file once, use buffer for both check and parse
             let Ok(content) = fs::read_to_string(path) else {
@@ -134,6 +147,13 @@ fn find_definitions(
 
             // Fast byte check via memchr::memmem (SIMD) — skip files without the symbol
             if memchr::memmem::find(content.as_bytes(), needle).is_none() {
+                return ignore::WalkState::Continue;
+            }
+
+            // Catch unmarked minified bundles that slipped past the filename check.
+            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD
+                && crate::lang::detection::is_minified_by_content(content.as_bytes())
+            {
                 return ignore::WalkState::Continue;
             }
 
@@ -425,10 +445,33 @@ fn find_usages(
 
             let path = entry.path();
 
+            // Skip files that look minified by filename — `.min.js`, `app-min.css`.
+            if path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(crate::lang::detection::is_minified_by_name)
+            {
+                return ignore::WalkState::Continue;
+            }
+
             // Skip oversized files
-            if let Ok(meta) = std::fs::metadata(path) {
-                if meta.len() > 500_000 {
-                    return ignore::WalkState::Continue;
+            let file_size = match std::fs::metadata(path) {
+                Ok(meta) => {
+                    if meta.len() > 500_000 {
+                        return ignore::WalkState::Continue;
+                    }
+                    meta.len()
+                }
+                Err(_) => 0,
+            };
+
+            // Catch unmarked minified bundles between 100KB and 500KB — they
+            // were not skipped by the filename check or the size cap above.
+            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD {
+                if let Ok(bytes) = std::fs::read(path) {
+                    if crate::lang::detection::is_minified_by_content(&bytes) {
+                        return ignore::WalkState::Continue;
+                    }
                 }
             }
 

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -465,14 +465,18 @@ fn find_usages(
                 Err(_) => 0,
             };
 
+            // Read once and dispatch via `search_slice` so the minified
+            // heuristic and the search share a single kernel read.
+            let Ok(bytes) = std::fs::read(path) else {
+                return ignore::WalkState::Continue;
+            };
+
             // Catch unmarked minified bundles between 100KB and 500KB — they
             // were not skipped by the filename check or the size cap above.
-            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD {
-                if let Ok(bytes) = std::fs::read(path) {
-                    if crate::lang::detection::is_minified_by_content(&bytes) {
-                        return ignore::WalkState::Continue;
-                    }
-                }
+            if file_size >= crate::lang::detection::MINIFIED_CHECK_THRESHOLD
+                && crate::lang::detection::is_minified_by_content(&bytes)
+            {
+                return ignore::WalkState::Continue;
             }
 
             let (file_lines, mtime) = file_metadata(path);
@@ -480,9 +484,9 @@ fn find_usages(
             let mut file_matches = Vec::new();
             let mut searcher = Searcher::new();
 
-            let _ = searcher.search_path(
+            let _ = searcher.search_slice(
                 matcher,
-                path,
+                &bytes,
                 UTF8(|line_num, line| {
                     file_matches.push(Match {
                         path: path.to_path_buf(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -63,6 +63,7 @@ pub enum ViewMode {
     HeadTail,
     Empty,
     Generated,
+    Minified,
     #[allow(dead_code)]
     Binary,
     #[allow(dead_code)]
@@ -79,6 +80,7 @@ impl std::fmt::Display for ViewMode {
             Self::HeadTail => write!(f, "head+tail"),
             Self::Empty => write!(f, "empty"),
             Self::Generated => write!(f, "generated — skipped"),
+            Self::Minified => write!(f, "minified — skipped"),
             Self::Binary => write!(f, "skipped"),
             Self::Error => write!(f, "error"),
             Self::Section => write!(f, "section"),


### PR DESCRIPTION
## Summary

Skip minified files at both read and search layers — they're parser-hostile, never useful structurally to LLMs, and waste tokens/CPU when they leak through.

Two-layer detection in `lang/detection.rs`:
1. **Filename pattern** — `.min.<ext>` and `-min.<ext>` (decade-old strong convention, low false-positive risk)
2. **Content heuristic** — newline density on first 2KB; only applied to files ≥ 100KB to bound cost

Wired into:
- `read/mod.rs`: minified files render as a header with `ViewMode::Minified` (same shape as `Generated`) instead of dumping the bundle
- `search/symbol.rs` and `search/content.rs` walkers: filename-pattern pre-filter before the size cap; content heuristic for unmarked bundles in the 100KB–500KB range
- `ViewMode::Minified` added to `types.rs`

Extracted from #64 by @sting8k.

## Test plan

- [x] 5 unit tests in `lang/detection.rs` covering positive/negative cases for both heuristics
- [x] `cargo test` — 244 passed (5 new)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: created `.min.js` file, verified `tilth file.min.js` returns header instead of contents

🤖 Generated with [Claude Code](https://claude.com/claude-code)