### PR TITLE
feat: append omission note when outline view is truncated

### DIFF
--- a/src/read/outline/mod.rs
+++ b/src/read/outline/mod.rs
@@ -43,9 +43,15 @@ pub fn generate(
 
 /// Append a note when the outline likely hit `max_lines` and more symbols
 /// exist below. Without this note, agents read the outline as exhaustive
-/// and miss symbols below the cap. Heuristic: line count >= cap signals
-/// truncation; we accept the rare false positive on files with exactly
-/// `OUTLINE_CAP` lines for the simpler implementation.
+/// and miss symbols below the cap.
+///
+/// Note: `max_lines` is an entry cap inside `format_entries` (one
+/// `out.push(...)` per entry, joined with `\n`). For the code-outline path
+/// `outline.lines().count() == entry_count` exactly. For other backends
+/// (markdown, structured, tabular) the same identity holds because each
+/// pushes single-line entries. So the heuristic compares like-for-like.
+/// We avoid claiming a specific count in the user-facing message — we
+/// only state that more symbols exist, which is the actionable signal.
 fn with_omission_note(outline: String, max_lines: usize) -> String {
     if max_lines == usize::MAX {
         return outline;
@@ -54,8 +60,9 @@ fn with_omission_note(outline: String, max_lines: usize) -> String {
         return outline;
     }
     format!(
-        "{outline}\n\n> outline truncated at {max_lines} lines — more symbols exist below. \
-         Use section=\"start-end\" for a specific range, or tilth_search \"<name>\" for a known symbol."
+        "{outline}\n\n> outline truncated — more symbols exist below the cap. \
+         Use section=\"<start>-<end>\" with the line numbers shown in [...] \
+         brackets above, or tilth_search \"<name>\" for a specific symbol."
     )
 }
 
@@ -91,5 +98,41 @@ mod tests {
             .join("\n");
         let result = with_omission_note(outline.clone(), usize::MAX);
         assert_eq!(result, outline);
+    }
+
+    /// Integration test: drive the full `generate()` pipeline with a
+    /// real Rust source containing more than OUTLINE_CAP top-level
+    /// functions. Verifies the cap actually fires and that
+    /// `with_omission_note` is wired into the pipeline correctly —
+    /// not just exercised in isolation.
+    #[test]
+    fn integration_note_on_capped_code_file() {
+        let src: String = (0..150)
+            .map(|i| format!("pub fn func_{i}() {{}}\n"))
+            .collect();
+        let path = std::path::Path::new("fake.rs");
+        let file_type = crate::types::FileType::Code(crate::types::Lang::Rust);
+        let result = super::generate(path, file_type, &src, src.as_bytes(), true);
+        assert!(
+            result.contains("outline truncated"),
+            "expected truncation note for 150 funcs over OUTLINE_CAP=100, got:\n{result}"
+        );
+    }
+
+    /// Integration test: a small file (5 functions) must NOT produce
+    /// the truncation note even when `capped=true` is passed, because
+    /// the actual entry count is well below the cap.
+    #[test]
+    fn integration_no_note_on_small_code_file() {
+        let src: String = (0..5)
+            .map(|i| format!("pub fn func_{i}() {{}}\n"))
+            .collect();
+        let path = std::path::Path::new("fake.rs");
+        let file_type = crate::types::FileType::Code(crate::types::Lang::Rust);
+        let result = super::generate(path, file_type, &src, src.as_bytes(), true);
+        assert!(
+            !result.contains("outline truncated"),
+            "spurious truncation note for 5 funcs (under OUTLINE_CAP=100):\n{result}"
+        );
     }
 }

--- a/src/read/outline/mod.rs
+++ b/src/read/outline/mod.rs
@@ -25,17 +25,71 @@ pub fn generate(
     if crate::types::is_test_file(path) {
         if let FileType::Code(lang) = file_type {
             if let Some(outline) = test_file::outline(content, lang, max_lines) {
-                return outline;
+                return with_omission_note(outline, max_lines);
             }
         }
     }
 
-    match file_type {
+    let outline = match file_type {
         FileType::Code(lang) => code::outline(content, lang, max_lines),
         FileType::Markdown => markdown::outline(buf, max_lines),
         FileType::StructuredData => structured::outline(path, content, max_lines),
         FileType::Tabular => tabular::outline(content, max_lines),
         FileType::Log => fallback::log_view(content),
         FileType::Other => fallback::head_tail(content),
+    };
+    with_omission_note(outline, max_lines)
+}
+
+/// Append a note when the outline likely hit `max_lines` and more symbols
+/// exist below. Without this note, agents read the outline as exhaustive
+/// and miss symbols below the cap. Heuristic: line count >= cap signals
+/// truncation; we accept the rare false positive on files with exactly
+/// `OUTLINE_CAP` lines for the simpler implementation.
+fn with_omission_note(outline: String, max_lines: usize) -> String {
+    if max_lines == usize::MAX {
+        return outline;
+    }
+    if outline.lines().count() < max_lines {
+        return outline;
+    }
+    format!(
+        "{outline}\n\n> outline truncated at {max_lines} lines — more symbols exist below. \
+         Use section=\"start-end\" for a specific range, or tilth_search \"<name>\" for a known symbol."
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::with_omission_note;
+
+    #[test]
+    fn note_appended_when_at_cap() {
+        let outline = (0..100)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = with_omission_note(outline, 100);
+        assert!(result.contains("outline truncated"));
+    }
+
+    #[test]
+    fn no_note_when_under_cap() {
+        let outline = (0..50)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = with_omission_note(outline.clone(), 100);
+        assert_eq!(result, outline);
+    }
+
+    #[test]
+    fn no_note_when_uncapped() {
+        let outline = (0..200)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let result = with_omission_note(outline.clone(), usize::MAX);
+        assert_eq!(result, outline);
     }
 }


### PR DESCRIPTION
## Summary

When outline view caps at OUTLINE_CAP=100 entries (files > 500KB), agents currently see the truncated outline with no signal that more symbols exist below — leading to "function not found" misreads and unnecessary follow-up reads.

Adds `with_omission_note()` in `read/outline/mod.rs`. When `max_lines` is set (i.e., the outline ran capped) and the resulting line count hits or exceeds the cap, append:

> outline truncated at <N> lines — more symbols exist below.
> Use section="start-end" or tilth_search "<name>" for specific symbols.

Heuristic uses `outline.lines().count()` vs `max_lines`. Accepts a rare false positive on files with exactly OUTLINE_CAP lines for the simpler implementation.

Extracted from #64 by @sting8k.

## Test plan

- [x] 3 unit tests in `read/outline/mod.rs` covering at-cap / under-cap / uncapped cases
- [x] `cargo test` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)