### PR TITLE
feat: suggest closest headings on tilth_read --section miss

### DIFF
--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -259,6 +259,53 @@ fn resolve_heading(buf: &[u8], heading: &str) -> Option<(usize, usize)> {
     Some((start_line, total_lines))
 }
 
+/// Return up to `top_n` markdown headings ranked by edit distance to `query`.
+///
+/// Used when a heading lookup misses — agents typo'd anchors, or the heading
+/// renamed since they last read. Returning the closest matches lets them
+/// retry with the right anchor without re-reading the whole file. Skips
+/// headings inside fenced code blocks and ignores ATX-close trailing `#`s
+/// and kramdown-style `{#anchor}` markers in the comparison text.
+fn suggest_headings(buf: &[u8], query: &str, top_n: usize) -> Vec<String> {
+    let q_text = query.trim_end().trim_start_matches('#').trim();
+    if q_text.is_empty() {
+        return Vec::new();
+    }
+    let q_lower = q_text.to_ascii_lowercase();
+
+    let mut in_code_block = false;
+    let mut scored: Vec<(usize, String)> = Vec::new();
+    for line in buf.split(|&b| b == b'\n') {
+        let Ok(s) = std::str::from_utf8(line) else {
+            continue;
+        };
+        let trimmed = s.trim_end();
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block || !trimmed.starts_with('#') {
+            continue;
+        }
+        let h_text = trimmed.trim_start_matches('#').trim();
+        if h_text.is_empty() {
+            continue;
+        }
+        // Strip kramdown attr blocks and ATX-close `#`s from comparison text.
+        let h_clean = h_text
+            .split('{')
+            .next()
+            .unwrap_or(h_text)
+            .trim_end_matches('#')
+            .trim();
+        let dist = edit_distance(&q_lower, &h_clean.to_ascii_lowercase());
+        scored.push((dist, trimmed.to_string()));
+    }
+
+    scored.sort_by_key(|(d, _)| *d);
+    scored.into_iter().take(top_n).map(|(_, h)| h).collect()
+}
+
 /// Read a specific line range from a file.
 /// Uses memchr to find the Nth newline offset and slice the mmap buffer directly
 /// instead of collecting all lines into a Vec.
@@ -275,9 +322,20 @@ fn read_section(path: &Path, range: &str, edit_mode: bool) -> Result<String, Til
 
     // Check if this is a heading-based address (markdown)
     let (start, end) = if range.starts_with('#') {
-        resolve_heading(buf, range).ok_or_else(|| TilthError::InvalidQuery {
-            query: range.to_string(),
-            reason: "heading not found in file".into(),
+        resolve_heading(buf, range).ok_or_else(|| {
+            let suggestions = suggest_headings(buf, range, 5);
+            let reason = if suggestions.is_empty() {
+                "heading not found in file".to_string()
+            } else {
+                format!(
+                    "heading not found in file. Closest matches:\n  {}",
+                    suggestions.join("\n  ")
+                )
+            };
+            TilthError::InvalidQuery {
+                query: range.to_string(),
+                reason,
+            }
         })?
     } else {
         parse_range(range).ok_or_else(|| TilthError::InvalidQuery {
@@ -536,5 +594,49 @@ mod tests {
 
         std::env::remove_var("TILTH_FULL_SIZE_CAP");
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn suggest_headings_returns_close_matches() {
+        let input = b"# Architecture\nfoo\n## Getting Started\nbar\n## Configuration\nbaz\n";
+        let suggestions = suggest_headings(input, "## Get Started", 5);
+        assert!(
+            suggestions.iter().any(|h| h.contains("Getting Started")),
+            "expected 'Getting Started' in suggestions, got: {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn suggest_headings_top_n_orders_by_distance() {
+        let input = b"# A\nfoo\n## Configuration\nbar\n## Authentication\nbaz\n## Settings\nqux\n";
+        // Whole-word typo of "Configuration" — Levenshtein favours close-length
+        // candidates here, so "Configuration" must rank ahead of the others.
+        let suggestions = suggest_headings(input, "## Configurashun", 5);
+        assert!(
+            suggestions[0].contains("Configuration"),
+            "expected 'Configuration' first, got: {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn suggest_headings_skips_code_blocks() {
+        let input = b"## Real Heading\nfoo\n```md\n## Inside Code\n```\n";
+        let suggestions = suggest_headings(input, "## Heading", 5);
+        // Heading inside code block must NOT appear
+        assert!(
+            !suggestions.iter().any(|h| h.contains("Inside Code")),
+            "fenced heading leaked into suggestions: {suggestions:?}"
+        );
+        assert!(
+            suggestions.iter().any(|h| h.contains("Real Heading")),
+            "expected real heading in suggestions: {suggestions:?}"
+        );
+    }
+
+    #[test]
+    fn suggest_headings_empty_query_returns_empty() {
+        let input = b"# A\n## B\n";
+        assert!(suggest_headings(input, "", 5).is_empty());
+        assert!(suggest_headings(input, "###", 5).is_empty());
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -263,9 +263,16 @@ fn resolve_heading(buf: &[u8], heading: &str) -> Option<(usize, usize)> {
 ///
 /// Used when a heading lookup misses — agents typo'd anchors, or the heading
 /// renamed since they last read. Returning the closest matches lets them
-/// retry with the right anchor without re-reading the whole file. Skips
-/// headings inside fenced code blocks and ignores ATX-close trailing `#`s
-/// and kramdown-style `{#anchor}` markers in the comparison text.
+/// retry with the right anchor without re-reading the whole file.
+///
+/// Recognizes `ATX` headings (`CommonMark` §4.6: 1–6 leading `#`s followed
+/// by a space). Skips headings inside fenced code blocks delimited by either
+/// triple backticks or triple tildes. `Setext` headings (`Title\n===`) are
+/// not recognized — they are rare in practice and would require lookback.
+/// Caveat on ranking: Levenshtein favours candidates of similar length to
+/// the query, so very short queries against long headings can rank tighter
+/// matches first; this is acceptable for a hint and aligned with the rest
+/// of the project's `edit_distance` use.
 fn suggest_headings(buf: &[u8], query: &str, top_n: usize) -> Vec<String> {
     let q_text = query.trim_end().trim_start_matches('#').trim();
     if q_text.is_empty() {
@@ -280,14 +287,26 @@ fn suggest_headings(buf: &[u8], query: &str, top_n: usize) -> Vec<String> {
             continue;
         };
         let trimmed = s.trim_end();
-        if trimmed.starts_with("```") {
+        // CommonMark allows both ``` and ~~~ as fence delimiters.
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
             in_code_block = !in_code_block;
             continue;
         }
         if in_code_block || !trimmed.starts_with('#') {
             continue;
         }
-        let h_text = trimmed.trim_start_matches('#').trim();
+        // CommonMark §4.6.1: ATX headings have 1–6 `#`s followed by a space
+        // (or end-of-line). Reject longer hash runs and hash-prefixes that
+        // aren't followed by whitespace (`##foo` is not a heading).
+        let hash_count = trimmed.bytes().take_while(|&b| b == b'#').count();
+        if !(1..=6).contains(&hash_count) {
+            continue;
+        }
+        let after_hashes = trimmed.as_bytes().get(hash_count).copied();
+        if !matches!(after_hashes, None | Some(b' ' | b'\t')) {
+            continue;
+        }
+        let h_text = trimmed[hash_count..].trim();
         if h_text.is_empty() {
             continue;
         }
@@ -455,10 +474,16 @@ fn suggest_similar(path: &Path) -> Option<String> {
     best.map(|(_, name)| name)
 }
 
-/// Simple Levenshtein distance — only used on short file names.
+/// Levenshtein distance over Unicode scalar values.
+///
+/// Operates on `char`s, not bytes — a single CJK or emoji glyph is one
+/// edit unit, not 3-4. Byte-level Levenshtein on UTF-8 inflates distances
+/// for non-ASCII content and breaks ranking for international markdown
+/// or filenames. Used by both filename suggestion (`suggest_similar`) and
+/// heading suggestion (`suggest_headings`).
 fn edit_distance(a: &str, b: &str) -> usize {
-    let a = a.as_bytes();
-    let b = b.as_bytes();
+    let a: Vec<char> = a.chars().collect();
+    let b: Vec<char> = b.chars().collect();
     let mut prev: Vec<usize> = (0..=b.len()).collect();
     let mut curr = vec![0; b.len() + 1];
 
@@ -638,5 +663,59 @@ mod tests {
         let input = b"# A\n## B\n";
         assert!(suggest_headings(input, "", 5).is_empty());
         assert!(suggest_headings(input, "###", 5).is_empty());
+    }
+
+    /// CommonMark allows `~~~` as a fence delimiter. Headings inside
+    /// must not be treated as suggestable.
+    #[test]
+    fn suggest_headings_skips_tilde_fenced_blocks() {
+        let input = b"## Real Heading\nfoo\n~~~md\n## Inside Tilde Fence\n~~~\n";
+        let suggestions = suggest_headings(input, "## Heading", 5);
+        assert!(
+            !suggestions.iter().any(|h| h.contains("Inside Tilde Fence")),
+            "tilde-fenced heading leaked: {suggestions:?}"
+        );
+        assert!(
+            suggestions.iter().any(|h| h.contains("Real Heading")),
+            "real heading missing: {suggestions:?}"
+        );
+    }
+
+    /// CommonMark §4.6.1 limits ATX headings to 1–6 `#`s. Lines with 7+
+    /// hashes are not headings, even with a space after.
+    #[test]
+    fn suggest_headings_rejects_seven_or_more_hashes() {
+        let input = b"## Real Heading\nfoo\n####### Not a Heading\n";
+        let suggestions = suggest_headings(input, "## Heading", 5);
+        assert!(
+            !suggestions.iter().any(|h| h.contains("Not a Heading")),
+            "7-hash line leaked as heading: {suggestions:?}"
+        );
+    }
+
+    /// CommonMark §4.6.1: hashes must be followed by a space (or EOL).
+    /// `##foo` (no space) is not a heading.
+    #[test]
+    fn suggest_headings_rejects_hashes_without_space() {
+        let input = b"## Real Heading\nfoo\n##NoSpace\n";
+        let suggestions = suggest_headings(input, "## Heading", 5);
+        assert!(
+            !suggestions.iter().any(|h| h.contains("NoSpace")),
+            "##NoSpace leaked as heading: {suggestions:?}"
+        );
+    }
+
+    /// edit_distance must operate on `char`s so non-ASCII headings rank
+    /// correctly. Byte-level Levenshtein would inflate distances for
+    /// CJK or emoji because those occupy 3–4 bytes per scalar value.
+    #[test]
+    fn edit_distance_is_unicode_aware() {
+        // 设置 (Settings) and 設定 (Configuration) — different chars,
+        // each one Unicode scalar. Distance should be 2, not 6.
+        assert_eq!(edit_distance("设置", "設定"), 2);
+        // emoji single-scalar: 🦀 vs 🐙 = distance 1.
+        assert_eq!(edit_distance("🦀", "🐙"), 1);
+        // ASCII baseline still works.
+        assert_eq!(edit_distance("kitten", "sitting"), 3);
     }
 }


### PR DESCRIPTION
## Summary

Currently, `tilth_read --section "## Heading"` returns a flat "heading not found in file" when the anchor is typo'd or stale, forcing the agent to re-read the whole file to find the right one.

Adds `suggest_headings(buf, query, top_n)` — scans markdown headings (skipping fenced code blocks and ATX-close trailing `#`s, ignoring kramdown `{#anchor}` attribute markers in comparison text), ranks by Levenshtein distance, returns the top N. Wired into the heading-miss error path so the response now includes:

```
heading not found in file. Closest matches:
  ## Getting Started
  ## Configuration
  ...
```

Reuses the existing `edit_distance` helper. Caveat: Levenshtein favors similar-length candidates, so very short queries against long headings can rank odd matches first — acceptable for a hint, and the test exercises the realistic typo case (whole-word transposition).

Extracted from #64 by @sting8k.

## Test plan

- [x] 4 unit tests in `read/mod.rs` covering close matches, ordering, code-block exclusion, empty query
- [x] `cargo test` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: `tilth file.md --section "## Get Started"` returns suggestions including "Getting Started"

🤖 Generated with [Claude Code](https://claude.com/claude-code)