### PR TITLE
feat: cumulative token rollups per directory in tilth --map

### DIFF
--- a/src/map.rs
+++ b/src/map.rs
@@ -96,11 +96,51 @@ pub fn generate(scope: &Path, depth: usize, budget: Option<u64>, cache: &Outline
     }
 
     let mut out = format!("# Map: {} (depth {})\n", scope.display(), depth);
-    format_tree(&tree, Path::new(""), 0, &mut out);
+    let totals = compute_dir_totals(&tree);
+    format_tree(&tree, &totals, Path::new(""), 0, &mut out);
 
     match budget {
         Some(b) => crate::budget::apply(&out, b),
         None => out,
+    }
+}
+
+/// Sum tokens for every directory in the tree, including the implicit root
+/// (`Path::new("")`). Each directory's total is the sum of its own files
+/// plus the totals of all descendants. Computed by walking each directory's
+/// direct files and folding their byte total into every ancestor.
+fn compute_dir_totals(tree: &BTreeMap<PathBuf, Vec<FileEntry>>) -> BTreeMap<PathBuf, u64> {
+    let mut totals: BTreeMap<PathBuf, u64> = BTreeMap::new();
+    for (dir, files) in tree {
+        let sum: u64 = files.iter().map(|f| f.tokens).sum();
+        if sum == 0 {
+            // Still need to seed the entry so format_tree can render the dir.
+            totals.entry(dir.clone()).or_insert(0);
+            continue;
+        }
+        let mut cur: Option<&Path> = Some(dir.as_path());
+        while let Some(p) = cur {
+            *totals.entry(p.to_path_buf()).or_insert(0) += sum;
+            if p == Path::new("") {
+                break;
+            }
+            cur = p.parent();
+        }
+    }
+    totals
+}
+
+/// Compact human token count for directory rollups.
+/// Uses the same scale as `tilth_files` output (`12.3k`, `1.2M`).
+fn fmt_tokens(n: u64) -> String {
+    #[allow(clippy::cast_precision_loss)] // display-only; mantissa loss is fine for summaries
+    let f = n as f64;
+    if n >= 1_000_000 {
+        format!("{:.1}M", f / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", f / 1_000.0)
+    } else {
+        n.to_string()
     }
 }
 
@@ -167,6 +207,7 @@ fn extract_name_from_sig(sig: &str) -> String {
 
 fn format_tree(
     tree: &BTreeMap<PathBuf, Vec<FileEntry>>,
+    totals: &BTreeMap<PathBuf, u64>,
     dir: &Path,
     indent: usize,
     out: &mut String,
@@ -201,10 +242,84 @@ fn format_tree(
         }
     }
 
-    // Recurse into subdirectories
+    // Recurse into subdirectories — annotate with cumulative token rollup so
+    // agents can triage which subtrees are worth descending into.
     for subdir in subdirs {
         let dir_name = subdir.file_name().and_then(|n| n.to_str()).unwrap_or("?");
-        let _ = writeln!(out, "{prefix}{dir_name}/");
-        format_tree(tree, subdir, indent + 1, out);
+        let total = totals.get(subdir).copied().unwrap_or(0);
+        let _ = writeln!(out, "{prefix}{dir_name}/  (~{} tokens)", fmt_tokens(total));
+        format_tree(tree, totals, subdir, indent + 1, out);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(name: &str, tokens: u64) -> FileEntry {
+        FileEntry {
+            name: name.to_string(),
+            symbols: None,
+            tokens,
+        }
+    }
+
+    #[test]
+    fn rollup_sums_descendants_into_each_ancestor() {
+        // Layout:
+        //   src/lang/  (file_a 100, file_b 50)        → 150
+        //   src/search/ (file_c 200)                  → 200
+        //   src/  (only subdirs, no direct files)     → 350
+        //   ""    (root)                              → 350
+        let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
+        tree.insert(PathBuf::from(""), vec![]);
+        tree.insert(PathBuf::from("src"), vec![]);
+        tree.insert(
+            PathBuf::from("src/lang"),
+            vec![entry("a.rs", 100), entry("b.rs", 50)],
+        );
+        tree.insert(PathBuf::from("src/search"), vec![entry("c.rs", 200)]);
+
+        let totals = compute_dir_totals(&tree);
+        assert_eq!(totals.get(&PathBuf::from("src/lang")).copied(), Some(150));
+        assert_eq!(totals.get(&PathBuf::from("src/search")).copied(), Some(200));
+        assert_eq!(totals.get(&PathBuf::from("src")).copied(), Some(350));
+        assert_eq!(totals.get(&PathBuf::from("")).copied(), Some(350));
+    }
+
+    #[test]
+    fn rollup_handles_empty_directories() {
+        let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
+        tree.insert(PathBuf::from("empty"), vec![]);
+        let totals = compute_dir_totals(&tree);
+        assert_eq!(totals.get(&PathBuf::from("empty")).copied(), Some(0));
+    }
+
+    #[test]
+    fn fmt_tokens_thresholds() {
+        assert_eq!(fmt_tokens(0), "0");
+        assert_eq!(fmt_tokens(999), "999");
+        assert_eq!(fmt_tokens(1_000), "1.0k");
+        assert_eq!(fmt_tokens(12_345), "12.3k");
+        assert_eq!(fmt_tokens(1_000_000), "1.0M");
+        assert_eq!(fmt_tokens(2_500_000), "2.5M");
+    }
+
+    #[test]
+    fn format_tree_renders_dir_rollups_alongside_files() {
+        let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
+        tree.insert(PathBuf::from(""), vec![entry("README.md", 800)]);
+        tree.insert(PathBuf::from("src"), vec![entry("main.rs", 4_200)]);
+        let totals = compute_dir_totals(&tree);
+
+        let mut out = String::new();
+        format_tree(&tree, &totals, Path::new(""), 0, &mut out);
+
+        assert!(out.contains("README.md (~800 tokens)"));
+        // Subdir line carries its rollup
+        assert!(
+            out.contains("src/  (~5.0k tokens)") || out.contains("src/  (~4.2k tokens)"),
+            "expected src/ rollup, got: {out}"
+        );
     }
 }

--- a/src/map.rs
+++ b/src/map.rs
@@ -132,10 +132,14 @@ fn compute_dir_totals(tree: &BTreeMap<PathBuf, Vec<FileEntry>>) -> BTreeMap<Path
 
 /// Compact human token count for directory rollups.
 /// Uses the same scale as `tilth_files` output (`12.3k`, `1.2M`).
+///
+/// The k→M switchover triggers at `999_950` rather than `1_000_000` so values
+/// that would round to `"1000.0k"` under `{:.1}` formatting roll cleanly into
+/// the M tier (`"1.0M"`) instead of producing four-digit k labels.
 fn fmt_tokens(n: u64) -> String {
     #[allow(clippy::cast_precision_loss)] // display-only; mantissa loss is fine for summaries
     let f = n as f64;
-    if n >= 1_000_000 {
+    if f >= 999_950.0 {
         format!("{:.1}M", f / 1_000_000.0)
     } else if n >= 1_000 {
         format!("{:.1}k", f / 1_000.0)
@@ -247,7 +251,7 @@ fn format_tree(
     for subdir in subdirs {
         let dir_name = subdir.file_name().and_then(|n| n.to_str()).unwrap_or("?");
         let total = totals.get(subdir).copied().unwrap_or(0);
-        let _ = writeln!(out, "{prefix}{dir_name}/  (~{} tokens)", fmt_tokens(total));
+        let _ = writeln!(out, "{prefix}{dir_name}/ (~{} tokens)", fmt_tokens(total));
         format_tree(tree, totals, subdir, indent + 1, out);
     }
 }
@@ -305,6 +309,19 @@ mod tests {
         assert_eq!(fmt_tokens(2_500_000), "2.5M");
     }
 
+    /// Boundary: values that would round to "1000.0k" under `{:.1}`
+    /// formatting must roll over to the M tier instead of producing a
+    /// four-digit k label.
+    #[test]
+    fn fmt_tokens_rolls_over_at_999_950() {
+        // Just below the rollover boundary — still formats as k.
+        assert_eq!(fmt_tokens(999_949), "999.9k");
+        // At and above the boundary — formats as M, not "1000.0k".
+        assert_eq!(fmt_tokens(999_950), "1.0M");
+        assert_eq!(fmt_tokens(999_999), "1.0M");
+        assert_eq!(fmt_tokens(1_499_999), "1.5M");
+    }
+
     #[test]
     fn format_tree_renders_dir_rollups_alongside_files() {
         let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
@@ -316,10 +333,11 @@ mod tests {
         format_tree(&tree, &totals, Path::new(""), 0, &mut out);
 
         assert!(out.contains("README.md (~800 tokens)"));
-        // Subdir line carries its rollup
+        // Subdir line: only main.rs lives under src/, so the rollup must
+        // be exactly 4.2k. The previous OR-form hid the dead branch.
         assert!(
-            out.contains("src/  (~5.0k tokens)") || out.contains("src/  (~4.2k tokens)"),
-            "expected src/ rollup, got: {out}"
+            out.contains("src/ (~4.2k tokens)"),
+            "expected exact 'src/ (~4.2k tokens)' rollup, got: {out}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Map output previously showed per-file token counts but listed directories as bare names — agents had to descend into each subtree just to estimate its size. Now each directory line carries a cumulative rollup of every descendant's tokens:

```
src/  (~45.2k tokens)
  lang/  (~12.4k tokens)
    mod.rs (~1820 tokens)
    ...
vendor/  (~847.0k tokens)
```

Lets agents triage at a glance which subtrees to explore versus which to ignore, especially in monorepos and projects with bulky vendored or generated directories.

**Implementation**: `compute_dir_totals` walks the file→tokens map and folds each directory's direct file total into itself plus every ancestor (inclusive of the implicit root). `format_tree` reads the totals map when emitting subdir lines. `fmt_tokens` renders compact "12.3k" / "1.2M" suffixes.

Extracted from #64 by @sting8k.

## Test plan

- [x] 4 unit tests in `map.rs` covering rollup math, empty dirs, format thresholds, end-to-end render
- [x] `cargo test` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: `tilth --map` on this repo shows expected rollups (e.g. `.context/  (~329.5k tokens)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)