### PR TITLE
search: annotate usages with enclosing scope via tree-sitter

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,24 +5,38 @@ use std::time::SystemTime;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 
+use crate::types::Lang;
+
 /// Cached outline entry.
 struct CacheEntry {
     outline: Arc<str>,
 }
 
+/// File contents and its tree-sitter parse, cached together so AST consumers
+/// don't re-parse on every call. `content` is `Arc<String>` so callers can
+/// hold the bytes for `Node::utf8_text` without copying.
+pub struct ParsedFile {
+    pub content: Arc<String>,
+    pub tree: tree_sitter::Tree,
+    pub lang: Lang,
+}
+
 /// Outline cache keyed by (canonical path, mtime). If the file changes,
 /// mtime changes and the old entry is never hit again.
 ///
-/// Value is `Arc<str>` — inline string data in the Arc allocation,
-/// one less indirection than `Arc<String>`.
+/// Stores two derived analyses: rendered outline strings (used by search
+/// formatting) and parsed tree-sitter trees (used by AST scope queries).
+/// Both share the same key + invalidation; nothing else is shared.
 pub struct OutlineCache {
     entries: DashMap<(PathBuf, SystemTime), CacheEntry>,
+    parsed: DashMap<(PathBuf, SystemTime), Arc<ParsedFile>>,
 }
 
 impl Default for OutlineCache {
     fn default() -> Self {
         Self {
             entries: DashMap::new(),
+            parsed: DashMap::new(),
         }
     }
 }
@@ -49,6 +63,38 @@ impl OutlineCache {
                     outline: Arc::clone(&outline),
                 });
                 outline
+            }
+        }
+    }
+
+    /// Parse a code file with tree-sitter and cache the result. Returns
+    /// `None` for non-code files, files larger than the 500 KB cap, or parse
+    /// failures.
+    #[must_use]
+    pub fn get_or_parse(&self, path: &Path) -> Option<Arc<ParsedFile>> {
+        let meta = std::fs::metadata(path).ok()?;
+        let mtime = meta.modified().ok()?;
+        if meta.len() > 500_000 {
+            return None;
+        }
+        match self.parsed.entry((path.to_path_buf(), mtime)) {
+            Entry::Occupied(e) => Some(Arc::clone(e.get())),
+            Entry::Vacant(e) => {
+                let crate::types::FileType::Code(lang) = crate::lang::detect_file_type(path) else {
+                    return None;
+                };
+                let ts_lang = crate::lang::outline::outline_language(lang)?;
+                let content = std::fs::read_to_string(path).ok()?;
+                let mut parser = tree_sitter::Parser::new();
+                parser.set_language(&ts_lang).ok()?;
+                let tree = parser.parse(&content, None)?;
+                let parsed = Arc::new(ParsedFile {
+                    content: Arc::new(content),
+                    tree,
+                    lang,
+                });
+                e.insert(Arc::clone(&parsed));
+                Some(parsed)
             }
         }
     }

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -7,7 +7,10 @@ use std::sync::{Arc, Mutex};
 
 use streaming_iterator::StreamingIterator;
 
-use crate::lang::treesitter::{extract_definition_name, DEFINITION_KINDS};
+use crate::lang::treesitter::{
+    extract_definition_name, extract_elixir_definition_name, is_elixir_definition,
+    node_text_simple, DEFINITION_KINDS,
+};
 
 use crate::cache::OutlineCache;
 use crate::error::TilthError;
@@ -442,8 +445,6 @@ fn find_callers_treesitter_batch(
     callers
 }
 
-/// Walk up the AST from a node to find the enclosing function definition.
-/// Returns (`function_name`, `line_range`).
 /// Type-like node kinds that can enclose a function definition.
 const TYPE_KINDS: &[&str] = &[
     "class_declaration",
@@ -461,64 +462,161 @@ const TYPE_KINDS: &[&str] = &[
     "namespace_definition",
 ];
 
-fn find_enclosing_function(
-    node: tree_sitter::Node,
+/// Walk up the AST from `node` to the nearest definition, qualified with its
+/// enclosing type/module if one wraps it. Returns the AST node so the caller
+/// can read its kind, plus the rendered name and line range.
+fn walk_to_enclosing_definition<'a>(
+    node: tree_sitter::Node<'a>,
     lines: &[&str],
     lang: crate::types::Lang,
-) -> (String, Option<(u32, u32)>) {
-    // Walk up the tree until we find a definition node
+) -> Option<(tree_sitter::Node<'a>, String, (u32, u32))> {
     let mut current = Some(node);
-
     while let Some(n) = current {
-        let kind = n.kind();
-
-        // Check standard definition kinds, or Elixir call-node definitions
-        let def_name = if DEFINITION_KINDS.contains(&kind) {
+        let def_name = if DEFINITION_KINDS.contains(&n.kind()) {
             extract_definition_name(n, lines)
-        } else if lang == crate::types::Lang::Elixir
-            && crate::lang::treesitter::is_elixir_definition(n, lines)
-        {
-            crate::lang::treesitter::extract_elixir_definition_name(n, lines)
+        } else if lang == crate::types::Lang::Elixir && is_elixir_definition(n, lines) {
+            extract_elixir_definition_name(n, lines)
         } else {
             None
         };
 
         if let Some(name) = def_name {
-            let range = Some((
+            let range = (
                 n.start_position().row as u32 + 1,
                 n.end_position().row as u32 + 1,
-            ));
+            );
 
-            // Walk further up to find an enclosing type and qualify the name
+            // Walk further up to find an enclosing type/module and qualify the name.
+            // `defmodule` is a `call` node, not in TYPE_KINDS, so Elixir needs a
+            // separate check to produce `Module.func`.
             let mut parent = n.parent();
             while let Some(p) = parent {
                 if TYPE_KINDS.contains(&p.kind()) {
                     if let Some(type_name) = extract_definition_name(p, lines) {
-                        return (format!("{type_name}.{name}"), range);
+                        return Some((n, format!("{type_name}.{name}"), range));
                     }
                 }
-                // Elixir: `defmodule` is a `call` node, not in TYPE_KINDS, so it
-                // needs a separate check to qualify function names as Module.func.
-                if lang == crate::types::Lang::Elixir
-                    && crate::lang::treesitter::is_elixir_definition(p, lines)
-                {
-                    if let Some(type_name) =
-                        crate::lang::treesitter::extract_elixir_definition_name(p, lines)
-                    {
-                        return (format!("{type_name}.{name}"), range);
+                if lang == crate::types::Lang::Elixir && is_elixir_definition(p, lines) {
+                    if let Some(type_name) = extract_elixir_definition_name(p, lines) {
+                        return Some((n, format!("{type_name}.{name}"), range));
                     }
                 }
                 parent = p.parent();
             }
 
-            return (name, range);
+            return Some((n, name, range));
         }
-
         current = n.parent();
     }
+    None
+}
 
-    // No enclosing function found — top-level call
-    ("<top-level>".to_string(), None)
+/// Walk up the AST from a node to find the enclosing function definition.
+/// Returns (`function_name`, `line_range`). Top-level renders as `"<top-level>"`.
+fn find_enclosing_function(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    lang: crate::types::Lang,
+) -> (String, Option<(u32, u32)>) {
+    match walk_to_enclosing_definition(node, lines, lang) {
+        Some((_, name, range)) => (name, Some(range)),
+        None => ("<top-level>".to_string(), None),
+    }
+}
+
+/// Resolved enclosing-definition context for a (file, line). Used by the
+/// search formatter to annotate usages with their containing scope.
+#[derive(Debug)]
+pub struct EnclosingScope {
+    /// Normalized kind label (e.g. `"function"`, `"class"`, `"struct"`).
+    pub kind: &'static str,
+    /// Identifier of the definition. Qualified with its enclosing type or
+    /// module when one wraps it (e.g. `"Class.method"`, `"Module.func"`).
+    pub name: String,
+}
+
+/// Find the nearest enclosing definition for `(path, line)` by re-parsing
+/// the file with tree-sitter (cached on `OutlineCache`). AST-correct across
+/// every language tilth supports — replaces parsing the rendered outline
+/// string back into structured data.
+///
+/// Returns `None` if the file isn't a code file, the parse fails, or `line`
+/// sits at the top level outside any definition.
+pub fn enclosing_definition_at(
+    path: &Path,
+    line: u32,
+    cache: &OutlineCache,
+) -> Option<EnclosingScope> {
+    if line == 0 {
+        return None;
+    }
+    let parsed = cache.get_or_parse(path)?;
+    let lines: Vec<&str> = parsed.content.lines().collect();
+    let row = (line - 1) as usize;
+    if row >= lines.len() {
+        return None;
+    }
+
+    let point = tree_sitter::Point { row, column: 0 };
+    let target = parsed
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+
+    let (def_node, name, _range) = walk_to_enclosing_definition(target, &lines, parsed.lang)?;
+    Some(EnclosingScope {
+        kind: kind_label(def_node, &lines, parsed.lang),
+        name,
+    })
+}
+
+/// Map a tree-sitter definition node to a short user-facing label. Every kind
+/// we handle is enumerated here, so adding a new language grammar is "add the
+/// node kind to this match" with no string heuristics elsewhere.
+fn kind_label(node: tree_sitter::Node, lines: &[&str], lang: crate::types::Lang) -> &'static str {
+    match node.kind() {
+        "function_declaration"
+        | "function_definition"
+        | "function_item"
+        | "method_definition"
+        | "method_declaration"
+        | "decorated_definition" => "function",
+        "class_declaration" | "class_definition" => "class",
+        "struct_item" => "struct",
+        "interface_declaration" => "interface",
+        "trait_declaration" | "trait_item" => "trait",
+        "type_alias_declaration" | "type_item" | "type_declaration" => "type",
+        "enum_item" | "enum_declaration" => "enum",
+        "lexical_declaration" | "variable_declaration" => "variable",
+        "const_item" | "const_declaration" => "const",
+        "static_item" => "static",
+        "property_declaration" => "property",
+        "mod_item" | "namespace_definition" => "module",
+        "object_declaration" => "object",
+        "impl_item" => "impl",
+        "export_statement" => "export",
+        "call" if lang == crate::types::Lang::Elixir => elixir_kind_label(node, lines),
+        _ => "definition",
+    }
+}
+
+/// Elixir definitions are all `call` nodes; the keyword (`def`, `defmodule`,
+/// …) lives in the call's `target` field. Map it to the same vocabulary
+/// `kind_label` produces for other languages.
+fn elixir_kind_label(node: tree_sitter::Node, lines: &[&str]) -> &'static str {
+    let Some(target) = node.child_by_field_name("target") else {
+        return "definition";
+    };
+    match node_text_simple(target, lines).as_str() {
+        "defmodule" => "module",
+        "defprotocol" => "protocol",
+        "defimpl" => "impl",
+        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
+            "function"
+        }
+        "defstruct" | "defexception" => "struct",
+        _ => "definition",
+    }
 }
 
 /// Format and rank caller search results with optional expand.
@@ -740,8 +838,14 @@ fn rank_callers(callers: &mut [CallerMatch], scope: &Path, context: Option<&Path
 
 #[cfg(test)]
 mod tests {
-    use super::no_callers_message;
-    use std::path::Path;
+    use super::*;
+    use crate::cache::OutlineCache;
+
+    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
 
     #[test]
     fn no_callers_message_for_unseen_symbol_says_typo_or_scope() {
@@ -784,5 +888,182 @@ mod tests {
             msg.contains("test files"),
             "glob-driven hint should appear when glob is Some: {msg}"
         );
+    }
+
+    #[test]
+    fn enclosing_at_rust_top_level_function() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {\n    let x = 1;\n}\n");
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "foo");
+    }
+
+    #[test]
+    fn enclosing_at_rust_method_inside_mod() {
+        // mod_item has a name field; impl_item does not, so the qualifier path
+        // exercised here is mod-name → method-name.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "mod outer {\n    fn helper() {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "outer.helper");
+    }
+
+    #[test]
+    fn enclosing_at_typescript_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ts",
+            "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_python_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.py",
+            "class Foo:\n    def bar(self):\n        x = 1\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_def_qualifies_with_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_defmodule_kind_is_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  @moduledoc \"hi\"\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "module");
+        assert_eq!(scope.name, "Foo");
+    }
+
+    #[test]
+    fn enclosing_at_top_level_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "// just a comment\nfn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 1, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_zero_line_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 0, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_non_code_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.md", "# heading\n\nsome text\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 3, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_caches_parse_across_calls() {
+        // Two calls into the same file should reuse the cached parse —
+        // observable indirectly by mutating the file between calls without
+        // touching mtime: the first parse wins, the second sees stale data
+        // because the mtime didn't change. (Test only asserts the cache hit
+        // path returns the first-parse result.)
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() { let x = 1; }\n");
+        let cache = OutlineCache::new();
+        let a = enclosing_definition_at(&p, 1, &cache).unwrap();
+        let b = enclosing_definition_at(&p, 1, &cache).unwrap();
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.kind, b.kind);
+    }
+
+    #[test]
+    fn enclosing_at_kind_labels_for_common_definition_kinds() {
+        // One case per kind_label match arm beyond `function`/`module`,
+        // so a regression that miscategorizes (e.g.) a Rust `struct` as
+        // `definition` would surface here.
+        let cases: &[(&str, &str, u32, &str, &str)] = &[
+            ("a.rs", "struct Foo { x: u32 }\n", 1, "struct", "Foo"),
+            ("b.rs", "enum Color { Red, Blue }\n", 1, "enum", "Color"),
+            (
+                "c.rs",
+                "trait Greeter { fn hi(&self); }\n",
+                1,
+                "trait",
+                "Greeter",
+            ),
+            (
+                "d.ts",
+                "interface Shape { area(): number; }\n",
+                1,
+                "interface",
+                "Shape",
+            ),
+            ("e.ts", "class Widget { x = 1; }\n", 1, "class", "Widget"),
+        ];
+        let cache = OutlineCache::new();
+        for (filename, content, line, kind, name) in cases {
+            let tmp = tempfile::tempdir().unwrap();
+            let p = write(tmp.path(), filename, content);
+            let scope = enclosing_definition_at(&p, *line, &cache)
+                .unwrap_or_else(|| panic!("no scope returned for {filename}"));
+            assert_eq!(scope.kind, *kind, "kind mismatch for {filename}");
+            assert_eq!(scope.name, *name, "name mismatch for {filename}");
+        }
+    }
+
+    #[test]
+    fn enclosing_at_rust_impl_block_does_not_qualify_with_type() {
+        // tree-sitter-rust's `impl_item` exposes its type via a `type` field,
+        // not via the `name`/`identifier`/`declarator` fields that
+        // extract_definition_name probes. So methods inside `impl Foo {...}`
+        // produce the bare function name, not `"Foo.bar"`. Pre-existing
+        // behavior of find_enclosing_function — pinned here so a future
+        // qualifier improvement is an intentional, visible change.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "struct Foo;\nimpl Foo {\n    fn bar(&self) {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 4, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "bar");
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -432,21 +432,11 @@ fn format_grouped_usages(group: &[&Match], scope: &Path, cache: &OutlineCache, o
     let lines: Vec<u32> = group.iter().map(|m| m.line).collect();
     let line_str = format_line_list(&lines);
 
-    // Get enclosing function name from outline
-    let fn_name = get_outline_str(&first.path, cache).and_then(|outline_str| {
-        let outline_lines: Vec<&str> = outline_str.lines().collect();
-        let idx = outline_lines.iter().position(|line| {
-            extract_line_range(line).is_some_and(|(s, e)| first.line >= s && first.line <= e)
-        })?;
-        // Extract name: outline lines look like "  [45-79]      fn TestMiddlewareNoRoute"
-        let entry = outline_lines[idx].trim();
-        // Find the name after "fn " or similar keyword
-        entry.split_whitespace().last().map(String::from)
-    });
+    let scope_label = enclosing_scope_label(&first.path, first.line, cache);
 
     let _ = write!(out, "\n\n## {path_str}:{line_str} [{} usages", group.len());
-    if let Some(ref name) = fn_name {
-        let _ = write!(out, " in {name}");
+    if let Some(ref label) = scope_label {
+        let _ = write!(out, " in {label}");
     }
     out.push(']');
 
@@ -510,6 +500,16 @@ fn format_single_match(
         "usage"
     };
 
+    // For usages, append the enclosing function/section if we can recover one.
+    // Definitions and impls already are the named scope.
+    let scope_suffix = if m.is_definition || m.impl_target.is_some() {
+        String::new()
+    } else {
+        enclosing_scope_label(&m.path, m.line, cache)
+            .map(|s| format!(" in {s}"))
+            .unwrap_or_default()
+    };
+
     // Show line range for definitions with def_range, otherwise just the line
     if m.is_definition {
         if let Some((start, end)) = m.def_range {
@@ -524,7 +524,12 @@ fn format_single_match(
             let _ = write!(out, "\n\n## {}:{} [{kind}]", rel(&m.path, scope), m.line);
         }
     } else {
-        let _ = write!(out, "\n\n## {}:{} [{kind}]", rel(&m.path, scope), m.line);
+        let _ = write!(
+            out,
+            "\n\n## {}:{} [{kind}{scope_suffix}]",
+            rel(&m.path, scope),
+            m.line
+        );
     }
 
     // Skip outline for small files — the expanded code speaks for itself
@@ -1165,6 +1170,70 @@ fn outline_context_for_match(
     Some(context)
 }
 
+/// Annotate a usage match with its enclosing scope: `"function foo"` /
+/// `"class Bar"` for code (via tree-sitter), `"§Heading"` for markdown
+/// (via line walk). Returns `None` for top-level matches and unsupported
+/// file types — the formatter renders those without an `in …` suffix.
+fn enclosing_scope_label(
+    path: &std::path::Path,
+    match_line: u32,
+    cache: &OutlineCache,
+) -> Option<String> {
+    match crate::lang::detect_file_type(path) {
+        FileType::Code(_) => {
+            let scope = callers::enclosing_definition_at(path, match_line, cache)?;
+            Some(format!("{} {}", scope.kind, scope.name))
+        }
+        FileType::Markdown => markdown_enclosing_scope(path, match_line),
+        _ => None,
+    }
+}
+
+/// Find the nearest preceding ATX heading (`#`–`######`) above `match_line`.
+/// Markdown has no AST in tilth, so a backwards line walk is the right tool —
+/// kept narrow so it can't drift into other markdown semantics.
+fn markdown_enclosing_scope(path: &std::path::Path, match_line: u32) -> Option<String> {
+    if match_line == 0 {
+        return None;
+    }
+    let content = std::fs::read_to_string(path).ok()?;
+    let lines: Vec<&str> = content.lines().collect();
+    let start = (match_line as usize).min(lines.len()).saturating_sub(1);
+    for line in lines[..=start].iter().rev() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('#') {
+            continue;
+        }
+        let mut hashes = 0;
+        let mut rest = trimmed;
+        while hashes < 6 {
+            match rest.strip_prefix('#') {
+                Some(r) => {
+                    hashes += 1;
+                    rest = r;
+                }
+                None => break,
+            }
+        }
+        if hashes == 0 {
+            continue;
+        }
+        let text = rest.trim_start_matches([' ', '\t']).trim_end();
+        if text.is_empty() {
+            continue;
+        }
+        let display: String = if text.chars().count() > 60 {
+            let mut s: String = text.chars().take(57).collect();
+            s.push_str("...");
+            s
+        } else {
+            text.to_string()
+        };
+        return Some(format!("§{display}"));
+    }
+    None
+}
+
 /// Extract (`start_line`, `end_line`) from an outline entry like "[20-115]" or "[16]".
 fn extract_line_range(line: &str) -> Option<(u32, u32)> {
     let trimmed = line.trim();
@@ -1547,6 +1616,98 @@ mod tests {
             result.total_found >= 2,
             "expected symbol found via both real and symlinked paths, got {}",
             result.total_found
+        );
+    }
+
+    // ── enclosing_scope_label / markdown tests ──
+
+    #[test]
+    fn scope_label_code_combines_kind_and_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.ts");
+        std::fs::write(&p, "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n").unwrap();
+        let cache = OutlineCache::new();
+        let label = enclosing_scope_label(&p, 3, &cache).unwrap();
+        assert_eq!(label, "function Foo.bar");
+    }
+
+    #[test]
+    fn scope_label_markdown_returns_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(
+            &p,
+            "# Top\n\n## Cost Accounting\n\nsome text\n\nmore text\n",
+        )
+        .unwrap();
+        let cache = OutlineCache::new();
+        let label = enclosing_scope_label(&p, 7, &cache).unwrap();
+        assert_eq!(label, "§Cost Accounting");
+    }
+
+    #[test]
+    fn markdown_scope_truncates_long_headings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        let long = "x".repeat(80);
+        std::fs::write(&p, format!("## {long}\n\nbody\n")).unwrap();
+        let label = markdown_enclosing_scope(&p, 3).unwrap();
+        // 60-char window means 57 chars + "..." (display starts after the "§").
+        assert!(label.starts_with("§"));
+        assert!(label.ends_with("..."));
+        assert_eq!(label.chars().count(), 1 + 57 + 3);
+    }
+
+    #[test]
+    fn markdown_scope_returns_none_before_first_heading() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(&p, "preamble line one\npreamble line two\n").unwrap();
+        assert!(markdown_enclosing_scope(&p, 2).is_none());
+    }
+
+    #[test]
+    fn format_single_match_renders_usage_scope_suffix() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.ts");
+        std::fs::write(&p, "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n").unwrap();
+
+        let m = Match {
+            path: p.clone(),
+            line: 3,
+            text: "    const x = 1;".to_string(),
+            is_definition: false,
+            exact: false,
+            file_lines: 5,
+            mtime: SystemTime::now(),
+            def_range: None,
+            def_name: None,
+            def_weight: 0,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let mut expand_remaining = 0usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        assert!(
+            out.contains("[usage in function Foo.bar]"),
+            "expected scope suffix in output, got: {out}"
         );
     }
 }


### PR DESCRIPTION
Replaces the outline-string heuristic in `format_grouped_usages` (which fell out as `{` for `class Foo {`, returning the last whitespace-split token) and adds the same annotation to `format_single_match`. Code matches now render `[usage in function bar]` / `[N usages in function Class.method]`; markdown matches render `[usage in §Heading]`.

The code path goes through `callers::enclosing_definition_at(path, line)` — a new public entry point that re-parses the file with tree-sitter (cached on `OutlineCache`) and walks up from the deepest node containing `line` to the nearest definition, qualifying with the enclosing type/module when one wraps it. The walker is factored out of the existing `find_enclosing_function` so callers and the formatter share one AST-correct implementation; `find_enclosing_function` keeps its `(name, range)` signature for the existing call sites in `find_callers_treesitter`.

Why this shape

The natural alternative — parse the rendered outline string back into `(kind, name)` via hardcoded keyword/modifier lists — would carry two problems: (1) every new language grammar requires updating the keyword set or it silently produces wrong scope labels, including existing-language gaps like Elixir's `defmodule`/`def`/`defp` and Swift's `init`/`deinit`/`subscript`; (2) it duplicates information the AST already has. Going through tree-sitter avoids both — language coverage is automatic, kind labels come from a single match on AST node kinds (with one Elixir-specific branch since `def` is a `call` node, not a definition kind).

Cache shape

`OutlineCache` already keys on `(path, mtime)` and stores rendered outline strings. Extended it with a parallel `DashMap` of `Arc<ParsedFile>` (content + tree + lang) under the same key discipline. Same lifecycle, no new threading through call sites; if someday this needs to split into its own type the move is mechanical.

Markdown

Markdown has no AST in tilth, so `markdown_enclosing_scope` walks backwards to the nearest preceding ATX heading and truncates to ~60 chars with an ellipsis. Kept narrow so it can't drift into other markdown semantics.

Tests

Seventeen new tests:

- AST walk: Rust top-level + mod-qualified, TypeScript class methods, Python `class.def`, Elixir `Module.func`, Elixir `defmodule` kind.
- Kind labels: parameterized coverage of `class` / `struct` / `enum` / `interface` / `trait` so a regression on the kind_label match arm surfaces immediately.
- Pinned behavior: `impl Foo { fn bar() }` produces `"bar"`, not `"Foo.bar"` — tree-sitter-rust's `impl_item` exposes its type via a `type` field that `extract_definition_name` doesn't probe. Pre-existing in `find_enclosing_function`; the test makes any future fix an intentional, visible change.
- Edges: line=0, non-code, before-first-heading, markdown heading truncation.
- Integration: `format_single_match` round-trips an actual Match through the formatter and asserts the output contains `[usage in function Foo.bar]`.