### PR TITLE
docs: README CLI parity + Claude Code skill prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Tree-sitter finds where symbols are **defined** — not just where strings appea
 
 Expanded definitions include a **callee footer** (`── calls ──`) showing resolved callees with file, line range, and signature — the agent can follow call chains without separate searches for each callee.
 
+### Expanded search
+
+CLI search returns compact results by default. Use `--expand` to inline source for the top matches:
+
+```bash
+$ tilth handleAuth --scope src/ --expand       # top 2 (default when flag is bare)
+$ tilth handleAuth --scope src/ --expand=5     # top 5
+```
+
+In MCP mode, `expand` defaults to 2 — no flag needed.
+
 ### Multi-symbol search
 
 Trace across files in one call:
@@ -68,12 +79,36 @@ Each symbol gets its own result block with definitions and expansions. The expan
 Find all call sites of a symbol using structural tree-sitter matching (not text search):
 
 ```bash
-$ tilth isTrustedProxy --kind callers --scope .
+$ tilth isTrustedProxy --callers --scope .
 # Callers of "isTrustedProxy" — 5 call sites
 
 ## context.go:1011 [caller: ClientIP]
 → trusted = c.engine.isTrustedProxy(remoteIP)
 ```
+
+In MCP mode, use `kind: "callers"` on `tilth_search` instead.
+
+### Blast-radius deps
+
+See what a file imports and what depends on it — useful before renaming or changing exports:
+
+```bash
+$ tilth src/auth.ts --deps
+# deps: src/auth.ts
+
+## Imports (3)
+  jsonwebtoken      (external)
+  @/config          src/config.ts
+  express           (external)
+
+## Dependents (4)
+  src/routes/api.ts        uses: handleAuth, AuthManager
+  src/middleware/cors.ts   uses: validateToken
+  src/app.ts               uses: AuthManager
+  test/auth.test.ts        uses: handleAuth, AuthManager
+```
+
+In MCP mode, use the `tilth_deps` tool.
 
 ### Session dedup
 
@@ -159,7 +194,7 @@ Add `--edit` to enable hash-anchored file editing (see [Edit mode](#edit-mode)):
 tilth install claude-code --edit
 ```
 
-Or call it from bash — see [AGENTS.md](./AGENTS.md) for the agent prompt.
+Or call it from bash — see [AGENTS.md](./AGENTS.md) for the MCP agent prompt, or [skills/SKILL.md](./skills/SKILL.md) for a Claude Code skill prompt.
 
 ### Smaller models
 
@@ -216,10 +251,13 @@ tilth <path> --section 45-89      # exact line range
 tilth <path> --section "## Foo"   # markdown heading
 tilth <path> --full               # force full content
 tilth <symbol> --scope <dir>      # definitions + usages
+tilth <symbol> --expand=5         # inline source for top 5 matches
+tilth <symbol> --callers          # find call sites (structural)
+tilth <path> --deps               # imports + dependents
 tilth "TODO: fix" --scope <dir>   # content search
 tilth "/<regex>/" --scope <dir>   # regex search
 tilth "*.test.ts" --scope <dir>   # glob files
-tilth diff HEAD~1                     # structural diff (function-level)
+tilth diff HEAD~1                 # structural diff (function-level)
 tilth --map --scope <dir>         # codebase skeleton (CLI only)
 ```
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: tilth
+description: Use the `tilth` CLI for code reading, outlining, search, callers, blast-radius deps, and structural diffs. Activate when the user asks to explore a repo, find a symbol, trace callers, read a file, view a diff, or analyze impact. Prefer `tilth` over `grep`/`cat`/`find`/`ls` — one invocation returns AST-aware outlines, definitions, callees, and usages.
+---
+
+# tilth — code intelligence CLI
+
+Tree-sitter + ripgrep + smart file reading in one binary. Replaces `grep`, `cat`, `find`, `ls` with AST-aware equivalents across 14 languages (Rust, TS/TSX, JS, Python, Go, Java, Scala, C, C++, Ruby, PHP, C#, Swift, Elixir).
+
+Run via Bash: `tilth <args>`. Search before reading — `tilth <symbol> --scope .` returns definitions, usages, and callee footers in one call.
+
+DO NOT use `grep`, `rg`, `cat`, `head`, `tail`, `find`, `ls` — use `tilth` instead.
+DO NOT re-read files whose content is already shown in expanded search results.
+
+## Read
+
+```bash
+tilth <path>                      # smart view: full if small, outline if large
+tilth <path> --section 45-89      # exact line range
+tilth <path> --section "## Foo"   # markdown heading (suggests fuzzy matches on miss)
+tilth <path> --full               # force full content
+```
+
+Outline format: `[<start>-<end>]  <symbol>`. Full/section format: `<line> │ <content>`. Binary files print `[skipped]`; lockfiles, minified bundles, generated code print `[generated]`.
+
+## Search
+
+```bash
+tilth <symbol> --scope <dir>                # definitions + usages
+tilth "Foo,Bar,Baz" --scope <dir>           # multi-symbol (max 5)
+tilth <symbol> --expand                     # inline source for top 2 matches
+tilth <symbol> --expand=5                   # inline source for top 5
+tilth <symbol> --callers --scope <dir>      # call sites (structural, not text)
+tilth "TODO: fix" --scope <dir>             # content search (literal text)
+tilth "/regex/" --scope <dir>               # regex search
+tilth <symbol> --glob "*.rs" --scope <dir>  # file pattern filter
+```
+
+Output per match:
+```
+## <path>:<start>-<end> [definition|usage|impl]
+<outline context>
+<expanded source block>
+── calls ──
+  <callee>  <path>:<start>-<end>  <signature>
+── siblings ──
+  <related>  <path>:<start>-<end>  <signature>
+```
+
+`--callers` finds direct, by-name call sites. If it returns 0 matches but the symbol exists, the call is likely indirect (trait/interface dispatch, reflection, route registration, callback) — fall back to `tilth <symbol> --scope .` to see references.
+
+## Files
+
+```bash
+tilth "*.test.ts" --scope <dir>   # glob (respects .gitignore)
+tilth --map --scope <dir>         # codebase skeleton with directory token rollups
+```
+
+## Deps (blast radius)
+
+```bash
+tilth <file> --deps               # what it imports + what depends on it
+```
+
+Use only before renaming, removing, or changing an export's signature.
+
+## Diff (structural)
+
+```bash
+tilth diff                        # uncommitted changes
+tilth diff HEAD~1                 # vs prior commit
+tilth diff main..feat             # branch comparison
+tilth diff --log HEAD~5..HEAD     # per-commit symbol summaries
+tilth diff --blast                # warn on signature-changed exports
+tilth diff --expand 3             # inline source for top 3 changed symbols
+```
+
+Function-level change detection — `[+]` added, `[-]` removed, `[~]` modified, `[~:sig]` signature changed. Replaces `git diff` for symbol-level review.
+
+## Budget
+
+```bash
+tilth <args> --budget 2000        # cap response at ~N tokens
+```
+
+Use when an outline or search returns more than you need.

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -18,7 +18,7 @@ DO NOT re-read files whose content is already shown in expanded search results.
 tilth <path>                      # smart view: full if small, outline if large
 tilth <path> --section 45-89      # exact line range
 tilth <path> --section "## Foo"   # markdown heading (suggests fuzzy matches on miss)
-tilth <path> --full               # force full content
+tilth <path> --full               # force full content (file paths)
 ```
 
 Outline format: `[<start>-<end>]  <symbol>`. Full/section format: `<line> │ <content>`. Binary files print `[skipped]`; lockfiles, minified bundles, generated code print `[generated]`.
@@ -30,11 +30,19 @@ tilth <symbol> --scope <dir>                # definitions + usages
 tilth "Foo,Bar,Baz" --scope <dir>           # multi-symbol (max 5)
 tilth <symbol> --expand                     # inline source for top 2 matches
 tilth <symbol> --expand=5                   # inline source for top 5
+tilth <symbol> --full                       # expand every match (capped at 50)
 tilth <symbol> --callers --scope <dir>      # call sites (structural, not text)
 tilth "TODO: fix" --scope <dir>             # content search (literal text)
 tilth "/regex/" --scope <dir>               # regex search
 tilth <symbol> --glob "*.rs" --scope <dir>  # file pattern filter
 ```
+
+`--full` semantics depend on query type:
+- File path → return whole file (bypass smart-view outline).
+- Symbol / text / regex → expand every match (capped at 50). Explicit `--expand=N` wins.
+- Glob → no-op.
+
+Symbol search also surfaces **markdown headings as soft definitions** — `tilth StreamingResponse --scope docs/` finds `## StreamingResponse` headings ranked between code defs (60-80) and usages (0). Section body inlines automatically in the default preview (capped at 40 lines; pass `--expand` for the rest).
 
 Output per match:
 ```


### PR DESCRIPTION
## Summary

Closes the README parity gap for v0.6+ CLI features (`--expand`, `--callers`, `--deps`) and adds `skills/SKILL.md` for Claude Code skill activation. Builds on #50 (option B — fresh write, no slop).

### README

- New `### Expanded search` section covering `--expand` (bare = top 2) and `--expand=5`, with MCP-mode note that `expand` defaults to 2.
- Stale `--kind callers` example replaced with `--callers`; MCP-mode note pointing to `kind: "callers"` on `tilth_search`.
- New `### Blast-radius deps` section with `--deps` example output (Imports + Dependents); MCP-mode note pointing to `tilth_deps`.
- Usage block adds `--expand=5`, `--callers`, `--deps` rows.
- "Or call it from bash" line now points to both AGENTS.md (MCP) and skills/SKILL.md (Claude Code skill).

### skills/SKILL.md (new, 87 lines)

YAML-frontmatter skill prompt for agents invoking tilth via Bash. Mirrors AGENTS.md tone (terse, directive). Current with v0.7.0:

- Structural diff (`tilth diff`, `--log`, `--blast`, `--expand`, `[~:sig]` markers)
- Fuzzy heading suggestions on `--section` miss
- Indirect-call hint when `--callers` returns 0 matches
- Map directory token rollups, minified-file skip, Elixir support
- Multi-symbol search syntax (`"Foo,Bar,Baz"`, max 5)

## Notes

- Box-drawing `── calls ──` (U+2500) preserved — matches `src/search/mod.rs:617`.
- Diverges from #50's draft: trims marketing bullets ("Key Advantages Over grep/cat/read"), drops generic "Workflow Patterns" section, fixes `-- calls --` ASCII regression.

## Test plan

- [x] Verified each CLI flag in `src/main.rs` (`--expand` requires `=`, `--callers` is bool, `--deps` is bool, `tilth diff --expand N` is positional).
- [x] Verified fuzzy heading suggestions exist (`src/read/mod.rs:290 suggest_headings`).
- [x] Verified no-callers indirect-call hint exists (`src/search/callers.rs:687 no_callers_message`).
- [x] Verified `[~:sig]` marker is consistent with README structural diff section.
- [ ] Reviewer to confirm SKILL.md activates correctly in Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: sting8k <prawps@gmail.com>