### PR TITLE
refactor: dead-code drops + module reorg from @choongng/dev (Tier 3)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,14 +101,11 @@ pub fn run_callers(
     expand: usize,
     budget_tokens: Option<u64>,
     glob: Option<&str>,
-    cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    let session = session::Session::new();
     let bloom = index::bloom::BloomFilterCache::new();
     let expand = if expand > 0 { expand } else { 2 };
-    let output = search::callers::search_callers_expanded(
-        target, scope, cache, &session, &bloom, expand, None, glob,
-    )?;
+    let output =
+        search::callers::search_callers_expanded(target, scope, &bloom, expand, None, glob)?;
     match budget_tokens {
         Some(b) => Ok(budget::apply(&output, b)),
         None => Ok(output),
@@ -120,10 +117,9 @@ pub fn run_deps(
     path: &Path,
     scope: &Path,
     budget_tokens: Option<u64>,
-    cache: &OutlineCache,
 ) -> Result<String, TilthError> {
     let bloom = index::bloom::BloomFilterCache::new();
-    let result = search::deps::analyze_deps(path, scope, cache, &bloom)?;
+    let result = search::deps::analyze_deps(path, scope, &bloom)?;
     let budget_usize = budget_tokens.map(|b| b as usize);
     Ok(search::deps::format_deps(&result, scope, budget_usize))
 }
@@ -196,7 +192,7 @@ fn run_inner(
             }
             out
         }
-        QueryType::Glob(pattern) => search::search_glob(&pattern, scope, cache)?,
+        QueryType::Glob(pattern) => search::search_glob(&pattern, scope)?,
         _ if use_expanded => {
             let ctx = ExpandedCtx {
                 session: session::Session::new(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -257,14 +257,7 @@ fn main() {
 
     // Callers mode
     if cli.callers {
-        let result = tilth::run_callers(
-            &query,
-            &scope,
-            expand,
-            cli.budget,
-            cli.glob.as_deref(),
-            &cache,
-        );
+        let result = tilth::run_callers(&query, &scope, expand, cli.budget, cli.glob.as_deref());
         emit_result(result, &query, cli.json, is_tty);
         return;
     }
@@ -286,7 +279,7 @@ fn main() {
                 }
             }
         };
-        let result = tilth::run_deps(&path, &scope, cli.budget, &cache);
+        let result = tilth::run_deps(&path, &scope, cli.budget);
         emit_result(result, &query, cli.json, is_tty);
         return;
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -394,13 +394,11 @@ pub(crate) fn dispatch_tool(
     match tool {
         "tilth_read" => tool_read(args, services.cache(), services.session(), edit_mode),
         "tilth_search" => tool_search(args, services.cache(), services.session(), services.bloom()),
-        "tilth_files" => tool_files(args, services.cache()),
-        "tilth_deps" => tool_deps(args, services.cache(), services.bloom()),
+        "tilth_files" => tool_files(args),
+        "tilth_deps" => tool_deps(args, services.bloom()),
         "tilth_diff" => tool_diff(args),
         "tilth_session" => tool_session(args, services.session()),
-        "tilth_edit" if edit_mode => {
-            tool_edit(args, services.session(), services.cache(), services.bloom())
-        }
+        "tilth_edit" if edit_mode => tool_edit(args, services.session(), services.bloom()),
         _ => Err(format!("unknown tool: {tool}")),
     }
 }
@@ -562,7 +560,7 @@ fn tool_search(
         "callers" => {
             session.record_search(query);
             crate::search::callers::search_callers_expanded(
-                query, &scope, cache, session, bloom, expand, context, glob,
+                query, &scope, bloom, expand, context, glob,
             )
         }
         _ => {
@@ -578,7 +576,7 @@ fn tool_search(
     Ok(result)
 }
 
-fn tool_files(args: &Value, cache: &OutlineCache) -> Result<String, String> {
+fn tool_files(args: &Value) -> Result<String, String> {
     let pattern = args
         .get("pattern")
         .and_then(|v| v.as_str())
@@ -586,18 +584,14 @@ fn tool_files(args: &Value, cache: &OutlineCache) -> Result<String, String> {
     let (scope, scope_warning) = resolve_scope(args);
     let budget = args.get("budget").and_then(serde_json::Value::as_u64);
 
-    let output = crate::search::search_glob(pattern, &scope, cache).map_err(|e| e.to_string())?;
+    let output = crate::search::search_glob(pattern, &scope).map_err(|e| e.to_string())?;
 
     let mut result = scope_warning.unwrap_or_default();
     result.push_str(&apply_budget(output, budget));
     Ok(result)
 }
 
-fn tool_deps(
-    args: &Value,
-    cache: &OutlineCache,
-    bloom: &Arc<BloomFilterCache>,
-) -> Result<String, String> {
+fn tool_deps(args: &Value, bloom: &Arc<BloomFilterCache>) -> Result<String, String> {
     let path_str = args
         .get("path")
         .and_then(|v| v.as_str())
@@ -609,7 +603,7 @@ fn tool_deps(
         .and_then(serde_json::Value::as_u64)
         .map(|b| b as usize);
 
-    let deps_result = crate::search::deps::analyze_deps(&path, &scope, cache, bloom)
+    let deps_result = crate::search::deps::analyze_deps(&path, &scope, bloom)
         .map_err(|e| e.to_string())?;
     let mut output = scope_warning.unwrap_or_default();
     output.push_str(&crate::search::deps::format_deps(
@@ -653,7 +647,6 @@ fn tool_session(args: &Value, session: &Session) -> Result<String, String> {
 fn tool_edit(
     args: &Value,
     session: &Session,
-    _cache: &OutlineCache,
     bloom: &Arc<BloomFilterCache>,
 ) -> Result<String, String> {
     let path_str = args

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -603,8 +603,8 @@ fn tool_deps(args: &Value, bloom: &Arc<BloomFilterCache>) -> Result<String, Stri
         .and_then(serde_json::Value::as_u64)
         .map(|b| b as usize);
 
-    let deps_result = crate::search::deps::analyze_deps(&path, &scope, bloom)
-        .map_err(|e| e.to_string())?;
+    let deps_result =
+        crate::search::deps::analyze_deps(&path, &scope, bloom).map_err(|e| e.to_string())?;
     let mut output = scope_warning.unwrap_or_default();
     output.push_str(&crate::search::deps::format_deps(
         &deps_result,

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -460,16 +460,18 @@ fn parse_cargo_toml(root: &Path) -> Option<ManifestInfo> {
 
     let content = fs::read_to_string(root.join("Cargo.toml")).ok()?;
     let parsed: CargoToml = toml::from_str(&content).ok()?;
-    let (name, version) = parsed
-        .package
-        .map_or((None, None), |p| (p.name, p.version));
+    let (name, version) = parsed.package.map_or((None, None), |p| (p.name, p.version));
     let mut deps: Vec<String> = parsed
         .dependencies
         .map(|d| d.into_iter().map(|(k, _)| k).collect())
         .unwrap_or_default();
     deps.sort();
     deps.truncate(10);
-    Some(ManifestInfo { name, version, deps })
+    Some(ManifestInfo {
+        name,
+        version,
+        deps,
+    })
 }
 
 fn parse_package_json(root: &Path) -> Option<ManifestInfo> {

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -165,7 +165,7 @@ fn fingerprint_inner(root: &Path) -> String {
 
             // Hot files (only for projects with local imports)
             if let Some(hot) = hot_files(root, &walk, primary_lang) {
-                lines.push(format!("  hot: {hot}"));
+                lines.push(format!("  hot (× = importers): {hot}"));
             }
 
             // Git context
@@ -192,7 +192,7 @@ fn fingerprint_inner(root: &Path) -> String {
     } else {
         // No manifest — still show hot, git, tests
         if let Some(hot) = hot_files(root, &walk, primary_lang) {
-            lines.push(format!("  hot: {hot}"));
+            lines.push(format!("  hot (× = importers): {hot}"));
         }
         if let Some(git) = git_context(root) {
             lines.push(format!("  git: {git}"));

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -8,6 +8,8 @@ use std::path::Path;
 use std::process::Command;
 use std::time::{Duration, Instant};
 
+use serde::Deserialize;
+
 use crate::lang::detect_file_type;
 use crate::read::imports::is_import_line;
 use crate::search::SKIP_DIRS;
@@ -445,73 +447,50 @@ fn parse_manifest(root: &Path, manifest: &str) -> Option<ManifestInfo> {
 }
 
 fn parse_cargo_toml(root: &Path) -> Option<ManifestInfo> {
-    let content = fs::read_to_string(root.join("Cargo.toml")).ok()?;
-    let mut name = None;
-    let mut version = None;
-    let mut deps: Vec<String> = Vec::new();
-    let mut in_package = false;
-    let mut in_deps = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        if trimmed.starts_with('[') {
-            in_package = trimmed == "[package]";
-            in_deps = trimmed == "[dependencies]";
-            continue;
-        }
-
-        if in_package {
-            if let Some(val) = extract_toml_string_value(trimmed, "name") {
-                name = Some(val);
-            } else if let Some(val) = extract_toml_string_value(trimmed, "version") {
-                version = Some(val);
-            }
-        }
-
-        if in_deps {
-            // dep_name = "version" or dep_name = { version = "..." }
-            if let Some(dep_name) = trimmed.split('=').next() {
-                let dep = dep_name.trim();
-                if !dep.is_empty() && !dep.starts_with('#') {
-                    deps.push(dep.to_string());
-                }
-            }
-        }
+    #[derive(Deserialize)]
+    struct CargoToml {
+        package: Option<Package>,
+        dependencies: Option<toml::Table>,
+    }
+    #[derive(Deserialize)]
+    struct Package {
+        name: Option<String>,
+        version: Option<String>,
     }
 
+    let content = fs::read_to_string(root.join("Cargo.toml")).ok()?;
+    let parsed: CargoToml = toml::from_str(&content).ok()?;
+    let (name, version) = parsed
+        .package
+        .map_or((None, None), |p| (p.name, p.version));
+    let mut deps: Vec<String> = parsed
+        .dependencies
+        .map(|d| d.into_iter().map(|(k, _)| k).collect())
+        .unwrap_or_default();
     deps.sort();
     deps.truncate(10);
-
-    Some(ManifestInfo {
-        name,
-        version,
-        deps,
-    })
+    Some(ManifestInfo { name, version, deps })
 }
 
 fn parse_package_json(root: &Path) -> Option<ManifestInfo> {
-    let content = fs::read_to_string(root.join("package.json")).ok()?;
-    let json: serde_json::Value = serde_json::from_str(&content).ok()?;
-
-    let name = json.get("name").and_then(|v| v.as_str()).map(String::from);
-    let version = json
-        .get("version")
-        .and_then(|v| v.as_str())
-        .map(String::from);
-
-    let mut deps: Vec<String> = Vec::new();
-    if let Some(obj) = json.get("dependencies").and_then(|v| v.as_object()) {
-        for key in obj.keys() {
-            deps.push(key.clone());
-        }
+    #[derive(Deserialize)]
+    struct PackageJson {
+        name: Option<String>,
+        version: Option<String>,
+        dependencies: Option<serde_json::Map<String, serde_json::Value>>,
     }
+
+    let content = fs::read_to_string(root.join("package.json")).ok()?;
+    let parsed: PackageJson = serde_json::from_str(&content).ok()?;
+    let mut deps: Vec<String> = parsed
+        .dependencies
+        .map(|d| d.into_iter().map(|(k, _)| k).collect())
+        .unwrap_or_default();
     deps.sort();
     deps.truncate(10);
-
     Some(ManifestInfo {
-        name,
-        version,
+        name: parsed.name,
+        version: parsed.version,
         deps,
     })
 }
@@ -558,108 +537,39 @@ fn parse_go_mod(root: &Path) -> Option<ManifestInfo> {
 }
 
 fn parse_pyproject_toml(root: &Path) -> Option<ManifestInfo> {
-    let content = fs::read_to_string(root.join("pyproject.toml")).ok()?;
-    let mut name = None;
-    let mut version = None;
-    let mut deps: Vec<String> = Vec::new();
-    let mut in_project = false;
-    let mut in_deps = false;
-
-    for line in content.lines() {
-        let trimmed = line.trim();
-
-        if trimmed.starts_with('[') {
-            in_project = trimmed == "[project]";
-            in_deps = trimmed == "[project.dependencies]"
-                || (in_project && trimmed == "dependencies = [");
-            continue;
-        }
-
-        if in_project {
-            if let Some(val) = extract_toml_string_value(trimmed, "name") {
-                name = Some(val);
-            } else if let Some(val) = extract_toml_string_value(trimmed, "version") {
-                version = Some(val);
-            }
-
-            // Inline dependencies array
-            if trimmed.starts_with("dependencies") && trimmed.contains('[') {
-                // Parse inline: dependencies = ["dep1", "dep2>=1.0"]
-                if let Some(arr_start) = trimmed.find('[') {
-                    let arr_content = &trimmed[arr_start..];
-                    for item in arr_content.split('"') {
-                        let item = item.trim();
-                        if item.is_empty()
-                            || item.starts_with('[')
-                            || item.starts_with(']')
-                            || item.starts_with(',')
-                        {
-                            continue;
-                        }
-                        // Extract package name (before any version specifier)
-                        let dep_name = item
-                            .split(&['>', '<', '=', '~', '!', ';', '['][..])
-                            .next()
-                            .unwrap_or(item)
-                            .trim();
-                        if !dep_name.is_empty() {
-                            deps.push(dep_name.to_string());
-                        }
-                    }
-                }
-            }
-        }
-
-        if in_deps && !trimmed.starts_with('[') {
-            // Multi-line deps array items: "dep_name>=1.0",
-            let clean = trimmed.trim_matches(&['"', '\'', ',', ' '][..]);
-            if !clean.is_empty() && clean != "]" {
-                let dep_name = clean
-                    .split(&['>', '<', '=', '~', '!', ';', '['][..])
-                    .next()
-                    .unwrap_or(clean)
-                    .trim();
-                if !dep_name.is_empty() {
-                    deps.push(dep_name.to_string());
-                }
-            }
-        }
+    #[derive(Default, Deserialize)]
+    struct PyProject {
+        project: Option<Project>,
+    }
+    #[derive(Default, Deserialize)]
+    struct Project {
+        name: Option<String>,
+        version: Option<String>,
+        dependencies: Option<Vec<String>>,
     }
 
+    let content = fs::read_to_string(root.join("pyproject.toml")).ok()?;
+    let parsed: PyProject = toml::from_str(&content).ok()?;
+    let project = parsed.project.unwrap_or_default();
+    let mut deps: Vec<String> = project
+        .dependencies
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|spec| {
+            let bare = spec
+                .split(&['>', '<', '=', '~', '!', ';', '[', ' '][..])
+                .next()?
+                .trim();
+            (!bare.is_empty()).then(|| bare.to_string())
+        })
+        .collect();
     deps.sort();
     deps.truncate(10);
-
     Some(ManifestInfo {
-        name,
-        version,
+        name: project.name,
+        version: project.version,
         deps,
     })
-}
-
-/// Extract a string value from a TOML key = "value" line.
-fn extract_toml_string_value(line: &str, key: &str) -> Option<String> {
-    let trimmed = line.trim();
-    if !trimmed.starts_with(key) {
-        return None;
-    }
-    let rest = trimmed[key.len()..].trim_start();
-    if !rest.starts_with('=') {
-        return None;
-    }
-    let after_eq = rest[1..].trim();
-    // Extract value between quotes: "value" or 'value'
-    let val = if let Some(rest) = after_eq.strip_prefix('"') {
-        rest.split('"').next().unwrap_or("")
-    } else if let Some(rest) = after_eq.strip_prefix('\'') {
-        rest.split('\'').next().unwrap_or("")
-    } else {
-        // Bare value — take up to whitespace or comment
-        after_eq.split_whitespace().next().unwrap_or("")
-    };
-    if val.is_empty() {
-        return None;
-    }
-    Some(val.to_string())
 }
 
 // ---------------------------------------------------------------------------

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -4,7 +4,6 @@ use std::sync::{LazyLock, Mutex};
 
 use streaming_iterator::StreamingIterator;
 
-use crate::cache::OutlineCache;
 use crate::lang::outline::{get_outline_entries, outline_language};
 use crate::types::{Lang, OutlineEntry};
 
@@ -283,7 +282,6 @@ pub fn resolve_callees(
     callee_names: &[String],
     source_path: &Path,
     source_content: &str,
-    _cache: &OutlineCache,
     bloom: &crate::index::bloom::BloomFilterCache,
 ) -> Vec<ResolvedCallee> {
     if callee_names.is_empty() {
@@ -426,13 +424,12 @@ pub fn resolve_callees_transitive(
     initial_names: &[String],
     source_path: &Path,
     source_content: &str,
-    cache: &OutlineCache,
     bloom: &crate::index::bloom::BloomFilterCache,
     depth_limit: u32,
     budget: usize,
 ) -> Vec<ResolvedCalleeNode> {
     // 1st hop: resolve direct callees (existing logic)
-    let first_hop = resolve_callees(initial_names, source_path, source_content, cache, bloom);
+    let first_hop = resolve_callees(initial_names, source_path, source_content, bloom);
 
     if depth_limit < 2 || first_hop.is_empty() {
         return first_hop
@@ -457,7 +454,7 @@ pub fn resolve_callees_transitive(
 
     for parent in first_hop {
         let children = if budget_remaining > 0 {
-            resolve_second_hop(&parent, cache, bloom, &mut visited, &mut budget_remaining)
+            resolve_second_hop(&parent, bloom, &mut visited, &mut budget_remaining)
         } else {
             Vec::new()
         };
@@ -473,7 +470,6 @@ pub fn resolve_callees_transitive(
 /// Resolve 2nd-hop callees for a single parent callee.
 fn resolve_second_hop(
     parent: &ResolvedCallee,
-    cache: &OutlineCache,
     bloom: &crate::index::bloom::BloomFilterCache,
     visited: &mut HashSet<(PathBuf, u32)>,
     budget: &mut usize,
@@ -494,7 +490,7 @@ fn resolve_second_hop(
         return Vec::new();
     }
 
-    let mut resolved = resolve_callees(&nested_names, &parent.file, &content, cache, bloom);
+    let mut resolved = resolve_callees(&nested_names, &parent.file, &content, bloom);
 
     // Filter: skip self-recursive calls and already-visited callees
     resolved.retain(|c| {

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -9,11 +9,9 @@ use streaming_iterator::StreamingIterator;
 
 use crate::lang::treesitter::{extract_definition_name, DEFINITION_KINDS};
 
-use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
 use crate::lang::outline::outline_language;
-use crate::session::Session;
 use crate::types::FileType;
 
 const MAX_MATCHES: usize = 10;
@@ -358,8 +356,6 @@ fn find_enclosing_function(
 pub fn search_callers_expanded(
     target: &str,
     scope: &Path,
-    _cache: &OutlineCache,
-    _session: &Session,
     bloom: &crate::index::bloom::BloomFilterCache,
     expand: usize,
     context: Option<&Path>,

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -17,13 +17,11 @@ use crate::session::Session;
 use crate::types::FileType;
 
 const MAX_MATCHES: usize = 10;
-/// Stop walking once we have this many raw matches. Generous headroom for dedup + ranking.
-const EARLY_QUIT_THRESHOLD: usize = 30;
 /// Max unique caller functions to trace for 2nd hop. Above this = wide fan-out, skip.
 const IMPACT_FANOUT_THRESHOLD: usize = 10;
 /// Max 2nd-hop results to display.
 const IMPACT_MAX_RESULTS: usize = 15;
-/// Early quit for batch caller search.
+/// Stop the batch caller walk once we have this many raw matches. Generous headroom for dedup + ranking.
 const BATCH_EARLY_QUIT: usize = 50;
 
 /// A single caller match — a call site of a target symbol.
@@ -35,217 +33,52 @@ pub struct CallerMatch {
     pub call_text: String,
     /// Line range of the calling function (for expand).
     pub caller_range: Option<(u32, u32)>,
-    /// File content, already read during `find_callers` — avoids re-reading during expand.
+    /// File content, already read during `find_callers_batch` — avoids re-reading during expand.
     /// Shared across all call sites in the same file via reference counting.
     pub content: Arc<String>,
 }
 
-/// Find all call sites of a target symbol across the codebase using tree-sitter.
-/// Walk the scope once, return all direct call sites of `target` plus
-/// whether the literal name appeared anywhere (used to distinguish
-/// "real symbol with no direct callers" from "typo'd query" — the hint
-/// shown to the agent differs between those cases).
-pub fn find_callers(
-    target: &str,
-    scope: &Path,
-    bloom: &crate::index::bloom::BloomFilterCache,
-    glob: Option<&str>,
-) -> Result<(Vec<CallerMatch>, bool), TilthError> {
-    let matches: Mutex<Vec<CallerMatch>> = Mutex::new(Vec::new());
-    let found_count = AtomicUsize::new(0);
-    let target_seen = AtomicBool::new(false);
+/// Scan `scope` for the literal `target` byte sequence. Used by the
+/// single-symbol `search_callers_expanded` path to distinguish "typo,
+/// doesn't exist" from "real symbol with no direct callers" (indirect
+/// dispatch, dead code, framework registration, …) when the caller walk
+/// returned zero matches. mmap is lazy, so the scan only pages in regions
+/// that contain the needle prefix.
+fn target_seen_in_scope(target: &str, scope: &Path, glob: Option<&str>) -> bool {
+    let Ok(walker) = super::walker(scope, glob) else {
+        return false;
+    };
     let needle = target.as_bytes();
-
-    let walker = super::walker(scope, glob)?;
+    let seen = AtomicBool::new(false);
 
     walker.run(|| {
-        let matches = &matches;
-        let found_count = &found_count;
-        let target_seen = &target_seen;
-
+        let seen = &seen;
         Box::new(move |entry| {
-            // Early termination: enough callers found
-            if found_count.load(Ordering::Relaxed) >= EARLY_QUIT_THRESHOLD {
+            if seen.load(Ordering::Relaxed) {
                 return ignore::WalkState::Quit;
             }
-
             let Ok(entry) = entry else {
                 return ignore::WalkState::Continue;
             };
-
             if !entry.file_type().is_some_and(|ft| ft.is_file()) {
                 return ignore::WalkState::Continue;
             }
-
             let path = entry.path();
-
-            // Single metadata call: check size and capture mtime together
-            let (file_len, mtime) = match std::fs::metadata(path) {
-                Ok(meta) => (
-                    meta.len(),
-                    meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH),
-                ),
-                Err(_) => return ignore::WalkState::Continue,
-            };
-            if file_len > 500_000 {
-                // Oversized files are not parsed, but we still need to know
-                // whether the literal target appears anywhere in scope so the
-                // "no callers" message can distinguish "real symbol, indirect
-                // dispatch" from "typo, doesn't exist." mmap is lazy, so the
-                // scan only touches pages that contain the needle prefix.
-                if !target_seen.load(Ordering::Relaxed) {
-                    if let Ok(file) = std::fs::File::open(path) {
-                        if let Ok(mmap) = unsafe { memmap2::Mmap::map(&file) } {
-                            if memchr::memmem::find(&mmap, needle).is_some() {
-                                target_seen.store(true, Ordering::Relaxed);
-                            }
-                        }
-                    }
-                }
-                return ignore::WalkState::Continue;
-            }
-
-            // Single read: read file once, use buffer for both check and parse
-            let Ok(content) = fs::read_to_string(path) else {
+            let Ok(file) = std::fs::File::open(path) else {
                 return ignore::WalkState::Continue;
             };
-
-            // Bloom pre-filter: skip if target is definitely not in file
-            if !bloom.contains(path, mtime, &content, target) {
-                return ignore::WalkState::Continue;
-            }
-
-            // Fast byte check via memchr::memmem (SIMD) — skip files without the symbol
-            if memchr::memmem::find(content.as_bytes(), needle).is_none() {
-                return ignore::WalkState::Continue;
-            }
-
-            // Symbol literal exists in this file (whether or not it's a call site).
-            target_seen.store(true, Ordering::Relaxed);
-
-            // Only process files with tree-sitter grammars
-            let file_type = detect_file_type(path);
-            let FileType::Code(lang) = file_type else {
+            let Ok(mmap) = (unsafe { memmap2::Mmap::map(&file) }) else {
                 return ignore::WalkState::Continue;
             };
-
-            let Some(ts_lang) = outline_language(lang) else {
-                return ignore::WalkState::Continue;
-            };
-
-            let file_callers = find_callers_treesitter(path, target, &ts_lang, &content, lang);
-
-            if !file_callers.is_empty() {
-                found_count.fetch_add(file_callers.len(), Ordering::Relaxed);
-                let mut all = matches
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                all.extend(file_callers);
+            if memchr::memmem::find(&mmap, needle).is_some() {
+                seen.store(true, Ordering::Relaxed);
+                return ignore::WalkState::Quit;
             }
-
             ignore::WalkState::Continue
         })
     });
 
-    let callers = matches
-        .into_inner()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    // Relaxed is sufficient: walker.run() uses thread::scope under the hood,
-    // and the join at the end of run() establishes happens-before between
-    // every worker store and this load. No Acquire/Release pair needed.
-    Ok((callers, target_seen.load(Ordering::Relaxed)))
-}
-
-/// Tree-sitter call site detection.
-fn find_callers_treesitter(
-    path: &Path,
-    target: &str,
-    ts_lang: &tree_sitter::Language,
-    content: &str,
-    lang: crate::types::Lang,
-) -> Vec<CallerMatch> {
-    // Get the query string for this language
-    let Some(query_str) = super::callees::callee_query_str(lang) else {
-        return Vec::new();
-    };
-
-    let mut parser = tree_sitter::Parser::new();
-    if parser.set_language(ts_lang).is_err() {
-        return Vec::new();
-    }
-
-    let Some(tree) = parser.parse(content, None) else {
-        return Vec::new();
-    };
-
-    let content_bytes = content.as_bytes();
-    let lines: Vec<&str> = content.lines().collect();
-
-    // One Arc per file — all call sites share the same allocation.
-    let shared_content: Arc<String> = Arc::new(content.to_string());
-
-    let Some(callers) = super::callees::with_callee_query(ts_lang, query_str, |query| {
-        let Some(callee_idx) = query.capture_index_for_name("callee") else {
-            return Vec::new();
-        };
-
-        let mut cursor = tree_sitter::QueryCursor::new();
-        let mut matches = cursor.matches(query, tree.root_node(), content_bytes);
-        let mut callers = Vec::new();
-
-        while let Some(m) = matches.next() {
-            for cap in m.captures {
-                if cap.index != callee_idx {
-                    continue;
-                }
-
-                // Check if the captured text matches our target symbol
-                let Ok(text) = cap.node.utf8_text(content_bytes) else {
-                    continue;
-                };
-
-                if text != target {
-                    continue;
-                }
-
-                // Found a call site! Now walk up to find the calling function
-                let line = cap.node.start_position().row as u32 + 1;
-
-                // Get the call text (the whole call expression, not just the callee)
-                let call_node = cap.node.parent().unwrap_or(cap.node);
-                let same_line = call_node.start_position().row == call_node.end_position().row;
-                let call_text: String = if same_line {
-                    let row = call_node.start_position().row;
-                    if row < lines.len() {
-                        lines[row].trim().to_string()
-                    } else {
-                        text.to_string()
-                    }
-                } else {
-                    text.to_string()
-                };
-
-                // Walk up the tree to find the enclosing function
-                let (calling_function, caller_range) =
-                    find_enclosing_function(cap.node, &lines, lang);
-
-                callers.push(CallerMatch {
-                    path: path.to_path_buf(),
-                    line,
-                    calling_function,
-                    call_text,
-                    caller_range,
-                    content: Arc::clone(&shared_content),
-                });
-            }
-        }
-
-        callers
-    }) else {
-        return Vec::new();
-    };
-
-    callers
+    seen.load(Ordering::Relaxed)
 }
 
 /// Find all call sites of any symbol in `targets` across the codebase using a single walk.
@@ -532,9 +365,12 @@ pub fn search_callers_expanded(
     context: Option<&Path>,
     glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let (callers, target_seen) = find_callers(target, scope, bloom, glob)?;
+    let single: HashSet<String> = std::iter::once(target.to_string()).collect();
+    let raw = find_callers_batch(&single, scope, bloom, glob)?;
+    let callers: Vec<CallerMatch> = raw.into_iter().map(|(_, m)| m).collect();
 
     if callers.is_empty() {
+        let target_seen = target_seen_in_scope(target, scope, glob);
         return Ok(no_callers_message(target, scope, target_seen, glob));
     }
 

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -6,7 +6,6 @@ use std::fmt::Write as _;
 use std::fs;
 use std::path::{Path, PathBuf};
 
-use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
 use crate::lang::outline::{extract_import_source, get_outline_entries};
@@ -56,7 +55,6 @@ pub struct Dependent {
 pub fn analyze_deps(
     path: &Path,
     scope: &Path,
-    cache: &OutlineCache,
     bloom: &crate::index::bloom::BloomFilterCache,
 ) -> Result<DepsResult, TilthError> {
     // Canonicalize for reliable path comparison (callers return absolute paths).
@@ -86,7 +84,6 @@ pub fn analyze_deps(
     // ── Phase 1: Extract exported symbols ────────────────────────────────────
 
     let entries = get_outline_entries(&content, lang);
-    let _ = cache; // available for future caching
 
     let mut all_names: Vec<String> = Vec::new();
     for entry in &entries {
@@ -119,7 +116,7 @@ pub fn analyze_deps(
 
     // Local deps via callee resolution
     let callee_names = extract_callee_names(&content, lang, None);
-    let resolved = resolve_callees(&callee_names, path, &content, cache, bloom);
+    let resolved = resolve_callees(&callee_names, path, &content, bloom);
 
     // Group resolved callees by file
     let mut local_by_file: HashMap<PathBuf, Vec<String>> = HashMap::new();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1417,9 +1417,11 @@ mod tests {
     fn callers_search_glob_restricts_results() {
         let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
         let bloom = crate::index::bloom::BloomFilterCache::new();
-        let (rs_callers, _) =
-            callers::find_callers("walker", &scope, &bloom, Some("*.rs")).expect("callers failed");
-        let (toml_callers, _) = callers::find_callers("walker", &scope, &bloom, Some("*.toml"))
+        let single: std::collections::HashSet<String> =
+            std::iter::once("walker".to_string()).collect();
+        let rs_callers = callers::find_callers_batch(&single, &scope, &bloom, Some("*.rs"))
+            .expect("callers failed");
+        let toml_callers = callers::find_callers_batch(&single, &scope, &bloom, Some("*.toml"))
             .expect("callers toml failed");
 
         assert!(
@@ -1430,7 +1432,7 @@ mod tests {
             toml_callers.is_empty(),
             "*.toml should not find callers of 'walker'"
         );
-        for c in &rs_callers {
+        for (_, c) in &rs_callers {
             assert_eq!(
                 c.path.extension().and_then(|e| e.to_str()),
                 Some("rs"),

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -305,11 +305,7 @@ pub fn format_raw_result(
     format_search_result(result, cache, None, &bloom, 0)
 }
 
-pub fn search_glob(
-    pattern: &str,
-    scope: &Path,
-    _cache: &OutlineCache,
-) -> Result<String, TilthError> {
+pub fn search_glob(pattern: &str, scope: &Path) -> Result<String, TilthError> {
     let result = glob::search(pattern, scope)?;
     format_glob_result(&result, scope)
 }
@@ -591,7 +587,6 @@ fn format_single_match(
                                     &callee_names,
                                     &m.path,
                                     &content,
-                                    cache,
                                     bloom,
                                     2,
                                     15,


### PR DESCRIPTION
Continuing the @choongng dev branch pull (after #75). Stacks on top of #75 — merge that first, then this rebases automatically onto main.

Thanks @choongng for the substantial refactor work — this PR pulls 4 of 5 originally-planned Tier 3 commits. **Skipping** `e3c4907` (extract bloom_walk/callee_query/scope, +658/-555 LOC) — it conflicts heavily with main's `src/search/{callers,mod}.rs` because it presumes the post-2d5365b shape diverges further than I can confidently resolve manually. Will land separately once the markdown bundle (PR-D, upcoming) settles the surrounding code.

**Skipping** `f5acfe1` (overview WalkBuilder migration) — verified by audit that it imports `apply_ignore_settings` from `7e4d963` (which is held pending UB fix on `std::env::set_var`). Will land with PR-E.

## Commits (Choong Ng as Author)

| SHA on dev | Title |
|---|---|
| `2d5365b` | search: collapse single-symbol caller path into find_callers_batch |
| `cb2d875` | search: drop unused cache/session params from helpers |
| `f703af2` | overview: anchor hot-files × count with an inline legend |
| `50a6e93` | overview: replace hand-rolled manifest parsers with serde |

## Our additions

- **`51da783`** — clippy + fmt drift cleanup (1 unused import in callers.rs, 2 fmt re-wraps from cache parameter removal). Not caught on choongng/dev because their toolchain is older.

## Behavior notes (verified by audit)

- **`2d5365b`** is conditionally behavior-preserving:
  - `EARLY_QUIT_THRESHOLD` 30→50 — single-symbol caller walks now collect more candidates before stopping, expanding the post-rank pool. `MAX_MATCHES = 10` still caps displayed output.
  - No-callers branch is bounded — `target_seen_in_scope` early-quits via `WalkState::Quit` on first hit. Only the genuine "doesn't exist" case walks full scope, and that's strictly cheaper than the old single-path's full walk.
  - Concurrency: no new races. `target_seen_in_scope` runs only after `find_callers_batch` returns empty, so doesn't race with the caller walk.

- **`cb2d875`** drops `cache: &OutlineCache` from public APIs `tilth::run_callers`, `tilth::run_deps`, and several MCP helper signatures. Pre-1.0; we have no external library consumers.

- **`50a6e93`** swaps hand-rolled TOML/YAML/JSON manifest parsing for serde. Improves PEP 621 handling (extracts `[project]` deps from pyproject.toml).

## Test plan

- [x] `cargo test --lib` — 267 passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Author preserved on all 4 cherry-picks
- [x] Manual smoke: `tilth foo --callers --scope src/` (single-symbol path)
- [x] Manual smoke: `tilth --map .` (overview legend visible)

## Follow-ups

- `e3c4907` reorg — separate PR after PR-D markdown lands
- `f5acfe1` WalkBuilder — depends on `7e4d963` (PR-E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)