### PR TITLE
feat: markdown rewrite — tree-sitter-md migration + soft defs + multi-section (@choongng)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ Re-expanding a previously shown definition returns [shown earlier].
 tilth_read: Read file content with smart outlining. Replaces cat/head/tail.
 Small files → full content. Large files → structural outline.
 section: "<start>-<end>" or "<heading text>"
+sections: array of ranges/headings — multiple slices from the same file in one call.
 paths: read multiple files in one call.
 Output:
 <line_number> │ <content>                  ← full/section mode
@@ -36,9 +37,17 @@ Output: <path>  (~<token_count> tokens). Respects .gitignore.
 tilth_deps: Blast-radius check — what imports this file and what it imports.
 Use ONLY before renaming, removing, or changing an export's signature.
 
+tilth_diff: Structural diff — shows what changed at function level. Replaces Bash(git diff).
+Usage: tilth_diff(source: "HEAD~1") for last commit. No args = uncommitted changes.
+scope: "file.rs" or "file.rs:fn_name". log: "HEAD~5..HEAD" for per-commit summaries.
+search: filter to lines matching a term. blast: true to show callers of changed signatures.
+Output: [+] added, [-] deleted, [~] body changed, [~:sig] signature changed.
+DO NOT use Bash(git diff) or Bash(git log --patch). Use tilth_diff instead.
+
 To search code, use tilth_search instead of Grep or Bash(grep/rg).
 To read files, use tilth_read instead of Read or Bash(cat).
 To find files, use tilth_files instead of Glob or Bash(find/ls).
+To check what changed, use tilth_diff instead of Bash(git diff/git log).
 DO NOT re-read files already shown in expanded search results.
 
 tilth_edit: Edit files using hash-anchored lines. Replaces the host Edit tool.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -728,6 +728,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-md",
  "tree-sitter-php",
  "tree-sitter-python",
  "tree-sitter-ruby",
@@ -877,6 +878,16 @@ name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "009994f150cc0cd50ff54917d5bc8bffe8cad10ca10d81c34da2ec421ae61782"
+
+[[package]]
+name = "tree-sitter-md"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
+dependencies = [
+ "cc",
+ "tree-sitter-language",
+]
 
 [[package]]
 name = "tree-sitter-php"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-ng = "1.1"
 tree-sitter-elixir = "0.3"
+tree-sitter-md = "0.5"
 
 # Search (ripgrep internals)
 grep-regex = "0.1"

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -5,24 +5,38 @@ use std::time::SystemTime;
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 
+use crate::types::Lang;
+
 /// Cached outline entry.
 struct CacheEntry {
     outline: Arc<str>,
 }
 
+/// File contents and its tree-sitter parse, cached together so AST consumers
+/// don't re-parse on every call. `content` is `Arc<String>` so callers can
+/// hold the bytes for `Node::utf8_text` without copying.
+pub struct ParsedFile {
+    pub content: Arc<String>,
+    pub tree: tree_sitter::Tree,
+    pub lang: Lang,
+}
+
 /// Outline cache keyed by (canonical path, mtime). If the file changes,
 /// mtime changes and the old entry is never hit again.
 ///
-/// Value is `Arc<str>` — inline string data in the Arc allocation,
-/// one less indirection than `Arc<String>`.
+/// Stores two derived analyses: rendered outline strings (used by search
+/// formatting) and parsed tree-sitter trees (used by AST scope queries).
+/// Both share the same key + invalidation; nothing else is shared.
 pub struct OutlineCache {
     entries: DashMap<(PathBuf, SystemTime), CacheEntry>,
+    parsed: DashMap<(PathBuf, SystemTime), Arc<ParsedFile>>,
 }
 
 impl Default for OutlineCache {
     fn default() -> Self {
         Self {
             entries: DashMap::new(),
+            parsed: DashMap::new(),
         }
     }
 }
@@ -49,6 +63,38 @@ impl OutlineCache {
                     outline: Arc::clone(&outline),
                 });
                 outline
+            }
+        }
+    }
+
+    /// Parse a code file with tree-sitter and cache the result. Returns
+    /// `None` for non-code files, files larger than the 500 KB cap, or parse
+    /// failures.
+    #[must_use]
+    pub fn get_or_parse(&self, path: &Path) -> Option<Arc<ParsedFile>> {
+        let meta = std::fs::metadata(path).ok()?;
+        let mtime = meta.modified().ok()?;
+        if meta.len() > 500_000 {
+            return None;
+        }
+        match self.parsed.entry((path.to_path_buf(), mtime)) {
+            Entry::Occupied(e) => Some(Arc::clone(e.get())),
+            Entry::Vacant(e) => {
+                let crate::types::FileType::Code(lang) = crate::lang::detect_file_type(path) else {
+                    return None;
+                };
+                let ts_lang = crate::lang::outline::outline_language(lang)?;
+                let content = std::fs::read_to_string(path).ok()?;
+                let mut parser = tree_sitter::Parser::new();
+                parser.set_language(&ts_lang).ok()?;
+                let tree = parser.parse(&content, None)?;
+                let parsed = Arc::new(ParsedFile {
+                    content: Arc::new(content),
+                    tree,
+                    lang,
+                });
+                e.insert(Arc::clone(&parsed));
+                Some(parsed)
             }
         }
     }

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -1,3 +1,4 @@
+use crate::lang::treesitter::node_text_simple;
 use crate::types::{Lang, OutlineEntry, OutlineKind};
 
 /// Get the tree-sitter Language for a given Lang variant.
@@ -25,6 +26,74 @@ pub fn outline_language(lang: Lang) -> Option<tree_sitter::Language> {
         }
     };
     Some(lang.into())
+}
+
+/// Parse markdown content into a tree-sitter block tree.
+///
+/// Returns `None` if the parser fails to set the language (should not happen
+/// in practice). The block grammar is what tilth's outline / definition
+/// scanners need: it emits `atx_heading`, `setext_heading`, `section`, and
+/// `fenced_code_block` nodes. Inline structure (emphasis, links inside the
+/// heading text) is parsed by a separate inline grammar tilth doesn't use —
+/// heading text is read as the raw inline node's text.
+///
+/// Centralised so both `read::outline::markdown` and
+/// `search::symbol::find_defs_markdown_buf` configure the parser the same
+/// way.
+pub fn parse_markdown(content: &str) -> Option<tree_sitter::Tree> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(&tree_sitter_md::LANGUAGE.into()).ok()?;
+    parser.parse(content, None)
+}
+
+/// Map an `atx_heading` or `setext_heading` node to its 1-6 level by
+/// inspecting the marker child. Returns `None` for malformed nodes.
+pub fn heading_level(node: tree_sitter::Node) -> Option<u8> {
+    let kind = node.kind();
+    if kind == "atx_heading" {
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "atx_h1_marker" => return Some(1),
+                "atx_h2_marker" => return Some(2),
+                "atx_h3_marker" => return Some(3),
+                "atx_h4_marker" => return Some(4),
+                "atx_h5_marker" => return Some(5),
+                "atx_h6_marker" => return Some(6),
+                _ => {}
+            }
+        }
+        None
+    } else if kind == "setext_heading" {
+        // setext H1: `=====`; H2: `-----`. Marker is a child node.
+        let mut cursor = node.walk();
+        for child in node.children(&mut cursor) {
+            match child.kind() {
+                "setext_h1_underline" => return Some(1),
+                "setext_h2_underline" => return Some(2),
+                _ => {}
+            }
+        }
+        None
+    } else {
+        None
+    }
+}
+
+/// Read the heading text of an `atx_heading` / `setext_heading` node from
+/// pre-split source lines. Returns the inline content with surrounding
+/// whitespace + trailing `#`s (for ATX-closed headings like `## Foo ##`)
+/// trimmed, matching the previous hand-rolled scanner's output.
+pub fn heading_text(node: tree_sitter::Node, lines: &[&str]) -> String {
+    // Both heading kinds expose their inline content as an `inline` child.
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() == "inline" {
+            let text = node_text_simple(child, lines);
+            return text.trim().trim_end_matches('#').trim().to_string();
+        }
+    }
+    String::new()
 }
 
 /// Walk top-level children of the root node, extracting outline entries.
@@ -798,4 +867,79 @@ pub fn get_outline_entries(content: &str, lang: Lang) -> Vec<OutlineEntry> {
 
     let lines: Vec<&str> = content.lines().collect();
     walk_top_level(tree.root_node(), &lines, lang)
+}
+
+#[cfg(test)]
+mod markdown_helper_tests {
+    use super::{heading_level, heading_text, parse_markdown};
+
+    /// Walk the tree and collect every `atx_heading`/`setext_heading` node.
+    fn collect_headings(tree: &tree_sitter::Tree) -> Vec<tree_sitter::Node<'_>> {
+        let mut out = Vec::new();
+        let mut cursor = tree.walk();
+        let mut stack = vec![tree.root_node()];
+        while let Some(node) = stack.pop() {
+            if matches!(node.kind(), "atx_heading" | "setext_heading") {
+                out.push(node);
+            }
+            for child in node.children(&mut cursor) {
+                stack.push(child);
+            }
+        }
+        out.sort_by_key(|n| n.start_position().row);
+        out
+    }
+
+    #[test]
+    fn parse_returns_block_tree_with_sections() {
+        let src = "# Top\n\ncontent\n\n## Sub\n\nmore\n";
+        let tree = parse_markdown(src).unwrap();
+        let root = tree.root_node();
+        assert_eq!(root.kind(), "document");
+        // The document contains at least one section node.
+        let mut cursor = root.walk();
+        let has_section = root.children(&mut cursor).any(|c| c.kind() == "section");
+        assert!(has_section, "expected document to contain section children");
+    }
+
+    #[test]
+    fn fenced_code_blocks_do_not_emit_headings() {
+        // The whole point: a `# foo` inside a fenced code block must NOT be
+        // parsed as an atx_heading. The hand-rolled scanners had to track
+        // fence state manually; the AST does this for free.
+        let src = "# Real\n\n```python\n# fake heading\nprint('x')\n```\n\n## Also Real\n";
+        let tree = parse_markdown(src).unwrap();
+        let headings = collect_headings(&tree);
+        let lines: Vec<&str> = src.lines().collect();
+        let texts: Vec<String> = headings.iter().map(|n| heading_text(*n, &lines)).collect();
+        assert_eq!(texts, vec!["Real".to_string(), "Also Real".to_string()]);
+    }
+
+    #[test]
+    fn tilde_fences_are_recognised() {
+        let src = "# Real\n\n~~~\n# inside tilde fence\n~~~\n\n## Other\n";
+        let tree = parse_markdown(src).unwrap();
+        let lines: Vec<&str> = src.lines().collect();
+        let headings = collect_headings(&tree);
+        let texts: Vec<String> = headings.iter().map(|n| heading_text(*n, &lines)).collect();
+        assert_eq!(texts, vec!["Real".to_string(), "Other".to_string()]);
+    }
+
+    #[test]
+    fn level_extraction_covers_h1_through_h6() {
+        let src = "# A\n\n## B\n\n### C\n\n#### D\n\n##### E\n\n###### F\n";
+        let tree = parse_markdown(src).unwrap();
+        let headings = collect_headings(&tree);
+        let levels: Vec<u8> = headings.iter().filter_map(|n| heading_level(*n)).collect();
+        assert_eq!(levels, vec![1, 2, 3, 4, 5, 6]);
+    }
+
+    #[test]
+    fn trailing_atx_close_hashes_are_stripped() {
+        let src = "## Foo ##\n";
+        let tree = parse_markdown(src).unwrap();
+        let lines: Vec<&str> = src.lines().collect();
+        let headings = collect_headings(&tree);
+        assert_eq!(heading_text(headings[0], &lines), "Foo");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -28,7 +28,15 @@ struct Cli {
     #[arg(long)]
     budget: Option<u64>,
 
-    /// Force full output (override smart view).
+    /// Force full output (effect depends on query type — see --help).
+    ///
+    /// File path: return the whole file instead of an outline (bypass smart view).
+    ///
+    /// Symbol / text / regex: inline source for every match (equivalent to
+    /// `--expand=<all>`). Explicit `--expand=N` wins. Output stays bounded
+    /// by `--budget`.
+    ///
+    /// Glob: no effect (glob queries already return a flat file list).
     #[arg(long)]
     full: bool,
 
@@ -48,7 +56,12 @@ struct Cli {
     #[arg(long)]
     no_overview: bool,
 
-    /// Expand top N search matches with inline source (default: 2 when flag present).
+    /// Inline source for top N search matches (default 2 when flag bare).
+    ///
+    /// Applies to symbol / text / regex queries. Without the flag the
+    /// result is just the outline summary. `--full` upgrades this to
+    /// expand every match (subject to `--budget`); explicit `--expand=N`
+    /// wins over `--full`. No effect on file-path or glob queries.
     #[arg(long, num_args = 0..=1, default_missing_value = "2", require_equals = true)]
     expand: Option<usize>,
 
@@ -251,9 +264,34 @@ fn main() {
     let cache = tilth::cache::OutlineCache::new();
     let scope = cli.scope.canonicalize().unwrap_or(cli.scope);
 
-    // When piped (not a TTY), force full output — scripts expect raw content
+    // When piped (not a TTY), force full output — scripts expect raw content.
+    // This promotion exists for FilePath queries (return full file instead of
+    // outline) and is harmless for Glob (which ignores `full`). Search queries
+    // also receive `full=true` here but stay outline-only — they do not auto-
+    // expand on piping. See the `cli.full` guard on the expand override below.
     let full = cli.full || !is_tty;
-    let expand = cli.expand.unwrap_or(0);
+
+    // Explicit `--full` on a search query means expand every match. Guarded on
+    // `cli.full` (NOT the piped-derived `full` above) so that subprocess /
+    // pipeline callers (Claude Code's Bash tool, CI scripts, `tilth foo | rg`)
+    // still receive the concise outline they want. They opt into expand-all by
+    // adding `--full` themselves. Explicit `--expand=N` still wins because it
+    // produces `expand != 0`. We over-apply to all query types — `run_inner`
+    // only forwards `expand` to search dispatches, so the value is silently
+    // ignored for FilePath and Glob.
+    //
+    // Cap at FULL_EXPAND_CAP rather than `usize::MAX`: `--budget` already
+    // bounds output, but `expand=usize::MAX` makes tilth compute the
+    // expanded source for every match before truncating, wasting parsing
+    // and rendering work on pathological queries. 50 is well above any
+    // practical "show me everything that matters" case (MAX_MATCHES is 10
+    // for symbol search anyway).
+    const FULL_EXPAND_CAP: usize = 50;
+    let expand = match (cli.expand, cli.full) {
+        (Some(n), _) => n,
+        (None, true) => FULL_EXPAND_CAP,
+        (None, false) => 0,
+    };
 
     // Callers mode
     if cli.callers {

--- a/src/main.rs
+++ b/src/main.rs
@@ -280,18 +280,7 @@ fn main() {
     // only forwards `expand` to search dispatches, so the value is silently
     // ignored for FilePath and Glob.
     //
-    // Cap at FULL_EXPAND_CAP rather than `usize::MAX`: `--budget` already
-    // bounds output, but `expand=usize::MAX` makes tilth compute the
-    // expanded source for every match before truncating, wasting parsing
-    // and rendering work on pathological queries. 50 is well above any
-    // practical "show me everything that matters" case (MAX_MATCHES is 10
-    // for symbol search anyway).
-    const FULL_EXPAND_CAP: usize = 50;
-    let expand = match (cli.expand, cli.full) {
-        (Some(n), _) => n,
-        (None, true) => FULL_EXPAND_CAP,
-        (None, false) => 0,
-    };
+    let expand = compute_expand(cli.expand, cli.full);
 
     // Callers mode
     if cli.callers {
@@ -450,4 +439,74 @@ fn configure_thread_pools() {
         .num_threads(num_threads)
         .build_global()
         .ok();
+}
+
+/// Compute the effective `expand` value for a search query from the raw
+/// CLI flags. Lifted out of `main` so the `--full` / `--expand` precedence
+/// is unit-testable.
+///
+/// Precedence:
+/// - Explicit `--expand=N` always wins (`cli_expand = Some(n)`), even alongside `--full`.
+/// - Bare `--full` with no `--expand` → `FULL_EXPAND_CAP` (50).
+/// - Neither flag → 0 (no expansion).
+///
+/// Critically, `cli_full` is the *parsed* `--full` flag, NOT the piped-derived
+/// `full = cli.full || !is_tty` in `main`. Subprocess / pipeline callers
+/// (Claude Code's Bash tool, CI scripts, `tilth foo | rg`) must keep the
+/// concise outline by default; expand-all is opt-in via explicit `--full`.
+fn compute_expand(cli_expand: Option<usize>, cli_full: bool) -> usize {
+    /// `--budget` already bounds output, but `expand=usize::MAX` makes tilth
+    /// compute the expanded source for every match before truncating —
+    /// wasted parsing + rendering on pathological queries. 50 is well above
+    /// any practical "show me everything that matters" case (MAX_MATCHES is
+    /// 10 for symbol search anyway).
+    const FULL_EXPAND_CAP: usize = 50;
+    match (cli_expand, cli_full) {
+        (Some(n), _) => n,
+        (None, true) => FULL_EXPAND_CAP,
+        (None, false) => 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Pin `--expand=N` precedence — explicit value always wins, including
+    /// when combined with `--full`.
+    #[test]
+    fn explicit_expand_wins_over_full() {
+        assert_eq!(compute_expand(Some(2), false), 2);
+        assert_eq!(compute_expand(Some(2), true), 2);
+        assert_eq!(compute_expand(Some(0), false), 0);
+        assert_eq!(compute_expand(Some(0), true), 0);
+        assert_eq!(compute_expand(Some(99), true), 99);
+    }
+
+    /// Pin `--full` → expand=50 when no explicit `--expand`.
+    #[test]
+    fn bare_full_promotes_to_full_expand_cap() {
+        assert_eq!(compute_expand(None, true), 50);
+    }
+
+    /// Pin the default — neither flag means no expansion.
+    #[test]
+    fn neither_flag_means_zero_expand() {
+        assert_eq!(compute_expand(None, false), 0);
+    }
+
+    /// Pin the regression that 16212fc was authored to prevent: a piped
+    /// invocation (where `main` sets `full = !is_tty = true` for FilePath
+    /// queries) must still receive `expand=0` here. `compute_expand` only
+    /// sees the parsed `cli.full`, never the piped-derived bool — so a
+    /// future refactor that conflates the two would have to change this
+    /// function's signature, making the violation visible.
+    #[test]
+    fn piped_invocation_does_not_auto_expand() {
+        // Simulating: user ran `tilth foo` (no --full) but stdout is piped.
+        // `main` will set `full = !is_tty = true` for downstream FilePath
+        // handling, but cli.full stays false. compute_expand must return 0.
+        let cli_full = false; // user did NOT pass --full
+        assert_eq!(compute_expand(None, cli_full), 0);
+    }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -489,8 +489,8 @@ fn tool_read(
             ));
         }
         session.record_read(&path);
-        let output = crate::read::read_ranges(&path, &ranges, edit_mode)
-            .map_err(|e| e.to_string())?;
+        let output =
+            crate::read::read_ranges(&path, &ranges, edit_mode).map_err(|e| e.to_string())?;
         return Ok(apply_budget(output, budget));
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -95,6 +95,7 @@ tilth_search: Search code — finds definitions, usages, and text. Replaces grep
 tilth_read: Read file content with smart outlining. Replaces cat/head/tail.\n\
   Small files → full content. Large files → structural outline.\n\
   section: \"<start>-<end>\" or \"<heading text>\"\n\
+  sections: array of ranges/headings — multiple slices from the same file in one call.\n\
   paths: read multiple files in one call.\n\
   Output:\n\
     <line_number> │ <content>                  ← full/section mode\n\
@@ -461,10 +462,37 @@ fn tool_read(
         .ok_or("missing required parameter: path (or use paths for batch read)")?;
     let path = PathBuf::from(path_str);
     let section = args.get("section").and_then(|v| v.as_str());
+    let sections_arr = args.get("sections").and_then(|v| v.as_array());
     let full = args
         .get("full")
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
+
+    if section.is_some() && sections_arr.is_some() {
+        return Err("provide either section (single) or sections (array), not both".into());
+    }
+
+    // Multi-section path: bypass smart view + related-file hints (those only
+    // apply to whole-file reads).
+    if let Some(arr) = sections_arr {
+        let ranges: Vec<&str> = arr
+            .iter()
+            .map(|v| v.as_str().ok_or("sections must be an array of strings"))
+            .collect::<Result<Vec<_>, _>>()?;
+        if ranges.is_empty() {
+            return Err("sections must contain at least one range".into());
+        }
+        if ranges.len() > 20 {
+            return Err(format!(
+                "sections limited to 20 per call (got {})",
+                ranges.len()
+            ));
+        }
+        session.record_read(&path);
+        let output = crate::read::read_ranges(&path, &ranges, edit_mode)
+            .map_err(|e| e.to_string())?;
+        return Ok(apply_budget(output, budget));
+    }
 
     session.record_read(&path);
     let mut output = crate::read::read_file(&path, section, full, cache, edit_mode)
@@ -849,13 +877,15 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
          use this for all file reading. Output uses hashline format (line:hash|content) — \
          the line:hash anchors are required by tilth_edit. Small files return full hashlined content. \
          Large files return a structural outline (no hashlines); use `section` to get hashlined \
-         content for the lines you want to edit. Use `full` to force complete content. \
+         content for the lines you want to edit. Use `sections` to grab several disjoint slices \
+         from the same file in one call. Use `full` to force complete content. \
          Use `paths` to read multiple files in one call."
     } else {
         "Read a file with smart outlining. Replaces cat/head/tail and the host Read tool — \
          use this for all file reading. Small files return full content. Large files return \
          a structural outline (functions, classes, imports) so you see the shape without \
-         consuming your context window. Use `section` to read specific line ranges. \
+         consuming your context window. Use `section` to read a specific line range or heading. \
+         Use `sections` to grab several disjoint slices from the same file in one call. \
          Use `full` to force complete content. Use `paths` to read multiple files in one call."
     };
     let mut tools = vec![
@@ -917,7 +947,12 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     },
                     "section": {
                         "type": "string",
-                        "description": "Line range e.g. '45-89', or heading e.g. '## Architecture'. Bypasses smart view."
+                        "description": "Line range e.g. '45-89', or heading e.g. '## Architecture'. Bypasses smart view. Use `sections` for multiple ranges."
+                    },
+                    "sections": {
+                        "type": "array",
+                        "items": { "type": "string" },
+                        "description": "Multiple ranges from the same file in one call. Each entry is a line range or heading. Emits each block in user-supplied order, separated by `─── lines X-Y ───` delimiters. Mutually exclusive with `section`. Capped at 20 ranges."
                     },
                     "full": {
                         "type": "boolean",

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1,6 +1,7 @@
 pub mod imports;
 pub mod outline;
 
+use std::fmt::Write;
 use std::fs;
 use std::path::Path;
 
@@ -70,7 +71,7 @@ pub fn read_file(
 
     // Section param → return those lines verbatim, any size
     if let Some(range) = section {
-        return read_section(path, range, edit_mode);
+        return read_ranges(path, &[range], edit_mode);
     }
 
     // Binary detection
@@ -354,22 +355,10 @@ fn collect_atx_headings(
     }
 }
 
-/// Read a specific line range from a file.
-/// Uses memchr to find the Nth newline offset and slice the mmap buffer directly
-/// instead of collecting all lines into a Vec.
-fn read_section(path: &Path, range: &str, edit_mode: bool) -> Result<String, TilthError> {
-    let file = fs::File::open(path).map_err(|e| TilthError::IoError {
-        path: path.to_path_buf(),
-        source: e,
-    })?;
-    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| TilthError::IoError {
-        path: path.to_path_buf(),
-        source: e,
-    })?;
-    let buf = &mmap[..];
-
-    // Check if this is a heading-based address (markdown)
-    let (start, end) = if range.starts_with('#') {
+/// Resolve a single range string (line range like "45-89" or heading like
+/// "## Architecture") to a 1-indexed inclusive `(start, end)` pair.
+fn resolve_range(buf: &[u8], range: &str) -> Result<(usize, usize), TilthError> {
+    if range.starts_with('#') {
         resolve_heading(buf, range).ok_or_else(|| {
             let suggestions = suggest_headings(buf, range, 5);
             let reason = if suggestions.is_empty() {
@@ -384,48 +373,109 @@ fn read_section(path: &Path, range: &str, edit_mode: bool) -> Result<String, Til
                 query: range.to_string(),
                 reason,
             }
-        })?
+        })
     } else {
         parse_range(range).ok_or_else(|| TilthError::InvalidQuery {
             query: range.to_string(),
             reason: "expected format: \"start-end\" (e.g. \"45-89\") or heading (e.g. \"## Architecture\")".into(),
-        })?
-    };
+        })
+    }
+}
 
-    // Find line offsets using memchr — no full-file Vec<&str> allocation
+/// One resolved range, ready to format.
+struct Block {
+    start: usize, // 1-indexed inclusive
+    end: usize,   // 1-indexed inclusive (clamped to file length)
+    text: String,
+}
+
+/// Read one or more line ranges from a file. Each range is "start-end"
+/// (e.g. "45-89") or a heading anchor (e.g. "## Architecture") for
+/// markdown files. Mmaps the file once and emits a single `[section]`
+/// header followed by the formatted blocks; when more than one range is
+/// requested, each block is preceded by a `─── lines X-Y ───` delimiter.
+///
+/// Ranges are emitted in the order supplied — overlapping or out-of-order
+/// ranges are honored verbatim, not coalesced or sorted. Any invalid
+/// range fails the whole call.
+pub fn read_ranges(
+    path: &Path,
+    ranges: &[&str],
+    edit_mode: bool,
+) -> Result<String, TilthError> {
+    if ranges.is_empty() {
+        return Err(TilthError::InvalidQuery {
+            query: String::new(),
+            reason: "at least one range is required".into(),
+        });
+    }
+
+    let file = fs::File::open(path).map_err(|e| TilthError::IoError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let mmap = unsafe { Mmap::map(&file) }.map_err(|e| TilthError::IoError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let buf = &mmap[..];
+
+    // Find line offsets once — shared across all ranges.
     let mut line_offsets: Vec<usize> = vec![0];
     for pos in memchr::memchr_iter(b'\n', buf) {
         line_offsets.push(pos + 1);
     }
     let total = line_offsets.len();
 
-    let s = (start.saturating_sub(1)).min(total);
-    let e = end.min(total);
+    let mut blocks: Vec<Block> = Vec::with_capacity(ranges.len());
+    let mut total_bytes: u64 = 0;
+    let mut total_lines: u32 = 0;
 
-    if s >= e {
-        return Err(TilthError::InvalidQuery {
-            query: range.to_string(),
-            reason: format!("range out of bounds (file has {total} lines)"),
+    for range in ranges {
+        let (start, end) = resolve_range(buf, range)?;
+        let s = start.saturating_sub(1).min(total);
+        let e = end.min(total);
+        if s >= e {
+            return Err(TilthError::InvalidQuery {
+                query: (*range).to_string(),
+                reason: format!("range out of bounds (file has {total} lines)"),
+            });
+        }
+        let start_byte = line_offsets[s];
+        let end_byte = if e < line_offsets.len() {
+            line_offsets[e]
+        } else {
+            buf.len()
+        };
+        let selected = String::from_utf8_lossy(&buf[start_byte..end_byte]);
+        total_bytes += selected.len() as u64;
+        total_lines += (e - s) as u32;
+        let formatted = if edit_mode {
+            format::hashlines(&selected, start as u32)
+        } else {
+            format::number_lines(&selected, start as u32)
+        };
+        blocks.push(Block {
+            start,
+            end: e,
+            text: formatted,
         });
     }
 
-    let start_byte = line_offsets[s];
-    let end_byte = if e < line_offsets.len() {
-        line_offsets[e]
-    } else {
-        buf.len()
-    };
+    let header = format::file_header(path, total_bytes, total_lines, ViewMode::Section);
 
-    let selected = String::from_utf8_lossy(&buf[start_byte..end_byte]);
-    let byte_len = selected.len() as u64;
-    let line_count = (e - s) as u32;
-    let header = format::file_header(path, byte_len, line_count, ViewMode::Section);
-    let formatted = if edit_mode {
-        format::hashlines(&selected, start as u32)
-    } else {
-        format::number_lines(&selected, start as u32)
-    };
-    Ok(format!("{header}\n\n{formatted}"))
+    if blocks.len() == 1 {
+        let b = &blocks[0];
+        return Ok(format!("{header}\n\n{}", b.text));
+    }
+
+    let mut out = String::with_capacity(header.len() + total_bytes as usize + blocks.len() * 32);
+    out.push_str(&header);
+    for b in &blocks {
+        let _ = write!(out, "\n\n─── lines {}-{} ───\n", b.start, b.end);
+        out.push_str(&b.text);
+    }
+    Ok(out)
 }
 
 /// Parse "45-89" into (45, 89). 1-indexed.
@@ -746,5 +796,113 @@ mod tests {
         assert_eq!(edit_distance("🦀", "🐙"), 1);
         // ASCII baseline still works.
         assert_eq!(edit_distance("kitten", "sitting"), 3);
+    }
+
+    fn write_temp(name: &str, content: &str) -> std::path::PathBuf {
+        use std::io::Write;
+        let path = std::env::temp_dir().join(name);
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn read_ranges_single_matches_legacy_section() {
+        // One range produces no `─── lines X-Y ───` delimiter — output is
+        // identical in shape to the pre-multi-section read.
+        let path = write_temp(
+            "tilth_test_ranges_single.txt",
+            "alpha\nbeta\ngamma\ndelta\nepsilon\n",
+        );
+        let out = read_ranges(&path, &["2-3"], false).unwrap();
+        assert!(out.contains("[section]"), "expected section header: {out}");
+        assert!(!out.contains("─── lines"), "single range must not emit delimiter: {out}");
+        assert!(out.contains("2  beta"), "expected line 2: {out}");
+        assert!(out.contains("3  gamma"), "expected line 3: {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_disjoint_two_blocks() {
+        let path = write_temp(
+            "tilth_test_ranges_disjoint.txt",
+            "l1\nl2\nl3\nl4\nl5\nl6\nl7\nl8\n",
+        );
+        let out = read_ranges(&path, &["1-2", "6-7"], false).unwrap();
+        assert!(out.contains("─── lines 1-2 ───"), "first delimiter: {out}");
+        assert!(out.contains("─── lines 6-7 ───"), "second delimiter: {out}");
+        assert!(out.contains("1  l1") && out.contains("7  l7"), "content: {out}");
+        // Header reports summed lines — 2 + 2 = 4
+        assert!(out.contains("(4 lines"), "summed line_count: {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_preserves_user_order() {
+        // Out-of-order ranges are NOT sorted — emit verbatim.
+        let path = write_temp(
+            "tilth_test_ranges_order.txt",
+            "a\nb\nc\nd\ne\nf\n",
+        );
+        let out = read_ranges(&path, &["5-6", "1-2"], false).unwrap();
+        let later = out.find("─── lines 5-6 ───").unwrap();
+        let earlier = out.find("─── lines 1-2 ───").unwrap();
+        assert!(later < earlier, "5-6 must appear before 1-2 (user order): {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_overlap_is_emitted_verbatim() {
+        // Overlap is honored — duplicated content, no coalescing.
+        let path = write_temp(
+            "tilth_test_ranges_overlap.txt",
+            "x1\nx2\nx3\nx4\nx5\n",
+        );
+        let out = read_ranges(&path, &["1-3", "2-4"], false).unwrap();
+        assert!(out.contains("─── lines 1-3 ───"), "first block: {out}");
+        assert!(out.contains("─── lines 2-4 ───"), "second block: {out}");
+        // line 2 ("x2") appears in both blocks
+        let occurrences = out.matches("  x2\n").count();
+        assert_eq!(occurrences, 2, "expected x2 to appear twice (overlap): {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_mixed_line_and_heading() {
+        let path = write_temp(
+            "tilth_test_ranges_mixed.md",
+            "# Top\nintro line\n## Foo\nfoo body\n## Bar\nbar body\n",
+        );
+        let out = read_ranges(&path, &["1-2", "## Bar"], false).unwrap();
+        assert!(out.contains("─── lines 1-2 ───"), "line-range delimiter: {out}");
+        // "## Bar" lives at lines 5-6 in this fixture
+        assert!(out.contains("─── lines 5-6 ───"), "heading-resolved delimiter: {out}");
+        assert!(out.contains("intro line") && out.contains("bar body"), "content: {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_invalid_second_range_fails_whole_call() {
+        let path = write_temp(
+            "tilth_test_ranges_invalid.txt",
+            "one\ntwo\nthree\n",
+        );
+        let err = read_ranges(&path, &["1-2", "not-a-range"], false).unwrap_err();
+        assert!(
+            matches!(err, TilthError::InvalidQuery { .. }),
+            "expected InvalidQuery, got: {err:?}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn read_ranges_empty_input_errors() {
+        let path = write_temp("tilth_test_ranges_empty.txt", "a\nb\n");
+        let err = read_ranges(&path, &[], false).unwrap_err();
+        assert!(
+            matches!(err, TilthError::InvalidQuery { .. }),
+            "expected InvalidQuery for empty input, got: {err:?}"
+        );
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -10,6 +10,7 @@ use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::format;
 use crate::lang::detect_file_type;
+use crate::lang::outline::{heading_level, heading_text, parse_markdown};
 use crate::types::{estimate_tokens, FileType, ViewMode};
 
 pub(crate) const TOKEN_THRESHOLD: u64 = 6_000;
@@ -180,97 +181,103 @@ pub fn would_outline(path: &Path) -> bool {
 /// Resolve a heading address to a line range in a markdown file.
 /// Returns `(start_line, end_line)` as 1-indexed inclusive range.
 /// Returns `None` if heading not found.
+///
+/// Walks the `tree-sitter-md` `section` tree: each ATX heading owns a
+/// `section` node spanning from the heading line through the line before
+/// the next same-or-higher-level heading (sub-headings nest as child
+/// sections and don't terminate the parent). Headings inside fenced /
+/// indented code blocks aren't emitted as `atx_heading` nodes, so the
+/// fence-state tracking the previous hand-rolled scanner needed is now
+/// the parser's responsibility.
 fn resolve_heading(buf: &[u8], heading: &str) -> Option<(usize, usize)> {
     let heading_trimmed = heading.trim_end();
-    let heading_level = heading_trimmed.chars().take_while(|&c| c == '#').count();
-
-    if heading_level == 0 {
+    let query_level = heading_trimmed.chars().take_while(|&c| c == '#').count();
+    if query_level == 0 || query_level > 6 {
+        return None;
+    }
+    // Normalise the query the same way `heading_text` normalises an
+    // `atx_heading` node — strip leading `#`s, surrounding whitespace,
+    // and any ATX-close `#`s — so `## Foo`, `## Foo ##`, and `##  Foo`
+    // all match the same node.
+    let query_text = heading_trimmed[query_level..]
+        .trim()
+        .trim_end_matches('#')
+        .trim();
+    if query_text.is_empty() {
         return None;
     }
 
-    // Build line offsets
-    let mut line_offsets: Vec<usize> = vec![0];
-    for pos in memchr::memchr_iter(b'\n', buf) {
-        line_offsets.push(pos + 1);
-    }
-    // Exclude phantom empty line after trailing newline (match outline's count)
-    let total_lines = if buf.last() == Some(&b'\n') {
-        line_offsets.len() - 1
-    } else {
-        line_offsets.len()
-    };
+    let content = std::str::from_utf8(buf).ok()?;
+    let tree = parse_markdown(content)?;
+    let lines: Vec<&str> = content.lines().collect();
 
-    let mut in_code_block = false;
-    let mut found_line: Option<usize> = None;
+    #[allow(clippy::cast_possible_truncation)]
+    let level = query_level as u8;
+    find_section(tree.root_node(), &lines, level, query_text)
+}
 
-    // Scan for the target heading
-    for (line_idx, &offset) in line_offsets.iter().enumerate() {
-        let line_end = if line_idx + 1 < line_offsets.len() {
-            line_offsets[line_idx + 1] - 1 // exclude newline
-        } else {
-            buf.len()
-        };
-
-        if let Ok(line_str) = std::str::from_utf8(&buf[offset..line_end]) {
-            let trimmed = line_str.trim_end();
-
-            // Track code blocks
-            if trimmed.starts_with("```") {
-                in_code_block = !in_code_block;
-                continue;
+/// Recursive section-tree walk for `resolve_heading`. Returns the first
+/// section whose `atx_heading` matches `(level, text)`.
+fn find_section(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    target_level: u8,
+    target_text: &str,
+) -> Option<(usize, usize)> {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "section" => {
+                if let Some(hit) = match_section(child, lines, target_level, target_text) {
+                    return Some(hit);
+                }
+                if let Some(hit) = find_section(child, lines, target_level, target_text) {
+                    return Some(hit);
+                }
             }
-
-            // Skip headings inside code blocks
-            if in_code_block {
-                continue;
-            }
-
-            // Check if this line matches the heading
-            if trimmed == heading_trimmed {
-                found_line = Some(line_idx + 1); // 1-indexed
-                break;
-            }
-        }
-    }
-
-    let start_line = found_line?;
-
-    // Find the next heading of same or higher level
-    in_code_block = false;
-    let start_idx = start_line - 1; // convert back to 0-indexed for iteration
-
-    for (line_idx, &offset) in line_offsets.iter().enumerate().skip(start_idx + 1) {
-        let line_end = if line_idx + 1 < line_offsets.len() {
-            line_offsets[line_idx + 1] - 1
-        } else {
-            buf.len()
-        };
-
-        if let Ok(line_str) = std::str::from_utf8(&buf[offset..line_end]) {
-            let trimmed = line_str.trim_end();
-
-            if trimmed.starts_with("```") {
-                in_code_block = !in_code_block;
-                continue;
-            }
-
-            if in_code_block {
-                continue;
-            }
-
-            // Check if this is a heading
-            if trimmed.starts_with('#') {
-                let level = trimmed.chars().take_while(|&c| c == '#').count();
-                if level <= heading_level {
-                    // 0-based line_idx of next heading = 1-indexed line before it
-                    return Some((start_line, line_idx));
+            // The parser owns these — no headings hide inside.
+            "fenced_code_block" | "indented_code_block" | "html_block" => {}
+            _ => {
+                if let Some(hit) = find_section(child, lines, target_level, target_text) {
+                    return Some(hit);
                 }
             }
         }
     }
+    None
+}
 
-    // No next heading found — section goes to end of file
-    Some((start_line, total_lines))
+fn match_section(
+    section: tree_sitter::Node,
+    lines: &[&str],
+    target_level: u8,
+    target_text: &str,
+) -> Option<(usize, usize)> {
+    let mut cursor = section.walk();
+    let heading = section
+        .children(&mut cursor)
+        .find(|c| c.kind() == "atx_heading")?;
+    if heading_level(heading) != Some(target_level) {
+        return None;
+    }
+    if heading_text(heading, lines) != target_text {
+        return None;
+    }
+    let start_line = heading.start_position().row + 1;
+    let end_line = section_end_line(section);
+    Some((start_line, end_line))
+}
+
+/// 1-indexed inclusive last line of a tree-sitter `section` node.
+/// `end_position` is exclusive; col 0 means we landed on the next line's
+/// row, so the section's last line is `end.row` itself.
+fn section_end_line(section: tree_sitter::Node) -> usize {
+    let end = section.end_position();
+    if end.column == 0 {
+        end.row
+    } else {
+        end.row + 1
+    }
 }
 
 /// Return up to `top_n` markdown headings ranked by edit distance to `query`.
@@ -279,10 +286,13 @@ fn resolve_heading(buf: &[u8], heading: &str) -> Option<(usize, usize)> {
 /// renamed since they last read. Returning the closest matches lets them
 /// retry with the right anchor without re-reading the whole file.
 ///
-/// Recognizes `ATX` headings (`CommonMark` §4.6: 1–6 leading `#`s followed
-/// by a space). Skips headings inside fenced code blocks delimited by either
-/// triple backticks or triple tildes. `Setext` headings (`Title\n===`) are
-/// not recognized — they are rare in practice and would require lookback.
+/// Walks `atx_heading` nodes from `tree-sitter-md`, which by construction
+/// covers `CommonMark` §4.6 (1–6 `#`s followed by space/EOL) and excludes
+/// headings inside fenced or indented code blocks. `Setext` headings
+/// (`Title\n===`) are silently ignored — see `find_defs_markdown_buf` for
+/// the same trade-off; the block grammar puts them at document scope so
+/// span computation doesn't apply.
+///
 /// Caveat on ranking: Levenshtein favours candidates of similar length to
 /// the query, so very short queries against long headings can rank tighter
 /// matches first; this is acceptable for a hint and aligned with the rest
@@ -294,49 +304,54 @@ fn suggest_headings(buf: &[u8], query: &str, top_n: usize) -> Vec<String> {
     }
     let q_lower = q_text.to_ascii_lowercase();
 
-    let mut in_code_block = false;
-    let mut scored: Vec<(usize, String)> = Vec::new();
-    for line in buf.split(|&b| b == b'\n') {
-        let Ok(s) = std::str::from_utf8(line) else {
-            continue;
-        };
-        let trimmed = s.trim_end();
-        // CommonMark allows both ``` and ~~~ as fence delimiters.
-        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
-            in_code_block = !in_code_block;
-            continue;
-        }
-        if in_code_block || !trimmed.starts_with('#') {
-            continue;
-        }
-        // CommonMark §4.6.1: ATX headings have 1–6 `#`s followed by a space
-        // (or end-of-line). Reject longer hash runs and hash-prefixes that
-        // aren't followed by whitespace (`##foo` is not a heading).
-        let hash_count = trimmed.bytes().take_while(|&b| b == b'#').count();
-        if !(1..=6).contains(&hash_count) {
-            continue;
-        }
-        let after_hashes = trimmed.as_bytes().get(hash_count).copied();
-        if !matches!(after_hashes, None | Some(b' ' | b'\t')) {
-            continue;
-        }
-        let h_text = trimmed[hash_count..].trim();
-        if h_text.is_empty() {
-            continue;
-        }
-        // Strip kramdown attr blocks and ATX-close `#`s from comparison text.
-        let h_clean = h_text
-            .split('{')
-            .next()
-            .unwrap_or(h_text)
-            .trim_end_matches('#')
-            .trim();
-        let dist = edit_distance(&q_lower, &h_clean.to_ascii_lowercase());
-        scored.push((dist, trimmed.to_string()));
-    }
+    let Ok(content) = std::str::from_utf8(buf) else {
+        return Vec::new();
+    };
+    let Some(tree) = parse_markdown(content) else {
+        return Vec::new();
+    };
+    let lines: Vec<&str> = content.lines().collect();
 
+    let mut scored: Vec<(usize, String)> = Vec::new();
+    collect_atx_headings(tree.root_node(), &lines, &q_lower, &mut scored);
     scored.sort_by_key(|(d, _)| *d);
     scored.into_iter().take(top_n).map(|(_, h)| h).collect()
+}
+
+/// Recursively collect `atx_heading` nodes scored by edit distance to
+/// `q_lower`. Code blocks are skipped — the grammar already guarantees
+/// no `atx_heading` nests inside them, but we elide the recursion to
+/// avoid walking large fenced bodies.
+fn collect_atx_headings(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    q_lower: &str,
+    out: &mut Vec<(usize, String)>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "atx_heading" => {
+                let h_text = heading_text(child, lines);
+                // Strip kramdown attr blocks before scoring (e.g. `## Foo {#id}`).
+                let h_clean = h_text.split('{').next().unwrap_or(&h_text).trim();
+                if h_clean.is_empty() {
+                    continue;
+                }
+                let dist = edit_distance(q_lower, &h_clean.to_ascii_lowercase());
+                let row = child.start_position().row;
+                let line_text = lines
+                    .get(row)
+                    .copied()
+                    .unwrap_or("")
+                    .trim_end()
+                    .to_string();
+                out.push((dist, line_text));
+            }
+            "fenced_code_block" | "indented_code_block" | "html_block" => {}
+            _ => collect_atx_headings(child, lines, q_lower, out),
+        }
+    }
 }
 
 /// Read a specific line range from a file.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -341,12 +341,7 @@ fn collect_atx_headings(
                 }
                 let dist = edit_distance(q_lower, &h_clean.to_ascii_lowercase());
                 let row = child.start_position().row;
-                let line_text = lines
-                    .get(row)
-                    .copied()
-                    .unwrap_or("")
-                    .trim_end()
-                    .to_string();
+                let line_text = lines.get(row).copied().unwrap_or("").trim_end().to_string();
                 out.push((dist, line_text));
             }
             "fenced_code_block" | "indented_code_block" | "html_block" => {}
@@ -398,11 +393,7 @@ struct Block {
 /// Ranges are emitted in the order supplied — overlapping or out-of-order
 /// ranges are honored verbatim, not coalesced or sorted. Any invalid
 /// range fails the whole call.
-pub fn read_ranges(
-    path: &Path,
-    ranges: &[&str],
-    edit_mode: bool,
-) -> Result<String, TilthError> {
+pub fn read_ranges(path: &Path, ranges: &[&str], edit_mode: bool) -> Result<String, TilthError> {
     if ranges.is_empty() {
         return Err(TilthError::InvalidQuery {
             query: String::new(),
@@ -816,7 +807,10 @@ mod tests {
         );
         let out = read_ranges(&path, &["2-3"], false).unwrap();
         assert!(out.contains("[section]"), "expected section header: {out}");
-        assert!(!out.contains("─── lines"), "single range must not emit delimiter: {out}");
+        assert!(
+            !out.contains("─── lines"),
+            "single range must not emit delimiter: {out}"
+        );
         assert!(out.contains("2  beta"), "expected line 2: {out}");
         assert!(out.contains("3  gamma"), "expected line 3: {out}");
         let _ = std::fs::remove_file(&path);
@@ -831,7 +825,10 @@ mod tests {
         let out = read_ranges(&path, &["1-2", "6-7"], false).unwrap();
         assert!(out.contains("─── lines 1-2 ───"), "first delimiter: {out}");
         assert!(out.contains("─── lines 6-7 ───"), "second delimiter: {out}");
-        assert!(out.contains("1  l1") && out.contains("7  l7"), "content: {out}");
+        assert!(
+            out.contains("1  l1") && out.contains("7  l7"),
+            "content: {out}"
+        );
         // Header reports summed lines — 2 + 2 = 4
         assert!(out.contains("(4 lines"), "summed line_count: {out}");
         let _ = std::fs::remove_file(&path);
@@ -840,30 +837,30 @@ mod tests {
     #[test]
     fn read_ranges_preserves_user_order() {
         // Out-of-order ranges are NOT sorted — emit verbatim.
-        let path = write_temp(
-            "tilth_test_ranges_order.txt",
-            "a\nb\nc\nd\ne\nf\n",
-        );
+        let path = write_temp("tilth_test_ranges_order.txt", "a\nb\nc\nd\ne\nf\n");
         let out = read_ranges(&path, &["5-6", "1-2"], false).unwrap();
         let later = out.find("─── lines 5-6 ───").unwrap();
         let earlier = out.find("─── lines 1-2 ───").unwrap();
-        assert!(later < earlier, "5-6 must appear before 1-2 (user order): {out}");
+        assert!(
+            later < earlier,
+            "5-6 must appear before 1-2 (user order): {out}"
+        );
         let _ = std::fs::remove_file(&path);
     }
 
     #[test]
     fn read_ranges_overlap_is_emitted_verbatim() {
         // Overlap is honored — duplicated content, no coalescing.
-        let path = write_temp(
-            "tilth_test_ranges_overlap.txt",
-            "x1\nx2\nx3\nx4\nx5\n",
-        );
+        let path = write_temp("tilth_test_ranges_overlap.txt", "x1\nx2\nx3\nx4\nx5\n");
         let out = read_ranges(&path, &["1-3", "2-4"], false).unwrap();
         assert!(out.contains("─── lines 1-3 ───"), "first block: {out}");
         assert!(out.contains("─── lines 2-4 ───"), "second block: {out}");
         // line 2 ("x2") appears in both blocks
         let occurrences = out.matches("  x2\n").count();
-        assert_eq!(occurrences, 2, "expected x2 to appear twice (overlap): {out}");
+        assert_eq!(
+            occurrences, 2,
+            "expected x2 to appear twice (overlap): {out}"
+        );
         let _ = std::fs::remove_file(&path);
     }
 
@@ -874,19 +871,25 @@ mod tests {
             "# Top\nintro line\n## Foo\nfoo body\n## Bar\nbar body\n",
         );
         let out = read_ranges(&path, &["1-2", "## Bar"], false).unwrap();
-        assert!(out.contains("─── lines 1-2 ───"), "line-range delimiter: {out}");
+        assert!(
+            out.contains("─── lines 1-2 ───"),
+            "line-range delimiter: {out}"
+        );
         // "## Bar" lives at lines 5-6 in this fixture
-        assert!(out.contains("─── lines 5-6 ───"), "heading-resolved delimiter: {out}");
-        assert!(out.contains("intro line") && out.contains("bar body"), "content: {out}");
+        assert!(
+            out.contains("─── lines 5-6 ───"),
+            "heading-resolved delimiter: {out}"
+        );
+        assert!(
+            out.contains("intro line") && out.contains("bar body"),
+            "content: {out}"
+        );
         let _ = std::fs::remove_file(&path);
     }
 
     #[test]
     fn read_ranges_invalid_second_range_fails_whole_call() {
-        let path = write_temp(
-            "tilth_test_ranges_invalid.txt",
-            "one\ntwo\nthree\n",
-        );
+        let path = write_temp("tilth_test_ranges_invalid.txt", "one\ntwo\nthree\n");
         let err = read_ranges(&path, &["1-2", "not-a-range"], false).unwrap_err();
         assert!(
             matches!(err, TilthError::InvalidQuery { .. }),

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -905,4 +905,29 @@ mod tests {
         );
         let _ = std::fs::remove_file(&path);
     }
+
+    #[test]
+    fn read_ranges_edit_mode_emits_hashlines_per_block() {
+        // Edit-mode output must be hashlined inside every block, not just the first.
+        // Hashline format is `<line>:<3hex>|<content>`.
+        let path = write_temp(
+            "tilth_test_ranges_edit_mode.txt",
+            "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n",
+        );
+        let out = read_ranges(&path, &["1-2", "5-6"], true).unwrap();
+        // Both delimiters present
+        assert!(out.contains("─── lines 1-2 ───"), "first delimiter: {out}");
+        assert!(out.contains("─── lines 5-6 ───"), "second delimiter: {out}");
+        // Hashline anchors present for at least one line in each block (the
+        // exact hash depends on FNV-1a so just check the `<n>:<hex>|` shape).
+        let line_one_match = out
+            .lines()
+            .any(|l| l.starts_with("1:") && l.contains("|alpha"));
+        let line_six_match = out
+            .lines()
+            .any(|l| l.starts_with("6:") && l.contains("|zeta"));
+        assert!(line_one_match, "expected hashline for line 1: {out}");
+        assert!(line_six_match, "expected hashline for line 6: {out}");
+        let _ = std::fs::remove_file(&path);
+    }
 }

--- a/src/read/outline/markdown.rs
+++ b/src/read/outline/markdown.rs
@@ -57,11 +57,7 @@ fn walk(
 
 /// If `section` opens with an `atx_heading` or `setext_heading`, append an
 /// entry of the form `[start-end] {indent}{hashes} {text}` to `entries`.
-fn emit_section_heading(
-    section: tree_sitter::Node,
-    lines: &[&str],
-    entries: &mut Vec<String>,
-) {
+fn emit_section_heading(section: tree_sitter::Node, lines: &[&str], entries: &mut Vec<String>) {
     let mut cursor = section.walk();
     for inner in section.children(&mut cursor) {
         // Only ATX headings nest as proper sections in the block grammar;

--- a/src/read/outline/markdown.rs
+++ b/src/read/outline/markdown.rs
@@ -1,85 +1,107 @@
-/// Markdown outline via memchr line scan — no markdown parser needed.
-/// Find lines starting with `#`, extract heading level and text,
-/// count code blocks per section. Shows line ranges for each heading.
+/// Markdown outline via tree-sitter-md. The block grammar emits `section`
+/// nodes that group each heading with its content (and any nested sections),
+/// so heading hierarchy + section spans drop out of the AST instead of
+/// requiring a hand-rolled fence-aware ATX scan. Fenced code blocks are
+/// `fenced_code_block` nodes and never produce false-positive headings.
+use crate::lang::outline::{heading_level, heading_text, parse_markdown};
+
 pub fn outline(buf: &[u8], max_lines: usize) -> String {
-    // First pass: collect all headings and count total lines
-    let mut headings = Vec::new();
-    let mut pos = 0;
-    let mut line_num = 0u32;
-    let mut code_block_count = 0u32;
-    let mut in_code_block = false;
+    let Ok(content) = std::str::from_utf8(buf) else {
+        return String::new();
+    };
+    let Some(tree) = parse_markdown(content) else {
+        return String::new();
+    };
+    let lines: Vec<&str> = content.lines().collect();
 
-    while pos < buf.len() && headings.len() < max_lines {
-        line_num += 1;
-
-        // Find end of current line
-        let line_end = memchr::memchr(b'\n', &buf[pos..]).map_or(buf.len(), |i| pos + i);
-
-        let line = &buf[pos..line_end];
-
-        // Track code blocks
-        if line.starts_with(b"```") {
-            if in_code_block {
-                in_code_block = false;
-            } else {
-                in_code_block = true;
-                code_block_count += 1;
-            }
-            pos = line_end + 1;
-            continue;
-        }
-
-        if !in_code_block && !line.is_empty() && line[0] == b'#' {
-            // Count heading level
-            let level = line.iter().take_while(|&&b| b == b'#').count();
-            if level <= 6 {
-                let text_start = level + usize::from(line.get(level) == Some(&b' '));
-                if let Ok(text) = std::str::from_utf8(&line[text_start..]) {
-                    headings.push((line_num, level, text.to_string()));
-                }
-            }
-        }
-
-        pos = line_end + 1;
-    }
-
-    let total_lines = line_num;
-
-    // Second pass: compute end lines for each heading and format output
     let mut entries = Vec::new();
-    let num_headings = headings.len();
-
-    for (i, (start_line, level, text)) in headings.iter().enumerate() {
-        // Find next heading with same or higher level (lower level number)
-        let end_line = if i + 1 < num_headings {
-            // Look for next heading with level <= current level
-            headings[i + 1..]
-                .iter()
-                .find(|(_, next_level, _)| next_level <= level)
-                .map_or(total_lines, |(next_start, _, _)| next_start - 1)
-        } else {
-            // Last heading extends to end of file
-            total_lines
-        };
-
-        let indent = "  ".repeat(level.saturating_sub(1));
-        let hashes = "#".repeat(*level);
-        let truncated = if text.len() > 80 {
-            format!("{}...", crate::types::truncate_str(text, 77))
-        } else {
-            text.clone()
-        };
-
-        entries.push(format!(
-            "[{start_line}-{end_line}] {indent}{hashes} {truncated}"
-        ));
-    }
+    let mut code_block_count = 0u32;
+    walk(
+        tree.root_node(),
+        &lines,
+        max_lines,
+        &mut entries,
+        &mut code_block_count,
+    );
 
     if code_block_count > 0 {
         entries.push(format!("\n({code_block_count} code blocks)"));
     }
-
     entries.join("\n")
+}
+
+fn walk(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    max_lines: usize,
+    entries: &mut Vec<String>,
+    code_block_count: &mut u32,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if entries.len() >= max_lines {
+            return;
+        }
+        match child.kind() {
+            "section" => {
+                emit_section_heading(child, lines, entries);
+                walk(child, lines, max_lines, entries, code_block_count);
+            }
+            "fenced_code_block" => {
+                *code_block_count += 1;
+            }
+            _ => walk(child, lines, max_lines, entries, code_block_count),
+        }
+    }
+}
+
+/// If `section` opens with an `atx_heading` or `setext_heading`, append an
+/// entry of the form `[start-end] {indent}{hashes} {text}` to `entries`.
+fn emit_section_heading(
+    section: tree_sitter::Node,
+    lines: &[&str],
+    entries: &mut Vec<String>,
+) {
+    let mut cursor = section.walk();
+    for inner in section.children(&mut cursor) {
+        // Only ATX headings nest as proper sections in the block grammar;
+        // setext headings sit as siblings inside one big document section,
+        // so section-span computation doesn't apply. Preserve the old
+        // hand-rolled scanner's behavior of silently ignoring setext.
+        if inner.kind() != "atx_heading" {
+            continue;
+        }
+        let Some(level) = heading_level(inner) else {
+            return;
+        };
+        let start_line = (inner.start_position().row + 1) as u32;
+        let end_line = section_end_line(section);
+        let text = heading_text(inner, lines);
+        let indent = "  ".repeat((level as usize).saturating_sub(1));
+        let hashes = "#".repeat(level as usize);
+        let display = if text.len() > 80 {
+            format!("{}...", crate::types::truncate_str(&text, 77))
+        } else {
+            text
+        };
+        entries.push(format!(
+            "[{start_line}-{end_line}] {indent}{hashes} {display}"
+        ));
+        return;
+    }
+}
+
+/// Convert a section node's exclusive end position to a 1-indexed inclusive
+/// line. Tree-sitter end positions point one past the last character — when
+/// the section ends with a newline, end.column is 0 on the row after the
+/// content; otherwise end.row is the row containing the last character.
+fn section_end_line(section: tree_sitter::Node) -> u32 {
+    let end = section.end_position();
+    if end.column == 0 {
+        end.row as u32
+    } else {
+        (end.row + 1) as u32
+    }
 }
 
 #[cfg(test)]
@@ -149,6 +171,32 @@ mod tests {
         let input = b"";
         let result = outline(input, 100);
 
+        assert_eq!(result, "");
+    }
+
+    /// AST handles fenced code blocks at the parser level — a `# foo` Python
+    /// comment inside a fenced block is part of the `fenced_code_block` node,
+    /// not an `atx_heading`. The hand-rolled scanner needed a manual fence
+    /// pre-pass to avoid treating it as a heading; the AST gets this for free.
+    #[test]
+    fn hash_inside_fenced_code_does_not_become_heading() {
+        let input = b"# Real\n\n```python\n# fake heading\nprint('x')\n```\n\n## Also Real\n";
+        let result = outline(input, 100);
+        let lines: Vec<&str> = result.lines().collect();
+        let heading_lines: Vec<&&str> = lines.iter().filter(|l| l.starts_with('[')).collect();
+        assert_eq!(heading_lines.len(), 2);
+        assert!(heading_lines[0].contains("# Real"));
+        assert!(heading_lines[1].contains("## Also Real"));
+    }
+
+    /// Setext headings (`Top\n====`) are not handled — the block grammar puts
+    /// every setext heading as a sibling inside one document-spanning section
+    /// rather than nesting them, so section-span computation doesn't apply.
+    /// The old hand-rolled scanner only matched ATX too; we preserve that.
+    #[test]
+    fn setext_headings_silently_ignored() {
+        let input = b"Top\n===\n\ncontent\n";
+        let result = outline(input, 100);
         assert_eq!(result, "");
     }
 }

--- a/src/search/bloom_walk.rs
+++ b/src/search/bloom_walk.rs
@@ -1,0 +1,100 @@
+//! Shared file-prefilter helper for relational queries (callers, callees,
+//! deps). Reads a file, gates on size, and runs the per-file bloom prefilter
+//! against any of the supplied target symbols. Returns content + mtime when
+//! the file is worth deeper inspection (tree-sitter parse, outline scan).
+
+use std::path::Path;
+use std::time::SystemTime;
+
+use crate::index::bloom::BloomFilterCache;
+
+/// Skip files larger than this; tree-sitter parses on huge files dominate
+/// query latency without surfacing useful matches.
+pub(super) const MAX_FILE_SIZE: u64 = 500_000;
+
+/// Read `path`, validate size, and pass through only when at least one
+/// target is bloom-positive. Returns `(content, mtime)` for the next stage,
+/// or `None` to skip the file.
+///
+/// Bloom is probabilistic: a positive may be a false positive. Callers that
+/// need a tighter pre-AST filter (e.g. memchr) should run it on the returned
+/// content before paying for tree-sitter.
+pub(super) fn read_with_bloom_check<I, S>(
+    path: &Path,
+    targets: I,
+    bloom: &BloomFilterCache,
+    max_size: u64,
+) -> Option<(String, SystemTime)>
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<str>,
+{
+    let meta = std::fs::metadata(path).ok()?;
+    if meta.len() > max_size {
+        return None;
+    }
+    let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
+    let content = std::fs::read_to_string(path).ok()?;
+
+    if !targets
+        .into_iter()
+        .any(|t| bloom.contains(path, mtime, &content, t.as_ref()))
+    {
+        return None;
+    }
+
+    Some((content, mtime))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+    use std::fs;
+
+    #[test]
+    fn returns_none_for_oversized_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("big.rs");
+        // Fill past max_size
+        let payload = "fn foo() {}\n".repeat(2);
+        fs::write(&p, &payload).unwrap();
+        let bloom = BloomFilterCache::new();
+        let targets: HashSet<String> = ["foo".to_string()].into_iter().collect();
+        // max_size below file len → skip
+        assert!(read_with_bloom_check(&p, &targets, &bloom, 1).is_none());
+    }
+
+    #[test]
+    fn returns_none_when_no_target_is_bloom_positive() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.rs");
+        fs::write(&p, "fn alpha() {}\n").unwrap();
+        let bloom = BloomFilterCache::new();
+        let targets: HashSet<String> = ["beta".to_string()].into_iter().collect();
+        assert!(read_with_bloom_check(&p, &targets, &bloom, MAX_FILE_SIZE).is_none());
+    }
+
+    #[test]
+    fn returns_content_when_target_present() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.rs");
+        fs::write(&p, "fn alpha() {}\n").unwrap();
+        let bloom = BloomFilterCache::new();
+        let targets: HashSet<String> = ["alpha".to_string()].into_iter().collect();
+        let (content, _) = read_with_bloom_check(&p, &targets, &bloom, MAX_FILE_SIZE).unwrap();
+        assert!(content.contains("alpha"));
+    }
+
+    #[test]
+    fn accepts_borrowed_str_targets() {
+        // callees.rs holds HashSet<&str>; the helper must accept that shape
+        // without forcing a String allocation per call.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.rs");
+        fs::write(&p, "fn alpha() {}\n").unwrap();
+        let bloom = BloomFilterCache::new();
+        let targets: HashSet<&str> = ["alpha"].into_iter().collect();
+        assert!(read_with_bloom_check(&p, &targets, &bloom, MAX_FILE_SIZE).is_some());
+    }
+}

--- a/src/search/callee_query.rs
+++ b/src/search/callee_query.rs
@@ -1,0 +1,165 @@
+//! Per-language tree-sitter queries for matching call expressions, with a
+//! global compiled-`Query` cache. Used by the caller-direction walk
+//! (`callers::find_callers_batch`) and the callee-direction extractor
+//! (`callees::extract_callee_names`) — they share both the query strings
+//! and the compiled-query cache.
+
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
+use crate::types::Lang;
+
+/// Return the tree-sitter query string for extracting callee names in the given language.
+/// Each language has patterns targeting `@callee` captures on call-like expressions.
+pub(super) fn callee_query_str(lang: Lang) -> Option<&'static str> {
+    match lang {
+        Lang::Rust => Some(concat!(
+            "(call_expression function: (identifier) @callee)\n",
+            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
+            "(call_expression function: (scoped_identifier name: (identifier) @callee))\n",
+            "(macro_invocation macro: (identifier) @callee)\n",
+        )),
+        Lang::Go => Some(concat!(
+            "(call_expression function: (identifier) @callee)\n",
+            "(call_expression function: (selector_expression field: (field_identifier) @callee))\n",
+        )),
+        Lang::Python => Some(concat!(
+            "(call function: (identifier) @callee)\n",
+            "(call function: (attribute attribute: (identifier) @callee))\n",
+        )),
+        Lang::JavaScript | Lang::TypeScript | Lang::Tsx => Some(concat!(
+            "(call_expression function: (identifier) @callee)\n",
+            "(call_expression function: (member_expression property: (property_identifier) @callee))\n",
+        )),
+        Lang::Java => Some(
+            "(method_invocation name: (identifier) @callee)\n",
+        ),
+        Lang::Scala => Some(concat!(
+            "(call_expression function: (identifier) @callee)\n",
+            "(call_expression function: (field_expression field: (identifier) @callee))\n",
+            "(infix_expression operator: (identifier) @callee)\n",
+        )),
+        Lang::C | Lang::Cpp => Some(concat!(
+            "(call_expression function: (identifier) @callee)\n",
+            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
+        )),
+        Lang::Ruby => Some(
+            "(call method: (identifier) @callee)\n",
+        ),
+        Lang::Php => Some(concat!(
+            "(function_call_expression function: (name) @callee)\n",
+            "(function_call_expression function: (qualified_name) @callee)\n",
+            "(function_call_expression function: (relative_name) @callee)\n",
+            "(member_call_expression name: (name) @callee)\n",
+            "(nullsafe_member_call_expression name: (name) @callee)\n",
+            "(scoped_call_expression name: (name) @callee)\n",
+        )),
+        Lang::CSharp => Some(concat!(
+            "(invocation_expression function: (identifier) @callee)\n",
+            "(invocation_expression function: (member_access_expression name: (identifier) @callee))\n",
+        )),
+        Lang::Swift => Some(concat!(
+            "(call_expression (simple_identifier) @callee)\n",
+            "(call_expression (navigation_expression suffix: (navigation_suffix suffix: (simple_identifier) @callee)))\n",
+        )),
+        Lang::Kotlin => Some(concat!(
+            "(call_expression (identifier) @callee)\n",
+            "(call_expression (navigation_expression (identifier) @callee .))\n",
+        )),
+        Lang::Elixir => Some(concat!(
+            "(call target: (identifier) @callee)\n",
+            "(call target: (dot right: (identifier) @callee))\n",
+        )),
+        _ => None,
+    }
+}
+
+/// Global cache of compiled tree-sitter queries for callee extraction.
+///
+/// Keyed by `(symbol_count, field_count)` — a pair that uniquely identifies
+/// each grammar in practice. We avoid keying by `Language::name()` because
+/// older grammars (ABI < 15) do not register a name and would return `None`,
+/// silently disabling the cache and callee extraction entirely.
+///
+/// `Query` is `Send + Sync` in tree-sitter 0.25, so a global `Mutex`-guarded
+/// map is safe and avoids recompiling the same query on every call.
+static QUERY_CACHE: LazyLock<Mutex<HashMap<(usize, usize), tree_sitter::Query>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Stable cache key for a tree-sitter language. Uses `(symbol_count,
+/// field_count)` which is unique for every grammar shipped with tilth.
+fn lang_cache_key(ts_lang: &tree_sitter::Language) -> (usize, usize) {
+    (ts_lang.node_kind_count(), ts_lang.field_count())
+}
+
+/// Look up or compile the callee query for `ts_lang`, then invoke `f` with a
+/// reference to the cached `Query`.  Returns `None` if compilation fails.
+pub(super) fn with_callee_query<R>(
+    ts_lang: &tree_sitter::Language,
+    query_str: &str,
+    f: impl FnOnce(&tree_sitter::Query) -> R,
+) -> Option<R> {
+    let key = lang_cache_key(ts_lang);
+    let mut cache = QUERY_CACHE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(key) {
+        let query = tree_sitter::Query::new(ts_lang, query_str).ok()?;
+        e.insert(query);
+    }
+    // Safety: we just inserted if absent, so the key is always present here.
+    Some(f(cache.get(&key).expect("just inserted")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn grammar_cache_keys_unique() {
+        // Verify that (node_kind_count, field_count) is unique across all shipped grammars.
+        // A collision would cause one language to serve another's cached query.
+        let grammars: Vec<(&str, tree_sitter::Language)> = vec![
+            ("rust", tree_sitter_rust::LANGUAGE.into()),
+            (
+                "typescript",
+                tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
+            ),
+            ("tsx", tree_sitter_typescript::LANGUAGE_TSX.into()),
+            ("javascript", tree_sitter_javascript::LANGUAGE.into()),
+            ("python", tree_sitter_python::LANGUAGE.into()),
+            ("go", tree_sitter_go::LANGUAGE.into()),
+            ("java", tree_sitter_java::LANGUAGE.into()),
+            ("c", tree_sitter_c::LANGUAGE.into()),
+            ("cpp", tree_sitter_cpp::LANGUAGE.into()),
+            ("ruby", tree_sitter_ruby::LANGUAGE.into()),
+            ("php", tree_sitter_php::LANGUAGE_PHP.into()),
+            ("scala", tree_sitter_scala::LANGUAGE.into()),
+            ("csharp", tree_sitter_c_sharp::LANGUAGE.into()),
+            ("swift", tree_sitter_swift::LANGUAGE.into()),
+            ("kotlin", tree_sitter_kotlin_ng::LANGUAGE.into()),
+            ("elixir", tree_sitter_elixir::LANGUAGE.into()),
+        ];
+        let mut seen = std::collections::HashMap::new();
+        for (name, lang) in &grammars {
+            let key = lang_cache_key(lang);
+            if let Some(prev) = seen.insert(key, name) {
+                panic!("cache key collision: {prev} and {name} both produce {key:?}");
+            }
+        }
+    }
+
+    #[test]
+    fn kotlin_callee_query_compiles() {
+        let lang: tree_sitter::Language = tree_sitter_kotlin_ng::LANGUAGE.into();
+        let query_str = callee_query_str(Lang::Kotlin).unwrap();
+        tree_sitter::Query::new(&lang, query_str).expect("kotlin callee query should compile");
+    }
+
+    #[test]
+    fn elixir_callee_query_compiles() {
+        let lang: tree_sitter::Language = tree_sitter_elixir::LANGUAGE.into();
+        let query_str = callee_query_str(Lang::Elixir).unwrap();
+        tree_sitter::Query::new(&lang, query_str).expect("elixir callee query should compile");
+    }
+}

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -1,6 +1,5 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
 
 use streaming_iterator::StreamingIterator;
 
@@ -25,108 +24,6 @@ pub struct ResolvedCalleeNode {
     pub children: Vec<ResolvedCallee>,
 }
 
-/// Return the tree-sitter query string for extracting callee names in the given language.
-/// Each language has patterns targeting `@callee` captures on call-like expressions.
-pub(crate) fn callee_query_str(lang: Lang) -> Option<&'static str> {
-    match lang {
-        Lang::Rust => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
-            "(call_expression function: (scoped_identifier name: (identifier) @callee))\n",
-            "(macro_invocation macro: (identifier) @callee)\n",
-        )),
-        Lang::Go => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (selector_expression field: (field_identifier) @callee))\n",
-        )),
-        Lang::Python => Some(concat!(
-            "(call function: (identifier) @callee)\n",
-            "(call function: (attribute attribute: (identifier) @callee))\n",
-        )),
-        Lang::JavaScript | Lang::TypeScript | Lang::Tsx => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (member_expression property: (property_identifier) @callee))\n",
-        )),
-        Lang::Java => Some(
-            "(method_invocation name: (identifier) @callee)\n",
-        ),
-        Lang::Scala => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (identifier) @callee))\n",
-            "(infix_expression operator: (identifier) @callee)\n",
-        )),
-        Lang::C | Lang::Cpp => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
-        )),
-        Lang::Ruby => Some(
-            "(call method: (identifier) @callee)\n",
-        ),
-        Lang::Php => Some(concat!(
-            "(function_call_expression function: (name) @callee)\n",
-            "(function_call_expression function: (qualified_name) @callee)\n",
-            "(function_call_expression function: (relative_name) @callee)\n",
-            "(member_call_expression name: (name) @callee)\n",
-            "(nullsafe_member_call_expression name: (name) @callee)\n",
-            "(scoped_call_expression name: (name) @callee)\n",
-        )),
-        Lang::CSharp => Some(concat!(
-            "(invocation_expression function: (identifier) @callee)\n",
-            "(invocation_expression function: (member_access_expression name: (identifier) @callee))\n",
-        )),
-        Lang::Swift => Some(concat!(
-            "(call_expression (simple_identifier) @callee)\n",
-            "(call_expression (navigation_expression suffix: (navigation_suffix suffix: (simple_identifier) @callee)))\n",
-        )),
-        Lang::Kotlin => Some(concat!(
-            "(call_expression (identifier) @callee)\n",
-            "(call_expression (navigation_expression (identifier) @callee .))\n",
-        )),
-        Lang::Elixir => Some(concat!(
-            "(call target: (identifier) @callee)\n",
-            "(call target: (dot right: (identifier) @callee))\n",
-        )),
-        _ => None,
-    }
-}
-
-/// Global cache of compiled tree-sitter queries for callee extraction.
-///
-/// Keyed by `(symbol_count, field_count)` — a pair that uniquely identifies
-/// each grammar in practice. We avoid keying by `Language::name()` because
-/// older grammars (ABI < 15) do not register a name and would return `None`,
-/// silently disabling the cache and callee extraction entirely.
-///
-/// `Query` is `Send + Sync` in tree-sitter 0.25, so a global `Mutex`-guarded
-/// map is safe and avoids recompiling the same query on every call.
-static QUERY_CACHE: LazyLock<Mutex<HashMap<(usize, usize), tree_sitter::Query>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// Stable cache key for a tree-sitter language. Uses `(symbol_count,
-/// field_count)` which is unique for every grammar shipped with tilth.
-fn lang_cache_key(ts_lang: &tree_sitter::Language) -> (usize, usize) {
-    (ts_lang.node_kind_count(), ts_lang.field_count())
-}
-
-/// Look up or compile the callee query for `ts_lang`, then invoke `f` with a
-/// reference to the cached `Query`.  Returns `None` if compilation fails.
-pub(super) fn with_callee_query<R>(
-    ts_lang: &tree_sitter::Language,
-    query_str: &str,
-    f: impl FnOnce(&tree_sitter::Query) -> R,
-) -> Option<R> {
-    let key = lang_cache_key(ts_lang);
-    let mut cache = QUERY_CACHE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    if let std::collections::hash_map::Entry::Vacant(e) = cache.entry(key) {
-        let query = tree_sitter::Query::new(ts_lang, query_str).ok()?;
-        e.insert(query);
-    }
-    // Safety: we just inserted if absent, so the key is always present here.
-    Some(f(cache.get(&key).expect("just inserted")))
-}
-
 /// Extract names of functions/methods called within a given line range.
 /// Uses tree-sitter query patterns to find call expressions.
 ///
@@ -142,7 +39,7 @@ pub fn extract_callee_names(
         return Vec::new();
     };
 
-    let Some(query_str) = callee_query_str(lang) else {
+    let Some(query_str) = super::callee_query::callee_query_str(lang) else {
         return Vec::new();
     };
 
@@ -157,7 +54,7 @@ pub fn extract_callee_names(
 
     let content_bytes = content.as_bytes();
 
-    let Some(names) = with_callee_query(&ts_lang, query_str, |query| {
+    let Some(names) = super::callee_query::with_callee_query(&ts_lang, query_str, |query| {
         let Some(callee_idx) = query.capture_index_for_name("callee") else {
             return Vec::new();
         };
@@ -314,29 +211,16 @@ pub fn resolve_callees(
             break;
         }
 
-        // Read file content once for both bloom check and parsing
-        let Ok(import_content) = std::fs::read_to_string(&import_path) else {
+        // Read + bloom prefilter via shared helper. Skip the file when no
+        // remaining symbol is bloom-positive.
+        let Some((import_content, _mtime)) = super::bloom_walk::read_with_bloom_check(
+            &import_path,
+            remaining.iter().copied(),
+            bloom,
+            super::bloom_walk::MAX_FILE_SIZE,
+        ) else {
             continue;
         };
-
-        // Get mtime for bloom cache
-        let mtime = std::fs::metadata(&import_path)
-            .and_then(|m| m.modified())
-            .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
-
-        // Bloom pre-filter: check if ANY of the remaining symbols might be in this file
-        let mut might_have_any = false;
-        for name in &remaining {
-            if bloom.contains(&import_path, mtime, &import_content, name) {
-                might_have_any = true;
-                break;
-            }
-        }
-
-        if !might_have_any {
-            // Bloom filter says none of the symbols are in this file
-            continue;
-        }
 
         let import_type = crate::lang::detect_file_type(&import_path);
         let crate::types::FileType::Code(import_lang) = import_type else {
@@ -525,47 +409,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn grammar_cache_keys_unique() {
-        // Verify that (node_kind_count, field_count) is unique across all shipped grammars.
-        // A collision would cause one language to serve another's cached query.
-        let grammars: Vec<(&str, tree_sitter::Language)> = vec![
-            ("rust", tree_sitter_rust::LANGUAGE.into()),
-            (
-                "typescript",
-                tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into(),
-            ),
-            ("tsx", tree_sitter_typescript::LANGUAGE_TSX.into()),
-            ("javascript", tree_sitter_javascript::LANGUAGE.into()),
-            ("python", tree_sitter_python::LANGUAGE.into()),
-            ("go", tree_sitter_go::LANGUAGE.into()),
-            ("java", tree_sitter_java::LANGUAGE.into()),
-            ("c", tree_sitter_c::LANGUAGE.into()),
-            ("cpp", tree_sitter_cpp::LANGUAGE.into()),
-            ("ruby", tree_sitter_ruby::LANGUAGE.into()),
-            ("php", tree_sitter_php::LANGUAGE_PHP.into()),
-            ("scala", tree_sitter_scala::LANGUAGE.into()),
-            ("csharp", tree_sitter_c_sharp::LANGUAGE.into()),
-            ("swift", tree_sitter_swift::LANGUAGE.into()),
-            ("kotlin", tree_sitter_kotlin_ng::LANGUAGE.into()),
-            ("elixir", tree_sitter_elixir::LANGUAGE.into()),
-        ];
-        let mut seen = std::collections::HashMap::new();
-        for (name, lang) in &grammars {
-            let key = lang_cache_key(lang);
-            if let Some(prev) = seen.insert(key, name) {
-                panic!("cache key collision: {prev} and {name} both produce {key:?}");
-            }
-        }
-    }
-
-    #[test]
-    fn kotlin_callee_query_compiles() {
-        let lang: tree_sitter::Language = tree_sitter_kotlin_ng::LANGUAGE.into();
-        let query_str = callee_query_str(crate::types::Lang::Kotlin).unwrap();
-        tree_sitter::Query::new(&lang, query_str).expect("kotlin callee query should compile");
-    }
-
-    #[test]
     fn extract_kotlin_callee_names() {
         let kotlin = r#"fun example() {
     println("hello")
@@ -610,13 +453,6 @@ function run($svc): void {
         assert!(names.contains(&"staticCall".to_string()));
         assert!(names.contains(&"methodCall".to_string()));
         assert!(names.contains(&"nullableCall".to_string()));
-    }
-
-    #[test]
-    fn elixir_callee_query_compiles() {
-        let lang: tree_sitter::Language = tree_sitter_elixir::LANGUAGE.into();
-        let query_str = callee_query_str(crate::types::Lang::Elixir).unwrap();
-        tree_sitter::Query::new(&lang, query_str).expect("elixir callee query should compile");
     }
 
     #[test]

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -12,6 +12,7 @@ use crate::lang::treesitter::{
     node_text_simple, DEFINITION_KINDS,
 };
 
+use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
 use crate::lang::outline::outline_language;

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -1,18 +1,11 @@
 use std::collections::HashSet;
 use std::fmt::Write as _;
-use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 
 use streaming_iterator::StreamingIterator;
 
-use crate::lang::treesitter::{
-    extract_definition_name, extract_elixir_definition_name, is_elixir_definition,
-    node_text_simple, DEFINITION_KINDS,
-};
-
-use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
 use crate::lang::outline::outline_language;
@@ -116,32 +109,18 @@ pub(crate) fn find_callers_batch(
 
             let path = entry.path();
 
-            // Single metadata call: check size and capture mtime together
-            let (file_len, mtime) = match std::fs::metadata(path) {
-                Ok(meta) => (
-                    meta.len(),
-                    meta.modified().unwrap_or(std::time::SystemTime::UNIX_EPOCH),
-                ),
-                Err(_) => return ignore::WalkState::Continue,
-            };
-            if file_len > 500_000 {
-                return ignore::WalkState::Continue;
-            }
-
-            // Single read: read file once, use buffer for both check and parse
-            let Ok(content) = fs::read_to_string(path) else {
+            // Read + size-gate + bloom prefilter in one shared step.
+            let Some((content, _mtime)) = super::bloom_walk::read_with_bloom_check(
+                path,
+                targets,
+                bloom,
+                super::bloom_walk::MAX_FILE_SIZE,
+            ) else {
                 return ignore::WalkState::Continue;
             };
 
-            // Bloom pre-filter: skip if none of the targets are definitely in the file
-            if !targets
-                .iter()
-                .any(|t| bloom.contains(path, mtime, &content, t))
-            {
-                return ignore::WalkState::Continue;
-            }
-
-            // Fast byte check via memchr::memmem (SIMD) — skip files without any target symbol
+            // Fast byte check via memchr::memmem (SIMD) — cheap second pass that
+            // eliminates bloom false positives before tree-sitter parses.
             if !targets
                 .iter()
                 .any(|t| memchr::memmem::find(content.as_bytes(), t.as_bytes()).is_some())
@@ -189,7 +168,7 @@ fn find_callers_treesitter_batch(
     lang: crate::types::Lang,
 ) -> Vec<(String, CallerMatch)> {
     // Get the query string for this language
-    let Some(query_str) = super::callees::callee_query_str(lang) else {
+    let Some(query_str) = super::callee_query::callee_query_str(lang) else {
         return Vec::new();
     };
 
@@ -208,7 +187,7 @@ fn find_callers_treesitter_batch(
     // One Arc per file — all call sites share the same allocation.
     let shared_content: Arc<String> = Arc::new(content.to_string());
 
-    let Some(callers) = super::callees::with_callee_query(ts_lang, query_str, |query| {
+    let Some(callers) = super::callee_query::with_callee_query(ts_lang, query_str, |query| {
         let Some(callee_idx) = query.capture_index_for_name("callee") else {
             return Vec::new();
         };
@@ -277,72 +256,6 @@ fn find_callers_treesitter_batch(
     callers
 }
 
-/// Type-like node kinds that can enclose a function definition.
-const TYPE_KINDS: &[&str] = &[
-    "class_declaration",
-    "class_definition",
-    "struct_item",
-    "impl_item",
-    "interface_declaration",
-    "trait_item",
-    "trait_declaration",
-    "type_declaration",
-    "enum_item",
-    "enum_declaration",
-    "module",
-    "mod_item",
-    "namespace_definition",
-];
-
-/// Walk up the AST from `node` to the nearest definition, qualified with its
-/// enclosing type/module if one wraps it. Returns the AST node so the caller
-/// can read its kind, plus the rendered name and line range.
-fn walk_to_enclosing_definition<'a>(
-    node: tree_sitter::Node<'a>,
-    lines: &[&str],
-    lang: crate::types::Lang,
-) -> Option<(tree_sitter::Node<'a>, String, (u32, u32))> {
-    let mut current = Some(node);
-    while let Some(n) = current {
-        let def_name = if DEFINITION_KINDS.contains(&n.kind()) {
-            extract_definition_name(n, lines)
-        } else if lang == crate::types::Lang::Elixir && is_elixir_definition(n, lines) {
-            extract_elixir_definition_name(n, lines)
-        } else {
-            None
-        };
-
-        if let Some(name) = def_name {
-            let range = (
-                n.start_position().row as u32 + 1,
-                n.end_position().row as u32 + 1,
-            );
-
-            // Walk further up to find an enclosing type/module and qualify the name.
-            // `defmodule` is a `call` node, not in TYPE_KINDS, so Elixir needs a
-            // separate check to produce `Module.func`.
-            let mut parent = n.parent();
-            while let Some(p) = parent {
-                if TYPE_KINDS.contains(&p.kind()) {
-                    if let Some(type_name) = extract_definition_name(p, lines) {
-                        return Some((n, format!("{type_name}.{name}"), range));
-                    }
-                }
-                if lang == crate::types::Lang::Elixir && is_elixir_definition(p, lines) {
-                    if let Some(type_name) = extract_elixir_definition_name(p, lines) {
-                        return Some((n, format!("{type_name}.{name}"), range));
-                    }
-                }
-                parent = p.parent();
-            }
-
-            return Some((n, name, range));
-        }
-        current = n.parent();
-    }
-    None
-}
-
 /// Walk up the AST from a node to find the enclosing function definition.
 /// Returns (`function_name`, `line_range`). Top-level renders as `"<top-level>"`.
 fn find_enclosing_function(
@@ -350,104 +263,9 @@ fn find_enclosing_function(
     lines: &[&str],
     lang: crate::types::Lang,
 ) -> (String, Option<(u32, u32)>) {
-    match walk_to_enclosing_definition(node, lines, lang) {
+    match super::scope::walk_to_enclosing_definition(node, lines, lang) {
         Some((_, name, range)) => (name, Some(range)),
         None => ("<top-level>".to_string(), None),
-    }
-}
-
-/// Resolved enclosing-definition context for a (file, line). Used by the
-/// search formatter to annotate usages with their containing scope.
-#[derive(Debug)]
-pub struct EnclosingScope {
-    /// Normalized kind label (e.g. `"function"`, `"class"`, `"struct"`).
-    pub kind: &'static str,
-    /// Identifier of the definition. Qualified with its enclosing type or
-    /// module when one wraps it (e.g. `"Class.method"`, `"Module.func"`).
-    pub name: String,
-}
-
-/// Find the nearest enclosing definition for `(path, line)` by re-parsing
-/// the file with tree-sitter (cached on `OutlineCache`). AST-correct across
-/// every language tilth supports — replaces parsing the rendered outline
-/// string back into structured data.
-///
-/// Returns `None` if the file isn't a code file, the parse fails, or `line`
-/// sits at the top level outside any definition.
-pub fn enclosing_definition_at(
-    path: &Path,
-    line: u32,
-    cache: &OutlineCache,
-) -> Option<EnclosingScope> {
-    if line == 0 {
-        return None;
-    }
-    let parsed = cache.get_or_parse(path)?;
-    let lines: Vec<&str> = parsed.content.lines().collect();
-    let row = (line - 1) as usize;
-    if row >= lines.len() {
-        return None;
-    }
-
-    let point = tree_sitter::Point { row, column: 0 };
-    let target = parsed
-        .tree
-        .root_node()
-        .descendant_for_point_range(point, point)?;
-
-    let (def_node, name, _range) = walk_to_enclosing_definition(target, &lines, parsed.lang)?;
-    Some(EnclosingScope {
-        kind: kind_label(def_node, &lines, parsed.lang),
-        name,
-    })
-}
-
-/// Map a tree-sitter definition node to a short user-facing label. Every kind
-/// we handle is enumerated here, so adding a new language grammar is "add the
-/// node kind to this match" with no string heuristics elsewhere.
-fn kind_label(node: tree_sitter::Node, lines: &[&str], lang: crate::types::Lang) -> &'static str {
-    match node.kind() {
-        "function_declaration"
-        | "function_definition"
-        | "function_item"
-        | "method_definition"
-        | "method_declaration"
-        | "decorated_definition" => "function",
-        "class_declaration" | "class_definition" => "class",
-        "struct_item" => "struct",
-        "interface_declaration" => "interface",
-        "trait_declaration" | "trait_item" => "trait",
-        "type_alias_declaration" | "type_item" | "type_declaration" => "type",
-        "enum_item" | "enum_declaration" => "enum",
-        "lexical_declaration" | "variable_declaration" => "variable",
-        "const_item" | "const_declaration" => "const",
-        "static_item" => "static",
-        "property_declaration" => "property",
-        "mod_item" | "namespace_definition" => "module",
-        "object_declaration" => "object",
-        "impl_item" => "impl",
-        "export_statement" => "export",
-        "call" if lang == crate::types::Lang::Elixir => elixir_kind_label(node, lines),
-        _ => "definition",
-    }
-}
-
-/// Elixir definitions are all `call` nodes; the keyword (`def`, `defmodule`,
-/// …) lives in the call's `target` field. Map it to the same vocabulary
-/// `kind_label` produces for other languages.
-fn elixir_kind_label(node: tree_sitter::Node, lines: &[&str]) -> &'static str {
-    let Some(target) = node.child_by_field_name("target") else {
-        return "definition";
-    };
-    match node_text_simple(target, lines).as_str() {
-        "defmodule" => "module",
-        "defprotocol" => "protocol",
-        "defimpl" => "impl",
-        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
-            "function"
-        }
-        "defstruct" | "defexception" => "struct",
-        _ => "definition",
     }
 }
 
@@ -672,13 +490,6 @@ fn rank_callers(callers: &mut [CallerMatch], scope: &Path, context: Option<&Path
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::cache::OutlineCache;
-
-    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
-        let p = dir.join(name);
-        fs::write(&p, content).unwrap();
-        p
-    }
 
     #[test]
     fn no_callers_message_for_unseen_symbol_says_typo_or_scope() {
@@ -721,182 +532,5 @@ mod tests {
             msg.contains("test files"),
             "glob-driven hint should appear when glob is Some: {msg}"
         );
-    }
-
-    #[test]
-    fn enclosing_at_rust_top_level_function() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(tmp.path(), "a.rs", "fn foo() {\n    let x = 1;\n}\n");
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "foo");
-    }
-
-    #[test]
-    fn enclosing_at_rust_method_inside_mod() {
-        // mod_item has a name field; impl_item does not, so the qualifier path
-        // exercised here is mod-name → method-name.
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.rs",
-            "mod outer {\n    fn helper() {\n        let x = 1;\n    }\n}\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "outer.helper");
-    }
-
-    #[test]
-    fn enclosing_at_typescript_method_qualifies_with_class() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.ts",
-            "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "Foo.bar");
-    }
-
-    #[test]
-    fn enclosing_at_python_method_qualifies_with_class() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.py",
-            "class Foo:\n    def bar(self):\n        x = 1\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "Foo.bar");
-    }
-
-    #[test]
-    fn enclosing_at_elixir_def_qualifies_with_module() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.ex",
-            "defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "Foo.bar");
-    }
-
-    #[test]
-    fn enclosing_at_elixir_defmodule_kind_is_module() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.ex",
-            "defmodule Foo do\n  @moduledoc \"hi\"\nend\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
-        assert_eq!(scope.kind, "module");
-        assert_eq!(scope.name, "Foo");
-    }
-
-    #[test]
-    fn enclosing_at_top_level_returns_none() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(tmp.path(), "a.rs", "// just a comment\nfn foo() {}\n");
-        let cache = OutlineCache::new();
-        assert!(enclosing_definition_at(&p, 1, &cache).is_none());
-    }
-
-    #[test]
-    fn enclosing_at_zero_line_returns_none() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(tmp.path(), "a.rs", "fn foo() {}\n");
-        let cache = OutlineCache::new();
-        assert!(enclosing_definition_at(&p, 0, &cache).is_none());
-    }
-
-    #[test]
-    fn enclosing_at_non_code_returns_none() {
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(tmp.path(), "a.md", "# heading\n\nsome text\n");
-        let cache = OutlineCache::new();
-        assert!(enclosing_definition_at(&p, 3, &cache).is_none());
-    }
-
-    #[test]
-    fn enclosing_at_caches_parse_across_calls() {
-        // Two calls into the same file should reuse the cached parse —
-        // observable indirectly by mutating the file between calls without
-        // touching mtime: the first parse wins, the second sees stale data
-        // because the mtime didn't change. (Test only asserts the cache hit
-        // path returns the first-parse result.)
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(tmp.path(), "a.rs", "fn foo() { let x = 1; }\n");
-        let cache = OutlineCache::new();
-        let a = enclosing_definition_at(&p, 1, &cache).unwrap();
-        let b = enclosing_definition_at(&p, 1, &cache).unwrap();
-        assert_eq!(a.name, b.name);
-        assert_eq!(a.kind, b.kind);
-    }
-
-    #[test]
-    fn enclosing_at_kind_labels_for_common_definition_kinds() {
-        // One case per kind_label match arm beyond `function`/`module`,
-        // so a regression that miscategorizes (e.g.) a Rust `struct` as
-        // `definition` would surface here.
-        let cases: &[(&str, &str, u32, &str, &str)] = &[
-            ("a.rs", "struct Foo { x: u32 }\n", 1, "struct", "Foo"),
-            ("b.rs", "enum Color { Red, Blue }\n", 1, "enum", "Color"),
-            (
-                "c.rs",
-                "trait Greeter { fn hi(&self); }\n",
-                1,
-                "trait",
-                "Greeter",
-            ),
-            (
-                "d.ts",
-                "interface Shape { area(): number; }\n",
-                1,
-                "interface",
-                "Shape",
-            ),
-            ("e.ts", "class Widget { x = 1; }\n", 1, "class", "Widget"),
-        ];
-        let cache = OutlineCache::new();
-        for (filename, content, line, kind, name) in cases {
-            let tmp = tempfile::tempdir().unwrap();
-            let p = write(tmp.path(), filename, content);
-            let scope = enclosing_definition_at(&p, *line, &cache)
-                .unwrap_or_else(|| panic!("no scope returned for {filename}"));
-            assert_eq!(scope.kind, *kind, "kind mismatch for {filename}");
-            assert_eq!(scope.name, *name, "name mismatch for {filename}");
-        }
-    }
-
-    #[test]
-    fn enclosing_at_rust_impl_block_does_not_qualify_with_type() {
-        // tree-sitter-rust's `impl_item` exposes its type via a `type` field,
-        // not via the `name`/`identifier`/`declarator` fields that
-        // extract_definition_name probes. So methods inside `impl Foo {...}`
-        // produce the bare function name, not `"Foo.bar"`. Pre-existing
-        // behavior of find_enclosing_function — pinned here so a future
-        // qualifier improvement is an intentional, visible change.
-        let tmp = tempfile::tempdir().unwrap();
-        let p = write(
-            tmp.path(),
-            "a.rs",
-            "struct Foo;\nimpl Foo {\n    fn bar(&self) {\n        let x = 1;\n    }\n}\n",
-        );
-        let cache = OutlineCache::new();
-        let scope = enclosing_definition_at(&p, 4, &cache).unwrap();
-        assert_eq!(scope.kind, "function");
-        assert_eq!(scope.name, "bar");
     }
 }

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -7,7 +7,10 @@ use std::sync::{Arc, Mutex};
 
 use streaming_iterator::StreamingIterator;
 
-use crate::lang::treesitter::{extract_definition_name, DEFINITION_KINDS};
+use crate::lang::treesitter::{
+    extract_definition_name, extract_elixir_definition_name, is_elixir_definition,
+    node_text_simple, DEFINITION_KINDS,
+};
 
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
@@ -273,8 +276,6 @@ fn find_callers_treesitter_batch(
     callers
 }
 
-/// Walk up the AST from a node to find the enclosing function definition.
-/// Returns (`function_name`, `line_range`).
 /// Type-like node kinds that can enclose a function definition.
 const TYPE_KINDS: &[&str] = &[
     "class_declaration",
@@ -292,64 +293,161 @@ const TYPE_KINDS: &[&str] = &[
     "namespace_definition",
 ];
 
-fn find_enclosing_function(
-    node: tree_sitter::Node,
+/// Walk up the AST from `node` to the nearest definition, qualified with its
+/// enclosing type/module if one wraps it. Returns the AST node so the caller
+/// can read its kind, plus the rendered name and line range.
+fn walk_to_enclosing_definition<'a>(
+    node: tree_sitter::Node<'a>,
     lines: &[&str],
     lang: crate::types::Lang,
-) -> (String, Option<(u32, u32)>) {
-    // Walk up the tree until we find a definition node
+) -> Option<(tree_sitter::Node<'a>, String, (u32, u32))> {
     let mut current = Some(node);
-
     while let Some(n) = current {
-        let kind = n.kind();
-
-        // Check standard definition kinds, or Elixir call-node definitions
-        let def_name = if DEFINITION_KINDS.contains(&kind) {
+        let def_name = if DEFINITION_KINDS.contains(&n.kind()) {
             extract_definition_name(n, lines)
-        } else if lang == crate::types::Lang::Elixir
-            && crate::lang::treesitter::is_elixir_definition(n, lines)
-        {
-            crate::lang::treesitter::extract_elixir_definition_name(n, lines)
+        } else if lang == crate::types::Lang::Elixir && is_elixir_definition(n, lines) {
+            extract_elixir_definition_name(n, lines)
         } else {
             None
         };
 
         if let Some(name) = def_name {
-            let range = Some((
+            let range = (
                 n.start_position().row as u32 + 1,
                 n.end_position().row as u32 + 1,
-            ));
+            );
 
-            // Walk further up to find an enclosing type and qualify the name
+            // Walk further up to find an enclosing type/module and qualify the name.
+            // `defmodule` is a `call` node, not in TYPE_KINDS, so Elixir needs a
+            // separate check to produce `Module.func`.
             let mut parent = n.parent();
             while let Some(p) = parent {
                 if TYPE_KINDS.contains(&p.kind()) {
                     if let Some(type_name) = extract_definition_name(p, lines) {
-                        return (format!("{type_name}.{name}"), range);
+                        return Some((n, format!("{type_name}.{name}"), range));
                     }
                 }
-                // Elixir: `defmodule` is a `call` node, not in TYPE_KINDS, so it
-                // needs a separate check to qualify function names as Module.func.
-                if lang == crate::types::Lang::Elixir
-                    && crate::lang::treesitter::is_elixir_definition(p, lines)
-                {
-                    if let Some(type_name) =
-                        crate::lang::treesitter::extract_elixir_definition_name(p, lines)
-                    {
-                        return (format!("{type_name}.{name}"), range);
+                if lang == crate::types::Lang::Elixir && is_elixir_definition(p, lines) {
+                    if let Some(type_name) = extract_elixir_definition_name(p, lines) {
+                        return Some((n, format!("{type_name}.{name}"), range));
                     }
                 }
                 parent = p.parent();
             }
 
-            return (name, range);
+            return Some((n, name, range));
         }
-
         current = n.parent();
     }
+    None
+}
 
-    // No enclosing function found — top-level call
-    ("<top-level>".to_string(), None)
+/// Walk up the AST from a node to find the enclosing function definition.
+/// Returns (`function_name`, `line_range`). Top-level renders as `"<top-level>"`.
+fn find_enclosing_function(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    lang: crate::types::Lang,
+) -> (String, Option<(u32, u32)>) {
+    match walk_to_enclosing_definition(node, lines, lang) {
+        Some((_, name, range)) => (name, Some(range)),
+        None => ("<top-level>".to_string(), None),
+    }
+}
+
+/// Resolved enclosing-definition context for a (file, line). Used by the
+/// search formatter to annotate usages with their containing scope.
+#[derive(Debug)]
+pub struct EnclosingScope {
+    /// Normalized kind label (e.g. `"function"`, `"class"`, `"struct"`).
+    pub kind: &'static str,
+    /// Identifier of the definition. Qualified with its enclosing type or
+    /// module when one wraps it (e.g. `"Class.method"`, `"Module.func"`).
+    pub name: String,
+}
+
+/// Find the nearest enclosing definition for `(path, line)` by re-parsing
+/// the file with tree-sitter (cached on `OutlineCache`). AST-correct across
+/// every language tilth supports — replaces parsing the rendered outline
+/// string back into structured data.
+///
+/// Returns `None` if the file isn't a code file, the parse fails, or `line`
+/// sits at the top level outside any definition.
+pub fn enclosing_definition_at(
+    path: &Path,
+    line: u32,
+    cache: &OutlineCache,
+) -> Option<EnclosingScope> {
+    if line == 0 {
+        return None;
+    }
+    let parsed = cache.get_or_parse(path)?;
+    let lines: Vec<&str> = parsed.content.lines().collect();
+    let row = (line - 1) as usize;
+    if row >= lines.len() {
+        return None;
+    }
+
+    let point = tree_sitter::Point { row, column: 0 };
+    let target = parsed
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+
+    let (def_node, name, _range) = walk_to_enclosing_definition(target, &lines, parsed.lang)?;
+    Some(EnclosingScope {
+        kind: kind_label(def_node, &lines, parsed.lang),
+        name,
+    })
+}
+
+/// Map a tree-sitter definition node to a short user-facing label. Every kind
+/// we handle is enumerated here, so adding a new language grammar is "add the
+/// node kind to this match" with no string heuristics elsewhere.
+fn kind_label(node: tree_sitter::Node, lines: &[&str], lang: crate::types::Lang) -> &'static str {
+    match node.kind() {
+        "function_declaration"
+        | "function_definition"
+        | "function_item"
+        | "method_definition"
+        | "method_declaration"
+        | "decorated_definition" => "function",
+        "class_declaration" | "class_definition" => "class",
+        "struct_item" => "struct",
+        "interface_declaration" => "interface",
+        "trait_declaration" | "trait_item" => "trait",
+        "type_alias_declaration" | "type_item" | "type_declaration" => "type",
+        "enum_item" | "enum_declaration" => "enum",
+        "lexical_declaration" | "variable_declaration" => "variable",
+        "const_item" | "const_declaration" => "const",
+        "static_item" => "static",
+        "property_declaration" => "property",
+        "mod_item" | "namespace_definition" => "module",
+        "object_declaration" => "object",
+        "impl_item" => "impl",
+        "export_statement" => "export",
+        "call" if lang == crate::types::Lang::Elixir => elixir_kind_label(node, lines),
+        _ => "definition",
+    }
+}
+
+/// Elixir definitions are all `call` nodes; the keyword (`def`, `defmodule`,
+/// …) lives in the call's `target` field. Map it to the same vocabulary
+/// `kind_label` produces for other languages.
+fn elixir_kind_label(node: tree_sitter::Node, lines: &[&str]) -> &'static str {
+    let Some(target) = node.child_by_field_name("target") else {
+        return "definition";
+    };
+    match node_text_simple(target, lines).as_str() {
+        "defmodule" => "module",
+        "defprotocol" => "protocol",
+        "defimpl" => "impl",
+        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
+            "function"
+        }
+        "defstruct" | "defexception" => "struct",
+        _ => "definition",
+    }
 }
 
 /// Format and rank caller search results with optional expand.
@@ -572,8 +670,14 @@ fn rank_callers(callers: &mut [CallerMatch], scope: &Path, context: Option<&Path
 
 #[cfg(test)]
 mod tests {
-    use super::no_callers_message;
-    use std::path::Path;
+    use super::*;
+    use crate::cache::OutlineCache;
+
+    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
 
     #[test]
     fn no_callers_message_for_unseen_symbol_says_typo_or_scope() {
@@ -616,5 +720,182 @@ mod tests {
             msg.contains("test files"),
             "glob-driven hint should appear when glob is Some: {msg}"
         );
+    }
+
+    #[test]
+    fn enclosing_at_rust_top_level_function() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {\n    let x = 1;\n}\n");
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "foo");
+    }
+
+    #[test]
+    fn enclosing_at_rust_method_inside_mod() {
+        // mod_item has a name field; impl_item does not, so the qualifier path
+        // exercised here is mod-name → method-name.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "mod outer {\n    fn helper() {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "outer.helper");
+    }
+
+    #[test]
+    fn enclosing_at_typescript_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ts",
+            "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_python_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.py",
+            "class Foo:\n    def bar(self):\n        x = 1\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_def_qualifies_with_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_defmodule_kind_is_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  @moduledoc \"hi\"\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "module");
+        assert_eq!(scope.name, "Foo");
+    }
+
+    #[test]
+    fn enclosing_at_top_level_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "// just a comment\nfn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 1, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_zero_line_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 0, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_non_code_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.md", "# heading\n\nsome text\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 3, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_caches_parse_across_calls() {
+        // Two calls into the same file should reuse the cached parse —
+        // observable indirectly by mutating the file between calls without
+        // touching mtime: the first parse wins, the second sees stale data
+        // because the mtime didn't change. (Test only asserts the cache hit
+        // path returns the first-parse result.)
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() { let x = 1; }\n");
+        let cache = OutlineCache::new();
+        let a = enclosing_definition_at(&p, 1, &cache).unwrap();
+        let b = enclosing_definition_at(&p, 1, &cache).unwrap();
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.kind, b.kind);
+    }
+
+    #[test]
+    fn enclosing_at_kind_labels_for_common_definition_kinds() {
+        // One case per kind_label match arm beyond `function`/`module`,
+        // so a regression that miscategorizes (e.g.) a Rust `struct` as
+        // `definition` would surface here.
+        let cases: &[(&str, &str, u32, &str, &str)] = &[
+            ("a.rs", "struct Foo { x: u32 }\n", 1, "struct", "Foo"),
+            ("b.rs", "enum Color { Red, Blue }\n", 1, "enum", "Color"),
+            (
+                "c.rs",
+                "trait Greeter { fn hi(&self); }\n",
+                1,
+                "trait",
+                "Greeter",
+            ),
+            (
+                "d.ts",
+                "interface Shape { area(): number; }\n",
+                1,
+                "interface",
+                "Shape",
+            ),
+            ("e.ts", "class Widget { x = 1; }\n", 1, "class", "Widget"),
+        ];
+        let cache = OutlineCache::new();
+        for (filename, content, line, kind, name) in cases {
+            let tmp = tempfile::tempdir().unwrap();
+            let p = write(tmp.path(), filename, content);
+            let scope = enclosing_definition_at(&p, *line, &cache)
+                .unwrap_or_else(|| panic!("no scope returned for {filename}"));
+            assert_eq!(scope.kind, *kind, "kind mismatch for {filename}");
+            assert_eq!(scope.name, *name, "name mismatch for {filename}");
+        }
+    }
+
+    #[test]
+    fn enclosing_at_rust_impl_block_does_not_qualify_with_type() {
+        // tree-sitter-rust's `impl_item` exposes its type via a `type` field,
+        // not via the `name`/`identifier`/`declarator` fields that
+        // extract_definition_name probes. So methods inside `impl Foo {...}`
+        // produce the bare function name, not `"Foo.bar"`. Pre-existing
+        // behavior of find_enclosing_function — pinned here so a future
+        // qualifier improvement is an intentional, visible change.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "struct Foo;\nimpl Foo {\n    fn bar(&self) {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 4, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "bar");
     }
 }

--- a/src/search/content.rs
+++ b/src/search/content.rs
@@ -6,7 +6,7 @@ use super::file_metadata;
 
 use crate::error::TilthError;
 use crate::search::rank;
-use crate::types::{Match, SearchResult};
+use crate::types::{FacetTotals, Match, SearchResult};
 use grep_regex::RegexMatcher;
 use grep_searcher::sinks::UTF8;
 use grep_searcher::Searcher;
@@ -152,5 +152,6 @@ pub fn search(
         total_found: total,
         definitions: 0,
         usages: total,
+        facet_totals: FacetTotals::default(),
     })
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -422,7 +422,7 @@ fn format_grouped_usages(group: &[&Match], scope: &Path, cache: &OutlineCache, o
 
     let scope_label = enclosing_scope_label(&first.path, first.line, cache);
 
-    let _ = write!(out, "\n\n## {path_str}:{line_str} [{} usages", group.len());
+    let _ = write!(out, "\n\n### {path_str}:{line_str} [{} usages", group.len());
     if let Some(ref label) = scope_label {
         let _ = write!(out, " in {label}");
     }
@@ -1697,6 +1697,49 @@ mod tests {
         assert!(
             out.contains("[usage in function Foo.bar]"),
             "expected scope suffix in output, got: {out}"
+        );
+    }
+
+    #[test]
+    fn format_grouped_usages_emits_h3_heading() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.ts");
+        std::fs::write(
+            &p,
+            "function host() {\n  doThing();\n  doThing();\n  doThing();\n}\n",
+        )
+        .unwrap();
+
+        let mk = |line: u32| Match {
+            path: p.clone(),
+            line,
+            text: "  doThing();".to_string(),
+            is_definition: false,
+            exact: false,
+            file_lines: 5,
+            mtime: SystemTime::now(),
+            def_range: None,
+            def_name: None,
+            def_weight: 0,
+            impl_target: None,
+        };
+        let m1 = mk(2);
+        let m2 = mk(3);
+        let m3 = mk(4);
+        let group: Vec<&Match> = vec![&m1, &m2, &m3];
+        let cache = OutlineCache::new();
+        let mut out = String::new();
+        format_grouped_usages(&group, tmp.path(), &cache, &mut out);
+
+        assert!(
+            out.starts_with("\n\n### "),
+            "grouped-usage heading must be H3, got: {out:?}"
+        );
+        assert!(
+            !out.starts_with("\n\n## "),
+            "grouped-usage heading must not be H2, got: {out:?}"
         );
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1799,6 +1799,51 @@ mod tests {
         assert_eq!(label, "§Outer");
     }
 
+    /// CommonMark §4.6.1 caps ATX headings at 6 leading `#`s. 7+ hashes is
+    /// raw text, not a heading, and must not surface as the enclosing scope.
+    /// Pre-AST migration the regex matched `#######` and produced a bogus
+    /// `§# Fake Heading 7` label.
+    #[test]
+    fn markdown_scope_rejects_seven_hash_atx_heading() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(
+            &p,
+            "## Real Heading\n\nbody line\n\n####### Fake Heading 7\n\ntrailing line\n",
+        )
+        .unwrap();
+        // Line 5 is the 7-hash line; line 7 is the line after.
+        // Both should resolve to the only real heading, "Real Heading".
+        assert_eq!(
+            markdown_enclosing_scope(&p, 5),
+            Some("§Real Heading".to_string())
+        );
+        assert_eq!(
+            markdown_enclosing_scope(&p, 7),
+            Some("§Real Heading".to_string())
+        );
+    }
+
+    /// CommonMark §4.6.1 requires whitespace after the leading `#`s. `##NoSpace`
+    /// is paragraph text, not a heading. Pre-AST migration the regex accepted
+    /// it and produced `§NoSpace`.
+    #[test]
+    fn markdown_scope_rejects_no_space_atx_heading() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(&p, "## Real Heading\n\n##NoSpace\n\ntrailing line\n").unwrap();
+        // Line 3 is the no-space candidate; both line 3 and line 5 must
+        // resolve to the only real heading.
+        assert_eq!(
+            markdown_enclosing_scope(&p, 3),
+            Some("§Real Heading".to_string())
+        );
+        assert_eq!(
+            markdown_enclosing_scope(&p, 5),
+            Some("§Real Heading".to_string())
+        );
+    }
+
     #[test]
     fn format_single_match_renders_usage_scope_suffix() {
         use crate::types::Match;

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -67,6 +67,11 @@ pub(crate) const SKIP_DIRS: &[&str] = &[
 
 const EXPAND_FULL_FILE_THRESHOLD: u64 = 800;
 
+/// Cap for inlined markdown section bodies in the default preview slot.
+/// Long sections get a tail "… (N more lines — pass --expand to see the full
+/// section)" so the user knows to expand for the rest.
+const MARKDOWN_PREVIEW_MAX_LINES: usize = 40;
+
 /// Build a parallel directory walker that searches ALL files except known junk directories.
 /// Does NOT respect .gitignore — ensures gitignored but locally-relevant files are found.
 /// When `glob` is Some, applies a file-pattern override (whitelist or negation).
@@ -543,6 +548,44 @@ fn format_single_match(
             rel(&m.path, scope),
             m.line
         );
+    }
+
+    // Markdown-heading defs (`def_weight == 30`): the heading text alone is
+    // just the query, so the default preview slot would carry no information.
+    // Inline the section body directly. Bypasses the --expand budget — this
+    // is a fixed-cost preview, not the on-demand expand — and short-circuits
+    // the rest of the function (no callees / siblings etc. apply to a
+    // markdown section). On any read failure or empty body, fall through to
+    // the existing outline / single-line preview branches.
+    if m.is_definition && m.def_weight == 30 {
+        if let Some((heading_line_1, section_end_1)) = m.def_range {
+            if let Ok(content) = fs::read_to_string(&m.path) {
+                let lines: Vec<&str> = content.lines().collect();
+                // def_range is `(heading_line, section_end)` in 1-indexed
+                // inclusive form (see `find_defs_markdown_buf`). The body
+                // starts at the line *after* the heading. In 0-indexed
+                // half-open form: `[heading_line_1 .. section_end_1)`.
+                let body_start = heading_line_1 as usize;
+                let body_end = (section_end_1 as usize).min(lines.len());
+                if body_start < body_end {
+                    let total_body_lines = body_end - body_start;
+                    let take_n = total_body_lines.min(MARKDOWN_PREVIEW_MAX_LINES);
+                    out.push('\n');
+                    for line in &lines[body_start..body_start + take_n] {
+                        out.push_str(line);
+                        out.push('\n');
+                    }
+                    if total_body_lines > take_n {
+                        let truncated = total_body_lines - take_n;
+                        let _ = write!(
+                            out,
+                            "… ({truncated} more lines — pass --expand to see the full section)"
+                        );
+                    }
+                    return;
+                }
+            }
+        }
     }
 
     // Skip outline for small files — the expanded code speaks for itself
@@ -1800,6 +1843,128 @@ mod tests {
         assert_eq!(count_label(10, 14), "10/14");
         // Zero / zero — still bare (no header is emitted at zero anyway).
         assert_eq!(count_label(0, 0), "0");
+    }
+
+    #[test]
+    fn format_single_match_inlines_markdown_section_body() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("notes.md");
+        std::fs::write(
+            &p,
+            "# Top\n\n## Session 50\n\nFirst paragraph.\n\nSecond line.\n\n## Other\n\nUnrelated.\n",
+        )
+        .unwrap();
+
+        // Mimic the `Match` `find_defs_markdown_buf` would produce for a
+        // markdown-heading def: weight 30, def_range covers the section span.
+        let m = Match {
+            path: p.clone(),
+            line: 3, // `## Session 50`
+            text: "## Session 50".to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines: 10,
+            mtime: SystemTime::now(),
+            def_range: Some((3, 7)), // heading line .. section_end (1-indexed inclusive)
+            def_name: Some("Session 50".to_string()),
+            def_weight: 30,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let mut expand_remaining = 0usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        assert!(
+            out.contains("First paragraph."),
+            "section body must be inlined, got: {out:?}"
+        );
+        assert!(
+            out.contains("Second line."),
+            "section body must include later body lines, got: {out:?}"
+        );
+        assert!(
+            !out.contains("Unrelated."),
+            "must stop at section_end, got: {out:?}"
+        );
+    }
+
+    #[test]
+    fn format_single_match_caps_long_markdown_section() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("long.md");
+        // Heading on line 1, then 60 body lines.
+        let mut content = String::from("## Big Section\n");
+        for i in 0..60 {
+            let _ = write!(content, "body line {i}\n");
+        }
+        std::fs::write(&p, &content).unwrap();
+
+        let m = Match {
+            path: p.clone(),
+            line: 1,
+            text: "## Big Section".to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines: 61,
+            mtime: SystemTime::now(),
+            def_range: Some((1, 61)),
+            def_name: Some("Big Section".to_string()),
+            def_weight: 30,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let mut expand_remaining = 0usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        // Cap is 40 lines; expect 60 - 40 = 20 truncated.
+        assert!(
+            out.contains("body line 0"),
+            "first body line must appear, got: {out:?}"
+        );
+        assert!(
+            out.contains("body line 39"),
+            "last kept body line must appear, got: {out:?}"
+        );
+        assert!(
+            !out.contains("body line 40"),
+            "body line beyond cap must be trimmed, got: {out:?}"
+        );
+        assert!(
+            out.contains("20 more lines"),
+            "must signal truncated lines, got: {out:?}"
+        );
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -322,6 +322,19 @@ fn count_label(shown: usize, total: usize) -> String {
     }
 }
 
+/// Emit a per-facet hidden-count tail line after a truncated facet's entries.
+/// Wording mirrors the linear-path global tail so a reader sees a single
+/// consistent shape — only the noun changes per facet kind.
+fn write_hidden_tail(out: &mut String, shown: usize, total: usize, kind: &str) {
+    if shown < total {
+        let hidden = total - shown;
+        let _ = write!(
+            out,
+            "\n\n... and {hidden} more {kind}. Narrow with scope."
+        );
+    }
+}
+
 /// Format match entries with optional expansion.
 /// Groups consecutive usage matches in the same enclosing function to reduce token noise.
 /// Shared expand state enables cross-query dedup in multi-symbol search.
@@ -877,7 +890,11 @@ fn format_search_result(
         let faceted = facets::facet_matches(result.matches.clone(), &result.scope);
         let totals = &result.facet_totals;
 
-        // Format each non-empty facet with section headers
+        // Format each non-empty facet with section headers. After a truncated
+        // facet's entries, emit a per-facet hidden-count line (`write_hidden_tail`)
+        // so the reader sees which facet got cut. The global tail used to live
+        // at the end of `format_search_result`; on the facet path we suppress
+        // it to avoid double-counting hidden matches across two surfaces.
         if !faceted.definitions.is_empty() {
             let _ = write!(
                 out,
@@ -893,6 +910,12 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+            );
+            write_hidden_tail(
+                &mut out,
+                faceted.definitions.len(),
+                totals.definitions,
+                "definitions",
             );
         }
 
@@ -912,6 +935,12 @@ fn format_search_result(
                 &mut expanded_files,
                 &mut out,
             );
+            write_hidden_tail(
+                &mut out,
+                faceted.implementations.len(),
+                totals.implementations,
+                "implementations",
+            );
         }
 
         if !faceted.tests.is_empty() {
@@ -930,6 +959,7 @@ fn format_search_result(
                     m.text.trim()
                 );
             }
+            write_hidden_tail(&mut out, faceted.tests.len(), totals.tests, "tests");
         }
 
         if !faceted.usages_local.is_empty() {
@@ -947,6 +977,12 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+            );
+            write_hidden_tail(
+                &mut out,
+                faceted.usages_local.len(),
+                totals.usages_local,
+                "usages",
             );
         }
 
@@ -966,6 +1002,12 @@ fn format_search_result(
                 &mut expanded_files,
                 &mut out,
             );
+            write_hidden_tail(
+                &mut out,
+                faceted.usages_cross.len(),
+                totals.usages_cross,
+                "usages",
+            );
         }
     } else {
         // Linear display for ≤5 matches
@@ -979,14 +1021,17 @@ fn format_search_result(
             &mut expanded_files,
             &mut out,
         );
-    }
 
-    if result.total_found > result.matches.len() {
-        let omitted = result.total_found - result.matches.len();
-        let _ = write!(
-            out,
-            "\n\n... and {omitted} more matches. Narrow with scope."
-        );
+        // Global hidden-tail only on the linear path. The faceted path emits
+        // a per-facet line for each truncated facet above; printing both
+        // would double-count the same hidden matches.
+        if result.total_found > result.matches.len() {
+            let omitted = result.total_found - result.matches.len();
+            let _ = write!(
+                out,
+                "\n\n... and {omitted} more matches. Narrow with scope."
+            );
+        }
     }
 
     let tokens = estimate_tokens(out.len() as u64);
@@ -1718,6 +1763,30 @@ mod tests {
         assert!(
             out.contains("[usage in function Foo.bar]"),
             "expected scope suffix in output, got: {out}"
+        );
+    }
+
+    #[test]
+    fn write_hidden_tail_emits_only_when_truncated() {
+        let mut out = String::new();
+        write_hidden_tail(&mut out, 3, 3, "definitions");
+        assert!(
+            out.is_empty(),
+            "no truncation → no tail line, got {out:?}"
+        );
+
+        let mut out = String::new();
+        write_hidden_tail(&mut out, 10, 14, "definitions");
+        assert_eq!(
+            out,
+            "\n\n... and 4 more definitions. Narrow with scope."
+        );
+
+        let mut out = String::new();
+        write_hidden_tail(&mut out, 3, 27, "usages");
+        assert_eq!(
+            out,
+            "\n\n... and 24 more usages. Narrow with scope."
         );
     }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -310,6 +310,18 @@ pub fn search_glob(pattern: &str, scope: &Path) -> Result<String, TilthError> {
     format_glob_result(&result, scope)
 }
 
+/// Render the count for a facet section heading. Returns the bare displayed
+/// count when nothing was hidden (`shown == total`), or `displayed/total`
+/// when the cap dropped some entries — so a reader sees at a glance whether
+/// the facet was truncated.
+fn count_label(shown: usize, total: usize) -> String {
+    if shown >= total {
+        format!("{shown}")
+    } else {
+        format!("{shown}/{total}")
+    }
+}
+
 /// Format match entries with optional expansion.
 /// Groups consecutive usage matches in the same enclosing function to reduce token noise.
 /// Shared expand state enables cross-query dedup in multi-symbol search.
@@ -863,10 +875,15 @@ fn format_search_result(
     // Apply faceting when there are many matches (>5)
     if result.matches.len() > 5 {
         let faceted = facets::facet_matches(result.matches.clone(), &result.scope);
+        let totals = &result.facet_totals;
 
         // Format each non-empty facet with section headers
         if !faceted.definitions.is_empty() {
-            let _ = write!(out, "\n\n## Definitions ({})", faceted.definitions.len());
+            let _ = write!(
+                out,
+                "\n\n## Definitions ({})",
+                count_label(faceted.definitions.len(), totals.definitions)
+            );
             format_matches(
                 &faceted.definitions,
                 &result.scope,
@@ -883,7 +900,7 @@ fn format_search_result(
             let _ = write!(
                 out,
                 "\n\n## Implementations ({})",
-                faceted.implementations.len()
+                count_label(faceted.implementations.len(), totals.implementations)
             );
             format_matches(
                 &faceted.implementations,
@@ -898,7 +915,11 @@ fn format_search_result(
         }
 
         if !faceted.tests.is_empty() {
-            let _ = write!(out, "\n\n## Tests ({})", faceted.tests.len());
+            let _ = write!(
+                out,
+                "\n\n## Tests ({})",
+                count_label(faceted.tests.len(), totals.tests)
+            );
             // Compact test format — one line per match, no expand budget consumed
             for m in &faceted.tests {
                 let _ = write!(
@@ -915,7 +936,7 @@ fn format_search_result(
             let _ = write!(
                 out,
                 "\n\n## Usages — same package ({})",
-                faceted.usages_local.len()
+                count_label(faceted.usages_local.len(), totals.usages_local)
             );
             format_matches(
                 &faceted.usages_local,
@@ -933,7 +954,7 @@ fn format_search_result(
             let _ = write!(
                 out,
                 "\n\n## Usages — other ({})",
-                faceted.usages_cross.len()
+                count_label(faceted.usages_cross.len(), totals.usages_cross)
             );
             format_matches(
                 &faceted.usages_cross,
@@ -1698,6 +1719,18 @@ mod tests {
             out.contains("[usage in function Foo.bar]"),
             "expected scope suffix in output, got: {out}"
         );
+    }
+
+    #[test]
+    fn count_label_renders_displayed_over_total_only_when_truncated() {
+        // No truncation — bare count.
+        assert_eq!(count_label(3, 3), "3");
+        // Defensive: shown > total (shouldn't happen in practice) — bare count.
+        assert_eq!(count_label(4, 3), "4");
+        // Truncated — displayed/total form.
+        assert_eq!(count_label(10, 14), "10/14");
+        // Zero / zero — still bare (no header is emitted at zero anyway).
+        assert_eq!(count_label(0, 0), "0");
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1285,49 +1285,69 @@ fn enclosing_scope_label(
     }
 }
 
-/// Find the nearest preceding ATX heading (`#`–`######`) above `match_line`.
-/// Markdown has no AST in tilth, so a backwards line walk is the right tool —
-/// kept narrow so it can't drift into other markdown semantics.
+/// Find the deepest ATX-heading section that encloses `match_line`. Returns
+/// the heading text prefixed with `§`. A `# foo` line inside a fenced or
+/// indented code block is NOT a heading — the tree-sitter-md block grammar
+/// owns that distinction, so we don't need our own fence pre-pass.
 fn markdown_enclosing_scope(path: &std::path::Path, match_line: u32) -> Option<String> {
     if match_line == 0 {
         return None;
     }
     let content = std::fs::read_to_string(path).ok()?;
+    let tree = crate::lang::outline::parse_markdown(&content)?;
     let lines: Vec<&str> = content.lines().collect();
-    let start = (match_line as usize).min(lines.len()).saturating_sub(1);
-    for line in lines[..=start].iter().rev() {
-        let trimmed = line.trim_start();
-        if !trimmed.starts_with('#') {
+    let mut best: Option<(tree_sitter::Node, u32)> = None;
+    walk_md_for_enclosing(tree.root_node(), match_line, &mut best);
+    let (heading, _) = best?;
+    let text = crate::lang::outline::heading_text(heading, &lines);
+    if text.is_empty() {
+        return None;
+    }
+    let display: String = if text.chars().count() > 60 {
+        let mut s: String = text.chars().take(57).collect();
+        s.push_str("...");
+        s
+    } else {
+        text
+    };
+    Some(format!("§{display}"))
+}
+
+fn walk_md_for_enclosing<'a>(
+    node: tree_sitter::Node<'a>,
+    match_line: u32,
+    best: &mut Option<(tree_sitter::Node<'a>, u32)>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        if child.kind() != "section" {
             continue;
         }
-        let mut hashes = 0;
-        let mut rest = trimmed;
-        while hashes < 6 {
-            match rest.strip_prefix('#') {
-                Some(r) => {
-                    hashes += 1;
-                    rest = r;
-                }
-                None => break,
+        let start = (child.start_position().row + 1) as u32;
+        let end_excl = child.end_position();
+        let end = if end_excl.column == 0 {
+            end_excl.row as u32
+        } else {
+            (end_excl.row + 1) as u32
+        };
+        if match_line < start || match_line > end {
+            continue;
+        }
+        // Section contains match_line. Record its heading if it has one,
+        // then recurse to find a deeper section.
+        let mut sec_cursor = child.walk();
+        if let Some(heading) = child
+            .children(&mut sec_cursor)
+            .find(|c| c.kind() == "atx_heading")
+        {
+            // Update best to the *deepest* (largest start_line) match.
+            match best {
+                Some((_, prev_start)) if *prev_start >= start => {}
+                _ => *best = Some((heading, start)),
             }
         }
-        if hashes == 0 {
-            continue;
-        }
-        let text = rest.trim_start_matches([' ', '\t']).trim_end();
-        if text.is_empty() {
-            continue;
-        }
-        let display: String = if text.chars().count() > 60 {
-            let mut s: String = text.chars().take(57).collect();
-            s.push_str("...");
-            s
-        } else {
-            text.to_string()
-        };
-        return Some(format!("§{display}"));
+        walk_md_for_enclosing(child, match_line, best);
     }
-    None
 }
 
 /// Extract (`start_line`, `end_line`) from an outline entry like "[20-115]" or "[16]".
@@ -1762,6 +1782,24 @@ mod tests {
         let p = tmp.path().join("a.md");
         std::fs::write(&p, "preamble line one\npreamble line two\n").unwrap();
         assert!(markdown_enclosing_scope(&p, 2).is_none());
+    }
+
+    /// `#`-prefixed lines inside fenced code blocks are NOT headings, so they
+    /// must not become the enclosing scope label of usages on adjacent lines.
+    /// Pre-fix this returned `§...` derived from a Python comment inside the
+    /// fence; post-fix the AST owns the distinction.
+    #[test]
+    fn markdown_scope_skips_hashes_inside_fenced_code() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(
+            &p,
+            "## Outer\n\nbefore fence\n\n```python\n# fake heading\nx = 1\n```\n\nafter fence\n",
+        )
+        .unwrap();
+        // Line 7 (`x = 1`) is inside the fence; the only real heading is `## Outer`.
+        let label = markdown_enclosing_scope(&p, 7).unwrap();
+        assert_eq!(label, "§Outer");
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -11,6 +11,10 @@ pub mod strip;
 pub mod symbol;
 pub mod truncate;
 
+mod bloom_walk;
+mod callee_query;
+pub mod scope;
+
 use std::collections::HashSet;
 use std::fmt::Write;
 use std::fs;
@@ -1274,8 +1278,8 @@ fn enclosing_scope_label(
 ) -> Option<String> {
     match crate::lang::detect_file_type(path) {
         FileType::Code(_) => {
-            let scope = callers::enclosing_definition_at(path, match_line, cache)?;
-            Some(format!("{} {}", scope.kind, scope.name))
+            let s = scope::enclosing_definition_at(path, match_line, cache)?;
+            Some(format!("{} {}", s.kind, s.name))
         }
         FileType::Markdown => markdown_enclosing_scope(path, match_line),
         _ => None,

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -2040,6 +2040,96 @@ mod tests {
             out.contains("20 more lines"),
             "must signal truncated lines, got: {out:?}"
         );
+        assert!(
+            out.contains("--expand"),
+            "tail must point to --expand for full section, got: {out:?}"
+        );
+    }
+
+    /// 99c4a3d's docstring is explicit: the markdown-section preview is a
+    /// fixed-cost short-circuit that bypasses the --expand budget. This pins
+    /// that intent — passing a non-zero `expand_remaining` must NOT cause
+    /// the renderer to skip the cap. Without this guard, a future refactor
+    /// could "fix" the short-circuit by routing through expand and turn
+    /// every markdown-heading match into a multi-hundred-line preview.
+    #[test]
+    fn format_single_match_markdown_cap_bypasses_expand_budget() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("long.md");
+        let mut content = String::from("## Big Section\n");
+        for i in 0..60 {
+            let _ = write!(content, "body line {i}\n");
+        }
+        std::fs::write(&p, &content).unwrap();
+
+        let m = Match {
+            path: p.clone(),
+            line: 1,
+            text: "## Big Section".to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines: 61,
+            mtime: SystemTime::now(),
+            def_range: Some((1, 61)),
+            def_name: Some("Big Section".to_string()),
+            def_weight: 30,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        // Non-zero expand budget — should NOT change the cap behavior.
+        let mut expand_remaining = 5usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        // Body lines beyond the cap must still be trimmed.
+        assert!(
+            !out.contains("body line 40"),
+            "cap must apply even with non-zero expand budget, got: {out:?}"
+        );
+        assert!(
+            out.contains("20 more lines"),
+            "tail must still report truncated lines, got: {out:?}"
+        );
+        // Budget must be untouched — short-circuit returns before consuming it.
+        assert_eq!(
+            expand_remaining, 5,
+            "markdown short-circuit must not consume expand budget"
+        );
+    }
+
+    /// Worst-case bound: with MAX_MATCHES = 10 markdown-heading defs each
+    /// hitting the 40-line preview cap, total inlined preview content is at
+    /// most 10 × 40 = 400 lines. This pins the bound by exercising the cap
+    /// and asserting the truncation shape, so a future bump of either
+    /// constant can't silently inflate worst-case output without updating
+    /// the test.
+    #[test]
+    fn markdown_preview_cap_constant_unchanged() {
+        // Pin both constants — if either changes, this assertion fails and
+        // the test author has to consider the worst-case product (currently
+        // 10 * 40 = 400 lines extra in default preview, on top of the
+        // outline context per match).
+        assert_eq!(
+            MARKDOWN_PREVIEW_MAX_LINES, 40,
+            "if you change MARKDOWN_PREVIEW_MAX_LINES, also re-evaluate the \
+             MAX_MATCHES * MARKDOWN_PREVIEW_MAX_LINES worst-case bound \
+             (currently 10 * 40 = 400 lines per search response)"
+        );
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -333,10 +333,7 @@ fn count_label(shown: usize, total: usize) -> String {
 fn write_hidden_tail(out: &mut String, shown: usize, total: usize, kind: &str) {
     if shown < total {
         let hidden = total - shown;
-        let _ = write!(
-            out,
-            "\n\n... and {hidden} more {kind}. Narrow with scope."
-        );
+        let _ = write!(out, "\n\n... and {hidden} more {kind}. Narrow with scope.");
     }
 }
 
@@ -1851,24 +1848,15 @@ mod tests {
     fn write_hidden_tail_emits_only_when_truncated() {
         let mut out = String::new();
         write_hidden_tail(&mut out, 3, 3, "definitions");
-        assert!(
-            out.is_empty(),
-            "no truncation → no tail line, got {out:?}"
-        );
+        assert!(out.is_empty(), "no truncation → no tail line, got {out:?}");
 
         let mut out = String::new();
         write_hidden_tail(&mut out, 10, 14, "definitions");
-        assert_eq!(
-            out,
-            "\n\n... and 4 more definitions. Narrow with scope."
-        );
+        assert_eq!(out, "\n\n... and 4 more definitions. Narrow with scope.");
 
         let mut out = String::new();
         write_hidden_tail(&mut out, 3, 27, "usages");
-        assert_eq!(
-            out,
-            "\n\n... and 24 more usages. Narrow with scope."
-        );
+        assert_eq!(out, "\n\n... and 24 more usages. Narrow with scope.");
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -420,21 +420,11 @@ fn format_grouped_usages(group: &[&Match], scope: &Path, cache: &OutlineCache, o
     let lines: Vec<u32> = group.iter().map(|m| m.line).collect();
     let line_str = format_line_list(&lines);
 
-    // Get enclosing function name from outline
-    let fn_name = get_outline_str(&first.path, cache).and_then(|outline_str| {
-        let outline_lines: Vec<&str> = outline_str.lines().collect();
-        let idx = outline_lines.iter().position(|line| {
-            extract_line_range(line).is_some_and(|(s, e)| first.line >= s && first.line <= e)
-        })?;
-        // Extract name: outline lines look like "  [45-79]      fn TestMiddlewareNoRoute"
-        let entry = outline_lines[idx].trim();
-        // Find the name after "fn " or similar keyword
-        entry.split_whitespace().last().map(String::from)
-    });
+    let scope_label = enclosing_scope_label(&first.path, first.line, cache);
 
     let _ = write!(out, "\n\n## {path_str}:{line_str} [{} usages", group.len());
-    if let Some(ref name) = fn_name {
-        let _ = write!(out, " in {name}");
+    if let Some(ref label) = scope_label {
+        let _ = write!(out, " in {label}");
     }
     out.push(']');
 
@@ -498,6 +488,16 @@ fn format_single_match(
         "usage"
     };
 
+    // For usages, append the enclosing function/section if we can recover one.
+    // Definitions and impls already are the named scope.
+    let scope_suffix = if m.is_definition || m.impl_target.is_some() {
+        String::new()
+    } else {
+        enclosing_scope_label(&m.path, m.line, cache)
+            .map(|s| format!(" in {s}"))
+            .unwrap_or_default()
+    };
+
     // Show line range for definitions with def_range, otherwise just the line
     if m.is_definition {
         if let Some((start, end)) = m.def_range {
@@ -512,7 +512,12 @@ fn format_single_match(
             let _ = write!(out, "\n\n## {}:{} [{kind}]", rel(&m.path, scope), m.line);
         }
     } else {
-        let _ = write!(out, "\n\n## {}:{} [{kind}]", rel(&m.path, scope), m.line);
+        let _ = write!(
+            out,
+            "\n\n## {}:{} [{kind}{scope_suffix}]",
+            rel(&m.path, scope),
+            m.line
+        );
     }
 
     // Skip outline for small files — the expanded code speaks for itself
@@ -1152,6 +1157,70 @@ fn outline_context_for_match(
     Some(context)
 }
 
+/// Annotate a usage match with its enclosing scope: `"function foo"` /
+/// `"class Bar"` for code (via tree-sitter), `"§Heading"` for markdown
+/// (via line walk). Returns `None` for top-level matches and unsupported
+/// file types — the formatter renders those without an `in …` suffix.
+fn enclosing_scope_label(
+    path: &std::path::Path,
+    match_line: u32,
+    cache: &OutlineCache,
+) -> Option<String> {
+    match crate::lang::detect_file_type(path) {
+        FileType::Code(_) => {
+            let scope = callers::enclosing_definition_at(path, match_line, cache)?;
+            Some(format!("{} {}", scope.kind, scope.name))
+        }
+        FileType::Markdown => markdown_enclosing_scope(path, match_line),
+        _ => None,
+    }
+}
+
+/// Find the nearest preceding ATX heading (`#`–`######`) above `match_line`.
+/// Markdown has no AST in tilth, so a backwards line walk is the right tool —
+/// kept narrow so it can't drift into other markdown semantics.
+fn markdown_enclosing_scope(path: &std::path::Path, match_line: u32) -> Option<String> {
+    if match_line == 0 {
+        return None;
+    }
+    let content = std::fs::read_to_string(path).ok()?;
+    let lines: Vec<&str> = content.lines().collect();
+    let start = (match_line as usize).min(lines.len()).saturating_sub(1);
+    for line in lines[..=start].iter().rev() {
+        let trimmed = line.trim_start();
+        if !trimmed.starts_with('#') {
+            continue;
+        }
+        let mut hashes = 0;
+        let mut rest = trimmed;
+        while hashes < 6 {
+            match rest.strip_prefix('#') {
+                Some(r) => {
+                    hashes += 1;
+                    rest = r;
+                }
+                None => break,
+            }
+        }
+        if hashes == 0 {
+            continue;
+        }
+        let text = rest.trim_start_matches([' ', '\t']).trim_end();
+        if text.is_empty() {
+            continue;
+        }
+        let display: String = if text.chars().count() > 60 {
+            let mut s: String = text.chars().take(57).collect();
+            s.push_str("...");
+            s
+        } else {
+            text.to_string()
+        };
+        return Some(format!("§{display}"));
+    }
+    None
+}
+
 /// Extract (`start_line`, `end_line`) from an outline entry like "[20-115]" or "[16]".
 fn extract_line_range(line: &str) -> Option<(u32, u32)> {
     let trimmed = line.trim();
@@ -1536,6 +1605,98 @@ mod tests {
             result.total_found >= 2,
             "expected symbol found via both real and symlinked paths, got {}",
             result.total_found
+        );
+    }
+
+    // ── enclosing_scope_label / markdown tests ──
+
+    #[test]
+    fn scope_label_code_combines_kind_and_name() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.ts");
+        std::fs::write(&p, "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n").unwrap();
+        let cache = OutlineCache::new();
+        let label = enclosing_scope_label(&p, 3, &cache).unwrap();
+        assert_eq!(label, "function Foo.bar");
+    }
+
+    #[test]
+    fn scope_label_markdown_returns_section() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(
+            &p,
+            "# Top\n\n## Cost Accounting\n\nsome text\n\nmore text\n",
+        )
+        .unwrap();
+        let cache = OutlineCache::new();
+        let label = enclosing_scope_label(&p, 7, &cache).unwrap();
+        assert_eq!(label, "§Cost Accounting");
+    }
+
+    #[test]
+    fn markdown_scope_truncates_long_headings() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        let long = "x".repeat(80);
+        std::fs::write(&p, format!("## {long}\n\nbody\n")).unwrap();
+        let label = markdown_enclosing_scope(&p, 3).unwrap();
+        // 60-char window means 57 chars + "..." (display starts after the "§").
+        assert!(label.starts_with("§"));
+        assert!(label.ends_with("..."));
+        assert_eq!(label.chars().count(), 1 + 57 + 3);
+    }
+
+    #[test]
+    fn markdown_scope_returns_none_before_first_heading() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.md");
+        std::fs::write(&p, "preamble line one\npreamble line two\n").unwrap();
+        assert!(markdown_enclosing_scope(&p, 2).is_none());
+    }
+
+    #[test]
+    fn format_single_match_renders_usage_scope_suffix() {
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.ts");
+        std::fs::write(&p, "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n").unwrap();
+
+        let m = Match {
+            path: p.clone(),
+            line: 3,
+            text: "    const x = 1;".to_string(),
+            is_definition: false,
+            exact: false,
+            file_lines: 5,
+            mtime: SystemTime::now(),
+            def_range: None,
+            def_name: None,
+            def_weight: 0,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let mut expand_remaining = 0usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        assert!(
+            out.contains("[usage in function Foo.bar]"),
+            "expected scope suffix in output, got: {out}"
         );
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -503,18 +503,18 @@ fn format_single_match(
         if let Some((start, end)) = m.def_range {
             let _ = write!(
                 out,
-                "\n\n## {}:{}-{} [{kind}]",
+                "\n\n### {}:{}-{} [{kind}]",
                 rel(&m.path, scope),
                 start,
                 end
             );
         } else {
-            let _ = write!(out, "\n\n## {}:{} [{kind}]", rel(&m.path, scope), m.line);
+            let _ = write!(out, "\n\n### {}:{} [{kind}]", rel(&m.path, scope), m.line);
         }
     } else {
         let _ = write!(
             out,
-            "\n\n## {}:{} [{kind}{scope_suffix}]",
+            "\n\n### {}:{} [{kind}{scope_suffix}]",
             rel(&m.path, scope),
             m.line
         );
@@ -830,7 +830,7 @@ fn basename_file_outline(
     let rel_path = rel(&matched_path, scope);
     let line_count = content.lines().count();
     Some(format!(
-        "### File overview: {rel_path} ({line_count} lines)\n{outline}"
+        "## File overview: {rel_path} ({line_count} lines)\n{outline}"
     ))
 }
 
@@ -866,7 +866,7 @@ fn format_search_result(
 
         // Format each non-empty facet with section headers
         if !faceted.definitions.is_empty() {
-            let _ = write!(out, "\n\n### Definitions ({})", faceted.definitions.len());
+            let _ = write!(out, "\n\n## Definitions ({})", faceted.definitions.len());
             format_matches(
                 &faceted.definitions,
                 &result.scope,
@@ -882,7 +882,7 @@ fn format_search_result(
         if !faceted.implementations.is_empty() {
             let _ = write!(
                 out,
-                "\n\n### Implementations ({})",
+                "\n\n## Implementations ({})",
                 faceted.implementations.len()
             );
             format_matches(
@@ -898,7 +898,7 @@ fn format_search_result(
         }
 
         if !faceted.tests.is_empty() {
-            let _ = write!(out, "\n\n### Tests ({})", faceted.tests.len());
+            let _ = write!(out, "\n\n## Tests ({})", faceted.tests.len());
             // Compact test format — one line per match, no expand budget consumed
             for m in &faceted.tests {
                 let _ = write!(
@@ -914,7 +914,7 @@ fn format_search_result(
         if !faceted.usages_local.is_empty() {
             let _ = write!(
                 out,
-                "\n\n### Usages — same package ({})",
+                "\n\n## Usages — same package ({})",
                 faceted.usages_local.len()
             );
             format_matches(
@@ -932,7 +932,7 @@ fn format_search_result(
         if !faceted.usages_cross.is_empty() {
             let _ = write!(
                 out,
-                "\n\n### Usages — other ({})",
+                "\n\n## Usages — other ({})",
                 faceted.usages_cross.len()
             );
             format_matches(

--- a/src/search/scope.rs
+++ b/src/search/scope.rs
@@ -1,0 +1,364 @@
+//! Enclosing-scope annotator: given a `(file, line)`, return the nearest
+//! enclosing definition, qualified with its containing type or module.
+//! Used by the search formatter to annotate usages with their containing
+//! function/class/module, and internally by `callers::find_enclosing_function`
+//! when reporting the calling-function context of a call site.
+
+use std::path::Path;
+
+use crate::cache::OutlineCache;
+use crate::lang::treesitter::{
+    extract_definition_name, extract_elixir_definition_name, is_elixir_definition,
+    node_text_simple, DEFINITION_KINDS,
+};
+
+/// Type-like node kinds that can enclose a function definition.
+const TYPE_KINDS: &[&str] = &[
+    "class_declaration",
+    "class_definition",
+    "struct_item",
+    "impl_item",
+    "interface_declaration",
+    "trait_item",
+    "trait_declaration",
+    "type_declaration",
+    "enum_item",
+    "enum_declaration",
+    "module",
+    "mod_item",
+    "namespace_definition",
+];
+
+/// Resolved enclosing-definition context for a (file, line). Used by the
+/// search formatter to annotate usages with their containing scope.
+#[derive(Debug)]
+pub struct EnclosingScope {
+    /// Normalized kind label (e.g. `"function"`, `"class"`, `"struct"`).
+    pub kind: &'static str,
+    /// Identifier of the definition. Qualified with its enclosing type or
+    /// module when one wraps it (e.g. `"Class.method"`, `"Module.func"`).
+    pub name: String,
+}
+
+/// Walk up the AST from `node` to the nearest definition, qualified with its
+/// enclosing type/module if one wraps it. Returns the AST node so the caller
+/// can read its kind, plus the rendered name and line range.
+pub(super) fn walk_to_enclosing_definition<'a>(
+    node: tree_sitter::Node<'a>,
+    lines: &[&str],
+    lang: crate::types::Lang,
+) -> Option<(tree_sitter::Node<'a>, String, (u32, u32))> {
+    let mut current = Some(node);
+    while let Some(n) = current {
+        let def_name = if DEFINITION_KINDS.contains(&n.kind()) {
+            extract_definition_name(n, lines)
+        } else if lang == crate::types::Lang::Elixir && is_elixir_definition(n, lines) {
+            extract_elixir_definition_name(n, lines)
+        } else {
+            None
+        };
+
+        if let Some(name) = def_name {
+            let range = (
+                n.start_position().row as u32 + 1,
+                n.end_position().row as u32 + 1,
+            );
+
+            // Walk further up to find an enclosing type/module and qualify the name.
+            // `defmodule` is a `call` node, not in TYPE_KINDS, so Elixir needs a
+            // separate check to produce `Module.func`.
+            let mut parent = n.parent();
+            while let Some(p) = parent {
+                if TYPE_KINDS.contains(&p.kind()) {
+                    if let Some(type_name) = extract_definition_name(p, lines) {
+                        return Some((n, format!("{type_name}.{name}"), range));
+                    }
+                }
+                if lang == crate::types::Lang::Elixir && is_elixir_definition(p, lines) {
+                    if let Some(type_name) = extract_elixir_definition_name(p, lines) {
+                        return Some((n, format!("{type_name}.{name}"), range));
+                    }
+                }
+                parent = p.parent();
+            }
+
+            return Some((n, name, range));
+        }
+        current = n.parent();
+    }
+    None
+}
+
+/// Find the nearest enclosing definition for `(path, line)` by re-parsing
+/// the file with tree-sitter (cached on `OutlineCache`). AST-correct across
+/// every language tilth supports — replaces parsing the rendered outline
+/// string back into structured data.
+///
+/// Returns `None` if the file isn't a code file, the parse fails, or `line`
+/// sits at the top level outside any definition.
+pub fn enclosing_definition_at(
+    path: &Path,
+    line: u32,
+    cache: &OutlineCache,
+) -> Option<EnclosingScope> {
+    if line == 0 {
+        return None;
+    }
+    let parsed = cache.get_or_parse(path)?;
+    let lines: Vec<&str> = parsed.content.lines().collect();
+    let row = (line - 1) as usize;
+    if row >= lines.len() {
+        return None;
+    }
+
+    let point = tree_sitter::Point { row, column: 0 };
+    let target = parsed
+        .tree
+        .root_node()
+        .descendant_for_point_range(point, point)?;
+
+    let (def_node, name, _range) = walk_to_enclosing_definition(target, &lines, parsed.lang)?;
+    Some(EnclosingScope {
+        kind: kind_label(def_node, &lines, parsed.lang),
+        name,
+    })
+}
+
+/// Map a tree-sitter definition node to a short user-facing label. Every kind
+/// we handle is enumerated here, so adding a new language grammar is "add the
+/// node kind to this match" with no string heuristics elsewhere.
+fn kind_label(node: tree_sitter::Node, lines: &[&str], lang: crate::types::Lang) -> &'static str {
+    match node.kind() {
+        "function_declaration"
+        | "function_definition"
+        | "function_item"
+        | "method_definition"
+        | "method_declaration"
+        | "decorated_definition" => "function",
+        "class_declaration" | "class_definition" => "class",
+        "struct_item" => "struct",
+        "interface_declaration" => "interface",
+        "trait_declaration" | "trait_item" => "trait",
+        "type_alias_declaration" | "type_item" | "type_declaration" => "type",
+        "enum_item" | "enum_declaration" => "enum",
+        "lexical_declaration" | "variable_declaration" => "variable",
+        "const_item" | "const_declaration" => "const",
+        "static_item" => "static",
+        "property_declaration" => "property",
+        "mod_item" | "namespace_definition" => "module",
+        "object_declaration" => "object",
+        "impl_item" => "impl",
+        "export_statement" => "export",
+        "call" if lang == crate::types::Lang::Elixir => elixir_kind_label(node, lines),
+        _ => "definition",
+    }
+}
+
+/// Elixir definitions are all `call` nodes; the keyword (`def`, `defmodule`,
+/// …) lives in the call's `target` field. Map it to the same vocabulary
+/// `kind_label` produces for other languages.
+fn elixir_kind_label(node: tree_sitter::Node, lines: &[&str]) -> &'static str {
+    let Some(target) = node.child_by_field_name("target") else {
+        return "definition";
+    };
+    match node_text_simple(target, lines).as_str() {
+        "defmodule" => "module",
+        "defprotocol" => "protocol",
+        "defimpl" => "impl",
+        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
+            "function"
+        }
+        "defstruct" | "defexception" => "struct",
+        _ => "definition",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    fn write(dir: &Path, name: &str, content: &str) -> PathBuf {
+        let p = dir.join(name);
+        fs::write(&p, content).unwrap();
+        p
+    }
+
+    #[test]
+    fn enclosing_at_rust_top_level_function() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {\n    let x = 1;\n}\n");
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "foo");
+    }
+
+    #[test]
+    fn enclosing_at_rust_method_inside_mod() {
+        // mod_item has a name field; impl_item does not, so the qualifier path
+        // exercised here is mod-name → method-name.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "mod outer {\n    fn helper() {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "outer.helper");
+    }
+
+    #[test]
+    fn enclosing_at_typescript_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ts",
+            "class Foo {\n  bar() {\n    const x = 1;\n  }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_python_method_qualifies_with_class() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.py",
+            "class Foo:\n    def bar(self):\n        x = 1\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_def_qualifies_with_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  def bar do\n    :ok\n  end\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 3, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "Foo.bar");
+    }
+
+    #[test]
+    fn enclosing_at_elixir_defmodule_kind_is_module() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.ex",
+            "defmodule Foo do\n  @moduledoc \"hi\"\nend\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 2, &cache).unwrap();
+        assert_eq!(scope.kind, "module");
+        assert_eq!(scope.name, "Foo");
+    }
+
+    #[test]
+    fn enclosing_at_top_level_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "// just a comment\nfn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 1, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_zero_line_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() {}\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 0, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_non_code_returns_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.md", "# heading\n\nsome text\n");
+        let cache = OutlineCache::new();
+        assert!(enclosing_definition_at(&p, 3, &cache).is_none());
+    }
+
+    #[test]
+    fn enclosing_at_caches_parse_across_calls() {
+        // Two calls into the same file should reuse the cached parse —
+        // observable indirectly by mutating the file between calls without
+        // touching mtime: the first parse wins, the second sees stale data
+        // because the mtime didn't change. (Test only asserts the cache hit
+        // path returns the first-parse result.)
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(tmp.path(), "a.rs", "fn foo() { let x = 1; }\n");
+        let cache = OutlineCache::new();
+        let a = enclosing_definition_at(&p, 1, &cache).unwrap();
+        let b = enclosing_definition_at(&p, 1, &cache).unwrap();
+        assert_eq!(a.name, b.name);
+        assert_eq!(a.kind, b.kind);
+    }
+
+    #[test]
+    fn enclosing_at_kind_labels_for_common_definition_kinds() {
+        // One case per kind_label match arm beyond `function`/`module`,
+        // so a regression that miscategorizes (e.g.) a Rust `struct` as
+        // `definition` would surface here.
+        let cases: &[(&str, &str, u32, &str, &str)] = &[
+            ("a.rs", "struct Foo { x: u32 }\n", 1, "struct", "Foo"),
+            ("b.rs", "enum Color { Red, Blue }\n", 1, "enum", "Color"),
+            (
+                "c.rs",
+                "trait Greeter { fn hi(&self); }\n",
+                1,
+                "trait",
+                "Greeter",
+            ),
+            (
+                "d.ts",
+                "interface Shape { area(): number; }\n",
+                1,
+                "interface",
+                "Shape",
+            ),
+            ("e.ts", "class Widget { x = 1; }\n", 1, "class", "Widget"),
+        ];
+        let cache = OutlineCache::new();
+        for (filename, content, line, kind, name) in cases {
+            let tmp = tempfile::tempdir().unwrap();
+            let p = write(tmp.path(), filename, content);
+            let scope = enclosing_definition_at(&p, *line, &cache)
+                .unwrap_or_else(|| panic!("no scope returned for {filename}"));
+            assert_eq!(scope.kind, *kind, "kind mismatch for {filename}");
+            assert_eq!(scope.name, *name, "name mismatch for {filename}");
+        }
+    }
+
+    #[test]
+    fn enclosing_at_rust_impl_block_does_not_qualify_with_type() {
+        // tree-sitter-rust's `impl_item` exposes its type via a `type` field,
+        // not via the `name`/`identifier`/`declarator` fields that
+        // extract_definition_name probes. So methods inside `impl Foo {...}`
+        // produce the bare function name, not `"Foo.bar"`. Pre-existing
+        // behavior of find_enclosing_function — pinned here so a future
+        // qualifier improvement is an intentional, visible change.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = write(
+            tmp.path(),
+            "a.rs",
+            "struct Foo;\nimpl Foo {\n    fn bar(&self) {\n        let x = 1;\n    }\n}\n",
+        );
+        let cache = OutlineCache::new();
+        let scope = enclosing_definition_at(&p, 4, &cache).unwrap();
+        assert_eq!(scope.kind, "function");
+        assert_eq!(scope.name, "bar");
+    }
+}

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -27,15 +27,13 @@ const EARLY_QUIT_THRESHOLD_DEFINITIONS: usize = 50;
 const EARLY_QUIT_THRESHOLD_USAGES: usize = MAX_MATCHES * 3;
 
 /// Display-side stratum: 0 = code def, 1 = doc-heading def, 2 = usage. Used
-/// as a stable sort key after `rank::sort` so the MAX_MATCHES cap can't drop
+/// as a stable sort key after `rank::sort` so the `MAX_MATCHES` cap can't drop
 /// real code defs in favor of markdown-heading defs of the same query.
 fn stratum_for_display(m: &Match) -> u8 {
-    if !m.is_definition {
-        2
-    } else if m.def_weight >= 60 {
-        0
+    if m.is_definition {
+        u8::from(m.def_weight < 60)
     } else {
-        1
+        2
     }
 }
 
@@ -1145,7 +1143,10 @@ end
     fn markdown_heading_with_trailing_hashes_matches() {
         // ATX allows optional trailing `#`s — strip them before matching.
         assert_eq!(md_find("## parseCitations ##\n", "parseCitations").len(), 1);
-        assert_eq!(md_find("### parseCitations ###\n", "parseCitations").len(), 1);
+        assert_eq!(
+            md_find("### parseCitations ###\n", "parseCitations").len(),
+            1
+        );
     }
 
     #[test]
@@ -1263,11 +1264,11 @@ Body to end.
 
         // Pre-cap order (after rank::sort): doc def, code def, doc def, code def, usage.
         let mut matches = vec![
-            mk(1, 30, true),  // doc def — high relevance
-            mk(2, 70, true),  // code def
-            mk(3, 30, true),  // doc def
-            mk(4, 70, true),  // code def
-            mk(5, 0, false),  // usage
+            mk(1, 30, true), // doc def — high relevance
+            mk(2, 70, true), // code def
+            mk(3, 30, true), // doc def
+            mk(4, 70, true), // code def
+            mk(5, 0, false), // usage
         ];
         matches.sort_by_key(stratum_for_display);
 

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -13,7 +13,7 @@ use crate::lang::treesitter::{
 
 use crate::error::TilthError;
 use crate::lang::detect_file_type;
-use crate::lang::outline::outline_language;
+use crate::lang::outline::{heading_text, outline_language, parse_markdown};
 use crate::search::rank;
 use crate::types::{FacetTotals, FileType, Match, SearchResult};
 use grep_regex::RegexMatcher;
@@ -589,17 +589,19 @@ fn find_usages(
 
 /// Markdown heading definition detector.
 ///
-/// A line `^#{1,6}\s+<text>` in a `.md`/`.mdx`/`.rst` file is treated as a
-/// soft definition of the section about <query> when <query> appears in
-/// <text> as a whole identifier (flanked by non-word chars). Setext
-/// headings (`===` underlines) and indented code blocks (4+ spaces) are
-/// intentionally ignored — Setext requires two-line look-ahead, and 4+
-/// space indents are CommonMark indented code blocks, not headings.
+/// An ATX heading (`^#{1,6}\s+<text>`) in a `.md`/`.mdx`/`.rst` file is
+/// treated as a soft definition of the section about <query> when <query>
+/// appears in <text> as a whole identifier (flanked by non-word chars).
+/// Setext headings, indented code blocks, and lines inside fenced code
+/// blocks are filtered out by the tree-sitter-md parser before we see them.
+///
+/// Section span (`def_range`) covers the heading line through the last
+/// non-blank line before the next same-or-higher-level heading, and is
+/// computed from the enclosing `section` node's end position. Sub-headings
+/// nest as child sections of the parent and don't terminate the parent.
 ///
 /// Whole-identifier match (not substring-anywhere) prevents false positives
-/// like query `func` matching heading `## refactoring guidelines`. Match is
-/// against the heading TEXT (after stripping `#` markers), so the `#`s
-/// themselves never count as boundary characters.
+/// like query `func` matching heading `## refactoring guidelines`.
 fn find_defs_markdown_buf(
     path: &Path,
     query: &str,
@@ -607,80 +609,115 @@ fn find_defs_markdown_buf(
     file_lines: u32,
     mtime: SystemTime,
 ) -> Vec<Match> {
-    let mut defs = Vec::new();
+    let Some(tree) = parse_markdown(content) else {
+        return Vec::new();
+    };
     let lines: Vec<&str> = content.lines().collect();
-
-    for (i, line) in lines.iter().enumerate() {
-        let Some((level, heading_text)) = parse_atx_heading(line) else {
-            continue;
-        };
-        if !contains_identifier(heading_text, query) {
-            continue;
-        }
-
-        // Section span: heading line through the line before the next ATX
-        // heading at the same or higher level (smaller `level` = higher).
-        // If no such heading follows, the section runs to EOF. Trailing
-        // blank lines are trimmed so the rendered range is tight.
-        let heading_line = (i + 1) as u32;
-        let mut end = lines.len();
-        for (j, peek) in lines.iter().enumerate().skip(i + 1) {
-            if let Some((peek_level, _)) = parse_atx_heading(peek) {
-                if peek_level <= level {
-                    end = j;
-                    break;
-                }
-            }
-        }
-        while end > i + 1 && lines[end - 1].trim().is_empty() {
-            end -= 1;
-        }
-        let section_end = end as u32;
-
-        defs.push(Match {
-            path: path.to_path_buf(),
-            line: heading_line,
-            text: line.trim_end().to_string(),
-            is_definition: true,
-            exact: true,
-            file_lines,
-            mtime,
-            // Populating def_range lets the renderer expand to the section
-            // body — the markdown analogue of a code definition's body.
-            def_range: Some((heading_line, section_end)),
-            def_name: Some(query.to_string()),
-            // Soft definition — code definitions are 60-80, usages 0. Sits
-            // between them so docs headings outrank passing mentions but
-            // never outrank the real source.
-            def_weight: 30,
-            impl_target: None,
-        });
-    }
-
+    let mut defs = Vec::new();
+    walk_md_sections(
+        tree.root_node(),
+        &lines,
+        query,
+        path,
+        file_lines,
+        mtime,
+        &mut defs,
+    );
     defs
 }
 
-/// Parse an ATX-style markdown heading. Returns `(level, text)` or `None`
-/// if the line is not a heading. Strips leading `#` markers and optional
-/// trailing `#`s. Per CommonMark: 0-3 spaces of indent allowed; 4+ spaces
-/// is a code block.
-fn parse_atx_heading(line: &str) -> Option<(usize, &str)> {
-    let leading_spaces = line.bytes().take_while(|&b| b == b' ').count();
-    if leading_spaces > 3 {
-        return None;
+#[allow(clippy::too_many_arguments)]
+fn walk_md_sections(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    query: &str,
+    path: &Path,
+    file_lines: u32,
+    mtime: SystemTime,
+    defs: &mut Vec<Match>,
+) {
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        match child.kind() {
+            "section" => {
+                emit_md_section_match(child, lines, query, path, file_lines, mtime, defs);
+                walk_md_sections(child, lines, query, path, file_lines, mtime, defs);
+            }
+            // The parser owns these — no headings hide inside.
+            "fenced_code_block" | "indented_code_block" | "html_block" => {}
+            _ => walk_md_sections(child, lines, query, path, file_lines, mtime, defs),
+        }
     }
-    let after_indent = &line[leading_spaces..];
-    let bytes = after_indent.as_bytes();
-    let hashes = bytes.iter().take_while(|&&b| b == b'#').count();
-    if !(1..=6).contains(&hashes) {
-        return None;
+}
+
+#[allow(clippy::too_many_arguments)]
+fn emit_md_section_match(
+    section: tree_sitter::Node,
+    lines: &[&str],
+    query: &str,
+    path: &Path,
+    file_lines: u32,
+    mtime: SystemTime,
+    defs: &mut Vec<Match>,
+) {
+    let mut cursor = section.walk();
+    let Some(heading) = section
+        .children(&mut cursor)
+        .find(|c| c.kind() == "atx_heading")
+    else {
+        return;
+    };
+    let text = heading_text(heading, lines);
+    if !contains_identifier(&text, query) {
+        return;
     }
-    if !matches!(bytes.get(hashes), Some(b' ' | b'\t')) {
-        return None;
+    let heading_line = (heading.start_position().row + 1) as u32;
+    let raw_end = md_section_end_line(section);
+    let section_end = trim_trailing_blank_lines(lines, heading_line, raw_end);
+    let line_text = lines
+        .get(heading.start_position().row)
+        .copied()
+        .unwrap_or("");
+    defs.push(Match {
+        path: path.to_path_buf(),
+        line: heading_line,
+        text: line_text.trim_end().to_string(),
+        is_definition: true,
+        exact: true,
+        file_lines,
+        mtime,
+        // Populating def_range lets the renderer expand to the section
+        // body — the markdown analogue of a code definition's body.
+        def_range: Some((heading_line, section_end)),
+        def_name: Some(query.to_string()),
+        // Soft definition — code definitions are 60-80, usages 0. Sits
+        // between them so docs headings outrank passing mentions but
+        // never outrank the real source.
+        def_weight: 30,
+        impl_target: None,
+    });
+}
+
+/// 1-indexed inclusive last line of a tree-sitter section node.
+fn md_section_end_line(section: tree_sitter::Node) -> u32 {
+    let end = section.end_position();
+    if end.column == 0 {
+        end.row as u32
+    } else {
+        (end.row + 1) as u32
     }
-    let text = after_indent[hashes..].trim();
-    // ATX allows optional trailing `#`s: `## Foo ##` — strip them.
-    Some((hashes, text.trim_end_matches('#').trim_end()))
+}
+
+fn trim_trailing_blank_lines(lines: &[&str], start: u32, end: u32) -> u32 {
+    let mut e = end;
+    while e > start
+        && lines
+            .get((e - 1) as usize)
+            .is_some_and(|l| l.trim().is_empty())
+    {
+        e -= 1;
+    }
+    e
 }
 
 /// True if `query` appears in `text` as a whole identifier — flanked by

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -26,6 +26,19 @@ const EARLY_QUIT_THRESHOLD_DEFINITIONS: usize = 50;
 /// Stop walking once we have this many raw usage matches.
 const EARLY_QUIT_THRESHOLD_USAGES: usize = MAX_MATCHES * 3;
 
+/// Display-side stratum: 0 = code def, 1 = doc-heading def, 2 = usage. Used
+/// as a stable sort key after `rank::sort` so the MAX_MATCHES cap can't drop
+/// real code defs in favor of markdown-heading defs of the same query.
+fn stratum_for_display(m: &Match) -> u8 {
+    if !m.is_definition {
+        2
+    } else if m.def_weight >= 60 {
+        0
+    } else {
+        1
+    }
+}
+
 /// Symbol search: find definitions via tree-sitter, usages via ripgrep, concurrently.
 /// Merge results, deduplicate, definitions first.
 pub fn search(
@@ -67,6 +80,15 @@ pub fn search(
     let usage_count = total - def_count;
 
     rank::sort(&mut merged, query, scope, context);
+
+    // Stratify so the cap can't drop a real code definition in favor of a
+    // markdown-heading "definition" of the same query. Stable within each
+    // stratum, so the relevance ordering from rank::sort is preserved. Code
+    // defs (def_weight >= 60) come first, doc-heading defs (def_weight 30)
+    // second, usages last. Display-side only — pre-cap totals (Phase 5) and
+    // the underlying ranking semantics for `--json` callers are unchanged.
+    merged.sort_by_key(stratum_for_display);
+
     merged.truncate(MAX_MATCHES);
 
     Ok(SearchResult {
@@ -703,6 +725,7 @@ fn is_definition_line(line: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
     use std::time::SystemTime;
 
     #[test]
@@ -1163,5 +1186,48 @@ Body to end.
         assert_eq!(defs.len(), 1);
         assert_eq!(defs[0].line, 1);
         assert_eq!(defs[0].def_range, Some((1, 1)));
+    }
+
+    #[test]
+    fn stratify_for_display_keeps_code_defs_above_doc_defs() {
+        // When the cap drops matches, real code defs must keep their slots
+        // and doc-heading defs slide below them. Rank order within each
+        // stratum is preserved by the stable sort.
+        let mk = |line: u32, weight: u16, is_definition: bool| Match {
+            path: PathBuf::from("test.rs"),
+            line,
+            text: String::new(),
+            is_definition,
+            exact: false,
+            file_lines: 100,
+            mtime: SystemTime::now(),
+            def_range: None,
+            def_name: None,
+            def_weight: weight,
+            impl_target: None,
+        };
+
+        // Pre-cap order (after rank::sort): doc def, code def, doc def, code def, usage.
+        let mut matches = vec![
+            mk(1, 30, true),  // doc def — high relevance
+            mk(2, 70, true),  // code def
+            mk(3, 30, true),  // doc def
+            mk(4, 70, true),  // code def
+            mk(5, 0, false),  // usage
+        ];
+        matches.sort_by_key(stratum_for_display);
+
+        // Code defs first (stable order: line 2 before line 4),
+        // then doc defs (line 1 before line 3), then the usage.
+        let lines: Vec<u32> = matches.iter().map(|m| m.line).collect();
+        assert_eq!(lines, vec![2, 4, 1, 3, 5]);
+
+        // Truncate-to-2 should keep both code defs, drop both doc defs.
+        matches.truncate(2);
+        assert!(
+            matches.iter().all(|m| m.def_weight >= 60),
+            "displayed slice after cap must be all code defs, got {:?}",
+            matches.iter().map(|m| m.def_weight).collect::<Vec<_>>()
+        );
     }
 }

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -175,9 +175,35 @@ fn find_definitions(
                 Vec::new()
             };
 
-            // Fallback: keyword heuristic for files without grammars
+            // Per-file-type fallback dispatch. The semantics of "definition"
+            // differ by file kind, so handle them separately:
+            //
+            // * Code without a tree-sitter grammar: keyword heuristic (looks
+            //   for lines starting with `function`/`const`/`class`/etc.).
+            // * Markdown / RST: heading-as-definition. A heading whose text
+            //   contains the query (`## parseCitations` in a doc) marks that
+            //   section AS being about the symbol — that is the documentation
+            //   analogue of a code definition. Quoted code blocks inside
+            //   docs are NOT treated as definitions; they're usages, because
+            //   the keyword heuristic would false-positive on every snippet
+            //   that quotes the real source. Heading defs carry a lower
+            //   `def_weight` (30) than code definitions (60-80) so the real
+            //   source still ranks first.
+            // * Structured data / tabular / log / other: no fallback.
+            //   Mentions are config values, data, or noise — not definitions.
+            //   (A future patch could treat top-level config keys matching
+            //   the query as soft definitions, but that's ambiguous enough
+            //   to skip for now.)
             if file_defs.is_empty() && ts_language.is_none() {
-                file_defs = find_defs_heuristic_buf(path, query, &content, file_lines, mtime);
+                file_defs = match file_type {
+                    FileType::Code(_) => {
+                        find_defs_heuristic_buf(path, query, &content, file_lines, mtime)
+                    }
+                    FileType::Markdown => {
+                        find_defs_markdown_buf(path, query, &content, file_lines, mtime)
+                    }
+                    _ => Vec::new(),
+                };
             }
 
             if !file_defs.is_empty() {
@@ -522,6 +548,97 @@ fn find_usages(
         .unwrap_or_else(std::sync::PoisonError::into_inner))
 }
 
+/// Markdown heading definition detector.
+///
+/// A line `^#{1,6}\s+<text>` in a `.md`/`.mdx`/`.rst` file is treated as a
+/// soft definition of the section about <query> when <query> appears in
+/// <text> as a whole identifier (flanked by non-word chars). Setext
+/// headings (`===` underlines) and indented code blocks (4+ spaces) are
+/// intentionally ignored — Setext requires two-line look-ahead, and 4+
+/// space indents are CommonMark indented code blocks, not headings.
+///
+/// Whole-identifier match (not substring-anywhere) prevents false positives
+/// like query `func` matching heading `## refactoring guidelines`. Match is
+/// against the heading TEXT (after stripping `#` markers), so the `#`s
+/// themselves never count as boundary characters.
+fn find_defs_markdown_buf(
+    path: &Path,
+    query: &str,
+    content: &str,
+    file_lines: u32,
+    mtime: SystemTime,
+) -> Vec<Match> {
+    let mut defs = Vec::new();
+
+    for (i, line) in content.lines().enumerate() {
+        let Some(heading_text) = extract_atx_heading_text(line) else {
+            continue;
+        };
+        if !contains_identifier(heading_text, query) {
+            continue;
+        }
+        defs.push(Match {
+            path: path.to_path_buf(),
+            line: (i + 1) as u32,
+            text: line.trim_end().to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines,
+            mtime,
+            def_range: None,
+            def_name: Some(query.to_string()),
+            // Soft definition — code definitions are 60-80, usages 0. Sits
+            // between them so docs headings outrank passing mentions but
+            // never outrank the real source.
+            def_weight: 30,
+            impl_target: None,
+        });
+    }
+
+    defs
+}
+
+/// Extract the text of an ATX-style markdown heading, or `None` if the line
+/// is not a heading. Strips leading `#` markers and optional trailing `#`s.
+/// Per CommonMark: 0-3 spaces of indent allowed; 4+ spaces is a code block.
+fn extract_atx_heading_text(line: &str) -> Option<&str> {
+    let leading_spaces = line.bytes().take_while(|&b| b == b' ').count();
+    if leading_spaces > 3 {
+        return None;
+    }
+    let after_indent = &line[leading_spaces..];
+    let bytes = after_indent.as_bytes();
+    let hashes = bytes.iter().take_while(|&&b| b == b'#').count();
+    if !(1..=6).contains(&hashes) {
+        return None;
+    }
+    if !matches!(bytes.get(hashes), Some(b' ' | b'\t')) {
+        return None;
+    }
+    let text = after_indent[hashes..].trim();
+    // ATX allows optional trailing `#`s: `## Foo ##` — strip them.
+    Some(text.trim_end_matches('#').trim_end())
+}
+
+/// True if `query` appears in `text` as a whole identifier — flanked by
+/// non-word characters (anything outside `[A-Za-z0-9_]`) or string ends.
+fn contains_identifier(text: &str, query: &str) -> bool {
+    if query.is_empty() {
+        return false;
+    }
+    text.match_indices(query).any(|(abs, _)| {
+        let bytes = text.as_bytes();
+        let before_ok = abs == 0 || !is_word_byte(bytes[abs - 1]);
+        let end_pos = abs + query.len();
+        let after_ok = end_pos == bytes.len() || !is_word_byte(bytes[end_pos]);
+        before_ok && after_ok
+    })
+}
+
+fn is_word_byte(b: u8) -> bool {
+    b.is_ascii_alphanumeric() || b == b'_'
+}
+
 /// Keyword heuristic fallback — only used when tree-sitter grammar unavailable.
 fn is_definition_line(line: &str) -> bool {
     let trimmed = line.trim();
@@ -828,5 +945,111 @@ end
             !elixir_find(code, "Inner").is_empty(),
             "should find nested 'Inner' module"
         );
+    }
+
+    fn md_find(content: &str, query: &str) -> Vec<Match> {
+        let lines = content.lines().count() as u32;
+        find_defs_markdown_buf(
+            std::path::Path::new("test.md"),
+            query,
+            content,
+            lines,
+            SystemTime::now(),
+        )
+    }
+
+    #[test]
+    fn markdown_heading_named_for_query_matches() {
+        let content = "# Intro\n\n## parseCitations\n\nProse.\n";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 3);
+        assert!(defs[0].is_definition);
+        assert_eq!(defs[0].def_weight, 30);
+    }
+
+    #[test]
+    fn markdown_heading_levels_one_through_six() {
+        for level in 1..=6 {
+            let hashes = "#".repeat(level);
+            let content = format!("{hashes} parseCitations\n");
+            assert_eq!(md_find(&content, "parseCitations").len(), 1, "h{level}");
+        }
+        // h7 is not a heading
+        assert!(md_find("####### parseCitations\n", "parseCitations").is_empty());
+    }
+
+    #[test]
+    fn markdown_heading_without_query_does_not_match() {
+        let content = "## Other section\n\n## Another heading\n";
+        assert!(md_find(content, "parseCitations").is_empty());
+    }
+
+    #[test]
+    fn markdown_substring_inside_word_does_not_match() {
+        // query "func" must not match "function" — that's the maintainer's
+        // word-boundary concern. Same for "factor" inside "refactoring".
+        assert!(md_find("## function pointers\n", "func").is_empty());
+        assert!(md_find("## refactoring guidelines\n", "factor").is_empty());
+        assert!(md_find("## getCitationsBatch\n", "Citations").is_empty());
+    }
+
+    #[test]
+    fn markdown_whole_word_in_phrase_matches() {
+        // Whole-word match anywhere in the heading text is a definition —
+        // a heading like `## How parseCitations works` IS naming the symbol.
+        let defs = md_find("## How parseCitations works\n", "parseCitations");
+        assert_eq!(defs.len(), 1);
+    }
+
+    #[test]
+    fn markdown_query_with_hyphen_matches() {
+        // Tracking-doc identifiers like `GUM-1732` must match. The hyphen
+        // is part of the query; word-boundary check applies only at the ends.
+        let defs = md_find("## GUM-1732: Cost attribution\n", "GUM-1732");
+        assert_eq!(defs.len(), 1);
+    }
+
+    #[test]
+    fn markdown_code_block_lines_do_not_match() {
+        // Fenced code block — line is not an ATX heading, even though
+        // the text contains `function parseCitations`.
+        let content = "## Real heading\n\n```ts\nfunction parseCitations() {}\n```\n";
+        let defs = md_find(content, "parseCitations");
+        assert!(defs.is_empty(), "fenced-code mention is not a definition");
+
+        // Indented code block (4+ space indent) — a `## ...` line indented
+        // 4 spaces is a code block per CommonMark, not a heading.
+        let content = "Intro.\n\n    ## parseCitations\n";
+        assert!(
+            md_find(content, "parseCitations").is_empty(),
+            "4-space-indented `## foo` is a code block, not a heading"
+        );
+    }
+
+    #[test]
+    fn markdown_heading_with_up_to_three_space_indent_matches() {
+        // 0-3 space indents are valid ATX headings per CommonMark.
+        for indent in 0..=3 {
+            let content = format!("{}## parseCitations\n", " ".repeat(indent));
+            assert_eq!(
+                md_find(&content, "parseCitations").len(),
+                1,
+                "indent {indent} should be a heading"
+            );
+        }
+    }
+
+    #[test]
+    fn markdown_heading_with_trailing_hashes_matches() {
+        // ATX allows optional trailing `#`s — strip them before matching.
+        assert_eq!(md_find("## parseCitations ##\n", "parseCitations").len(), 1);
+        assert_eq!(md_find("### parseCitations ###\n", "parseCitations").len(), 1);
+    }
+
+    #[test]
+    fn markdown_hashes_without_space_are_not_headings() {
+        // `##foo` (no space after `#`s) is not a heading.
+        assert!(md_find("##parseCitations\n", "parseCitations").is_empty());
     }
 }

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -15,7 +15,7 @@ use crate::error::TilthError;
 use crate::lang::detect_file_type;
 use crate::lang::outline::outline_language;
 use crate::search::rank;
-use crate::types::{FileType, Match, SearchResult};
+use crate::types::{FacetTotals, FileType, Match, SearchResult};
 use grep_regex::RegexMatcher;
 use grep_searcher::sinks::UTF8;
 use grep_searcher::Searcher;
@@ -85,9 +85,25 @@ pub fn search(
     // markdown-heading "definition" of the same query. Stable within each
     // stratum, so the relevance ordering from rank::sort is preserved. Code
     // defs (def_weight >= 60) come first, doc-heading defs (def_weight 30)
-    // second, usages last. Display-side only — pre-cap totals (Phase 5) and
-    // the underlying ranking semantics for `--json` callers are unchanged.
+    // second, usages last. Display-side only — pre-cap totals below and the
+    // underlying ranking semantics for `--json` callers are unchanged.
     merged.sort_by_key(stratum_for_display);
+
+    // Compute per-subfacet totals on the *pre-cap* set so the renderer can
+    // print `displayed/total` headings + per-facet hidden-count lines.
+    // `merged` is bounded by the early-quit thresholds (~80 entries), so the
+    // clone is cheap. Faceting is pure / side-effect-free.
+    let totals = {
+        let snapshot = merged.clone();
+        let f = super::facets::facet_matches(snapshot, scope);
+        FacetTotals {
+            definitions: f.definitions.len(),
+            implementations: f.implementations.len(),
+            tests: f.tests.len(),
+            usages_local: f.usages_local.len(),
+            usages_cross: f.usages_cross.len(),
+        }
+    };
 
     merged.truncate(MAX_MATCHES);
 
@@ -98,6 +114,7 @@ pub fn search(
         total_found: total,
         definitions: def_count,
         usages: usage_count,
+        facet_totals: totals,
     })
 }
 

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -569,23 +569,46 @@ fn find_defs_markdown_buf(
     mtime: SystemTime,
 ) -> Vec<Match> {
     let mut defs = Vec::new();
+    let lines: Vec<&str> = content.lines().collect();
 
-    for (i, line) in content.lines().enumerate() {
-        let Some(heading_text) = extract_atx_heading_text(line) else {
+    for (i, line) in lines.iter().enumerate() {
+        let Some((level, heading_text)) = parse_atx_heading(line) else {
             continue;
         };
         if !contains_identifier(heading_text, query) {
             continue;
         }
+
+        // Section span: heading line through the line before the next ATX
+        // heading at the same or higher level (smaller `level` = higher).
+        // If no such heading follows, the section runs to EOF. Trailing
+        // blank lines are trimmed so the rendered range is tight.
+        let heading_line = (i + 1) as u32;
+        let mut end = lines.len();
+        for (j, peek) in lines.iter().enumerate().skip(i + 1) {
+            if let Some((peek_level, _)) = parse_atx_heading(peek) {
+                if peek_level <= level {
+                    end = j;
+                    break;
+                }
+            }
+        }
+        while end > i + 1 && lines[end - 1].trim().is_empty() {
+            end -= 1;
+        }
+        let section_end = end as u32;
+
         defs.push(Match {
             path: path.to_path_buf(),
-            line: (i + 1) as u32,
+            line: heading_line,
             text: line.trim_end().to_string(),
             is_definition: true,
             exact: true,
             file_lines,
             mtime,
-            def_range: None,
+            // Populating def_range lets the renderer expand to the section
+            // body — the markdown analogue of a code definition's body.
+            def_range: Some((heading_line, section_end)),
             def_name: Some(query.to_string()),
             // Soft definition — code definitions are 60-80, usages 0. Sits
             // between them so docs headings outrank passing mentions but
@@ -598,10 +621,11 @@ fn find_defs_markdown_buf(
     defs
 }
 
-/// Extract the text of an ATX-style markdown heading, or `None` if the line
-/// is not a heading. Strips leading `#` markers and optional trailing `#`s.
-/// Per CommonMark: 0-3 spaces of indent allowed; 4+ spaces is a code block.
-fn extract_atx_heading_text(line: &str) -> Option<&str> {
+/// Parse an ATX-style markdown heading. Returns `(level, text)` or `None`
+/// if the line is not a heading. Strips leading `#` markers and optional
+/// trailing `#`s. Per CommonMark: 0-3 spaces of indent allowed; 4+ spaces
+/// is a code block.
+fn parse_atx_heading(line: &str) -> Option<(usize, &str)> {
     let leading_spaces = line.bytes().take_while(|&b| b == b' ').count();
     if leading_spaces > 3 {
         return None;
@@ -617,7 +641,7 @@ fn extract_atx_heading_text(line: &str) -> Option<&str> {
     }
     let text = after_indent[hashes..].trim();
     // ATX allows optional trailing `#`s: `## Foo ##` — strip them.
-    Some(text.trim_end_matches('#').trim_end())
+    Some((hashes, text.trim_end_matches('#').trim_end()))
 }
 
 /// True if `query` appears in `text` as a whole identifier — flanked by
@@ -1051,5 +1075,93 @@ end
     fn markdown_hashes_without_space_are_not_headings() {
         // `##foo` (no space after `#`s) is not a heading.
         assert!(md_find("##parseCitations\n", "parseCitations").is_empty());
+    }
+
+    #[test]
+    fn markdown_section_span_runs_to_next_same_level_heading() {
+        // `## parseCitations` body ends at the next `## ...` (same level).
+        // The blank line on line 4 (between body and next heading) is
+        // trimmed, so the span ends at line 3.
+        let content = "\
+## parseCitations
+
+Body line.
+
+## Other section
+
+Unrelated.
+";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 1);
+        assert_eq!(defs[0].def_range, Some((1, 3)));
+    }
+
+    #[test]
+    fn markdown_section_span_runs_to_higher_level_heading() {
+        // A `## ...` ends a sub-section under `### parseCitations` because
+        // the outer heading is higher level (smaller hash count). The blank
+        // line preceding `## Outer two` is trimmed.
+        let content = "\
+## Outer
+
+### parseCitations
+
+Body.
+
+## Outer two
+";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 3);
+        assert_eq!(defs[0].def_range, Some((3, 5)));
+    }
+
+    #[test]
+    fn markdown_section_span_skips_deeper_subheadings() {
+        // A `### ...` does NOT end the enclosing `## parseCitations`
+        // section — only same-or-higher-level headings do.
+        let content = "\
+## parseCitations
+
+Lead-in.
+
+### Detail
+
+Subprose.
+
+## Next
+";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 1);
+        assert_eq!(defs[0].def_range, Some((1, 7)));
+    }
+
+    #[test]
+    fn markdown_section_span_runs_to_eof_when_no_following_heading() {
+        let content = "\
+## parseCitations
+
+Body to end.
+";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 1);
+        // Three content lines; trailing newline does not produce a 4th.
+        assert_eq!(defs[0].def_range, Some((1, 3)));
+    }
+
+    #[test]
+    fn markdown_section_span_handles_heading_with_no_body() {
+        // Adjacent headings: span is just the heading line itself.
+        let content = "\
+## parseCitations
+## Other
+";
+        let defs = md_find(content, "parseCitations");
+        assert_eq!(defs.len(), 1);
+        assert_eq!(defs[0].line, 1);
+        assert_eq!(defs[0].def_range, Some((1, 1)));
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -119,6 +119,22 @@ pub struct SearchResult {
     pub total_found: usize,
     pub definitions: usize,
     pub usages: usize,
+    /// Pre-cap subfacet counts. Computed in `symbol::search` by faceting the
+    /// merged set before truncation; used by the renderer to print
+    /// `displayed/total` headings and the per-facet hidden-count tail line.
+    pub facet_totals: FacetTotals,
+}
+
+/// Pre-cap counts per subfacet. Defaults to all-zero for callers that don't
+/// facet (`content::search`, `regex` paths) — the renderer renders a bare
+/// count when displayed == total, so zero totals never surface a header.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct FacetTotals {
+    pub definitions: usize,
+    pub implementations: usize,
+    pub tests: usize,
+    pub usages_local: usize,
+    pub usages_cross: usize,
 }
 
 /// A single entry in a code outline.


### PR DESCRIPTION
Massive thanks to @choongng for the substantial work on the [dev branch](https://github.com/choongng/tilth/commits/dev/) — this is the markdown rewrite cluster. Pulls **17 commits** from dev with full author attribution + 5 follow-up commits from us. Stacked on #76; merge that first.

Closes #72.

## What lands

1. **Markdown headings as soft definitions in symbol search** — `tilth Foo --scope docs/` now finds `## Foo` headings, ranked between code defs (60-80) and usages (0). Section body inlined in the default preview slot (capped at 40 lines, expand for full body).
2. **The 3 PR #72 markdown_enclosing_scope bugs are fixed structurally** via tree-sitter-md grammar — pinned by 3 new regression tests so they can't return.
3. **`--full` on search queries now expands all matches** (capped at 50). Pre-fix it was a silent no-op for symbol/text/regex queries.
4. **Multi-section reads** — `tilth_read` accepts `sections: ["1-10", "## Foo"]` array.
5. **Faceted search totals** — `displayed/total` headings per facet, per-facet hidden-count lines.
6. **search internals reorg** — `e3c4907` extracts `bloom_walk`, `callee_query`, and `scope` into dedicated modules (~+658/-555 LOC). Pure refactor; tests preserved.
7. **Quoted-code mentions no longer tag as definitions** (PR #66 review fix already applied here via `d621828`).

## Cherry-picked commits (Choong Ng as Author on each)

| SHA on dev | Title |
|---|---|
| `7cad3f1` | search: annotate usages with enclosing scope via tree-sitter (PR #72 base) |
| `d621828` | Don't tag quoted-code mentions as definitions; recognize markdown headings |
| `02e9a51` | search: expand markdown heading definitions to the section body |
| `7d76b16` | search: fix inverted markdown heading levels in search output |
| `3e10ab6` | search: render grouped-usage entries as H3 to match single-match path |
| `c8ae866` | search: prefer code definitions over doc-heading defs when filling cap |
| `ac21c9b` | search: show displayed/total in facet headings via FacetTotals |
| `cc1525a` | search: emit per-facet hidden-count line; drop global tail on facet path |
| `99c4a3d` | search: inline section body for markdown-heading definitions in default preview |
| `12c7045` | outline: switch markdown to tree-sitter-md AST |
| `47c3471` | search: switch markdown defs to tree-sitter-md AST |
| `c592109` | search: switch markdown_enclosing_scope to AST (kills the 3 regex bugs) |
| `76dfb7f` | read: switch resolve_heading + suggest_headings to AST |
| `16212fc` | Make --full imply expand-all on search queries |
| `4e25400` | read: accept multiple sections per call via sections array |
| `a333204` | read: cover edit-mode hashline output in multi-section tests |
| `e3c4907` | search: extract bloom_walk, callee_query, scope from relational queries |

**Skipped:** `8882d72` (fence-state regex fix) — superseded by `47c3471` AST migration.

## New dependency

`tree-sitter-md = "0.5"` — same provenance as our 14 other tree-sitter grammars (tree-sitter-grammars org, MIT, 600 ⭐, actively maintained, 610k downloads). Decoupled from our `tree-sitter = "0.25"` pin via the `tree-sitter-language` abstraction.

## Our additions on top

- **`5d52013`** — pinned regression tests for the 3 PR #72 markdown bugs (7-hash, no-space, in-fence). Sit at the `markdown_enclosing_scope` layer so any future caller-level refactor still has the contract enforced.
- **`15cbcba`** — clippy + fmt drift cleanup. `c8ae866`'s `stratum_for_display` tripped `clippy::doc_markdown` and `clippy::bool_to_int_with_if` on Rust 1.94; fmt drift in 4 files from the cherry-picks.
- **`c4489e0`** — pinned tests for two more behaviors:
  - `format_single_match_markdown_cap_bypasses_expand_budget` — locks 99c4a3d's design intent that markdown short-circuit ignores `--expand` (otherwise a future "fix" would inflate every markdown match into a multi-hundred-line response).
  - `markdown_preview_cap_constant_unchanged` — guards the worst-case bound `MAX_MATCHES * MARKDOWN_PREVIEW_MAX_LINES = 400 lines` per response.
  - Extracted `compute_expand(cli_expand, cli_full)` from main.rs and added 4 tests pinning the `--full` / `--expand` precedence so the piped→auto-expand regression 16212fc fixed can't return.

## Conflict resolutions during cherry-pick

Three commits had conflicts because they assumed `7e4d963` (`.gitignore` default + `.tilthignore`) was already on the branch. Resolved by dropping the `7e4d963`-specific bits — they'll come with PR-E:
- `99c4a3d`: dropped `apply_ignore_settings` reference, kept `MARKDOWN_PREVIEW_MAX_LINES`.
- `47c3471`: took the AST-migration form of `find_defs_markdown_buf` (the regex-based version is gone).
- `16212fc`: dropped the `--no-ignore` CLI flag, kept the `--full` / `--expand` doc rewrite + `FULL_EXPAND_CAP=50` logic.
- `e3c4907`: standard "take theirs" for the import/extraction conflicts (4 in callers.rs, 1 in mod.rs).

## Test plan

- [x] `cargo test --lib` — **331 passed** (was 267 on main; +60 tests from this bundle, +4 from us)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] All 3 PR #72 markdown bugs pinned with regression tests
- [x] Author preserved on all 17 cherry-picks (`git log --pretty='%an' main..HEAD`)
- [x] **Benchmark spot-check on fastapi (1139 .md files)** — search ~5%, --map ~6% within measurement noise. No regression worth gating on. Posted as comment.
- [ ] Reviewer to run full benchmark (sonnet × 26 tasks) before merge as final gate

## Follow-ups (not blocking this PR)

- `b3fea19` ARCHITECTURE.md (907 lines) — separate docs PR
- `f5acfe1` overview WalkBuilder — held with PR-E (depends on `7e4d963`)
- `7e4d963` `.gitignore` default + `.tilthignore` — held with PR-E (UB fix needed first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)