### PR TITLE
docs: fix README opencode install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ tilth install cursor           # ~/.cursor/mcp.json
 tilth install windsurf         # ~/.codeium/windsurf/mcp_config.json
 tilth install vscode           # .vscode/mcp.json (project scope)
 tilth install claude-desktop
-tilth install opencode         # ~/.opencode.json
+tilth install opencode         # ~/.config/opencode/opencode.json
 tilth install gemini           # ~/.gemini/settings.json
 tilth install codex            # ~/.codex/config.toml
 tilth install amp              # ~/.config/amp/settings.json


### PR DESCRIPTION
One-line follow-up to #73 (@jmarcelomb).

The opencode config path was corrected in install.rs from \`~/.opencode.json\` → \`~/.config/opencode/opencode.json\`, but the install table in the README still showed the old path. Brings docs in sync.

Caught during re-review of #73 — non-blocker, kept separate so the install.rs fix landed cleanly under Marcelo's authorship.