### PR TITLE
refactor: adopt thiserror, fastbloom, and strsim

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,9 +39,17 @@ Output: <path>  (~<token_count> tokens). Respects .gitignore.
 tilth_deps: Blast-radius check — what imports this file and what it imports.
 Use ONLY before renaming, removing, or changing an export's signature.
 
+tilth_diff: Structural diff — shows what changed at function level. Replaces Bash(git diff).
+Usage: tilth_diff(source: "HEAD~1") for last commit. No args = uncommitted changes.
+scope: "file.rs" or "file.rs:fn_name". log: "HEAD~5..HEAD" for per-commit summaries.
+search: filter to lines matching a term. blast: true to show callers of changed signatures.
+Output: [+] added, [-] deleted, [~] body changed, [~:sig] signature changed.
+DO NOT use Bash(git diff) or Bash(git log --patch). Use tilth_diff instead.
+
 To search code, use tilth_search instead of Grep or Bash(grep/rg).
 To read files, use tilth_read instead of Read or Bash(cat).
 To find files, use tilth_files instead of Glob or Bash(find/ls).
+To check what changed, use tilth_diff instead of Bash(git diff/git log).
 DO NOT re-read files already shown in expanded search results.
 
 tilth_edit: Batch edit one or more files using hash-anchored lines. Replaces the host Edit tool.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,7 @@
 tilth — code intelligence MCP server. Replaces grep, cat, find, ls with AST-aware equivalents.
 
+ALWAYS BATCH. When you have 2+ files to read, call tilth_read once with paths: [...]. When you have edits to multiple files, call tilth_edit once with files: [...]. Never make N serial calls when one will do — each tool call is a turn.
+
 To explore code, always search first. tilth_search finds definitions, usages, and file locations in one call.
 Usage: tilth_search(query: "handleRequest").
 tilth_files is ONLY for listing directory contents when you have no symbol or text to search for.
@@ -22,10 +24,11 @@ Output per match:
 <name>  <path>:<start>-<end>  <signature>
 Re-expanding a previously shown definition returns [shown earlier].
 
-tilth_read: Read file content with smart outlining. Replaces cat/head/tail.
+tilth_read: Read one or more files with smart outlining. Replaces cat/head/tail.
+paths: ["a.rs", "b.rs"] reads many in one call (max 20). PREFER this over serial single-file reads.
+path: "a.rs" for a single file.
 Small files → full content. Large files → structural outline.
 section: "<start>-<end>" or "<heading text>"
-paths: read multiple files in one call.
 Output:
 <line_number> │ <content>                  ← full/section mode
 [<start>-<end>]  <symbol name>             ← outline mode
@@ -41,13 +44,18 @@ To read files, use tilth_read instead of Read or Bash(cat).
 To find files, use tilth_files instead of Glob or Bash(find/ls).
 DO NOT re-read files already shown in expanded search results.
 
-tilth_edit: Edit files using hash-anchored lines. Replaces the host Edit tool.
+tilth_edit: Batch edit one or more files using hash-anchored lines. Replaces the host Edit tool.
+ALWAYS group edits to multiple files into ONE tilth_edit call (max 20 files). Never call tilth_edit twice in a row.
 tilth_read → copy anchors (<line>:<hash>) → pass to tilth_edit.
-Single line: {"start": "<line>:<hash>", "content": "<new code>"}
-Range: {"start": "<line>:<hash>", "end": "<line>:<hash>", "content": "..."}
-Delete: {"start": "<line>:<hash>", "content": ""}
-Hash mismatch → file changed, re-read and retry.
+Shape: {"files": [{"path": "a.rs", "edits": [...]}, {"path": "b.rs", "edits": [...]}]}
+Single file: {"files": [{"path": "a.rs", "edits": [{"start": "<line>:<hash>", "content": "<new code>"}]}]}
+Edit forms inside `edits`:
+  Single line: {"start": "<line>:<hash>", "content": "<new code>"}
+  Range:       {"start": "<line>:<hash>", "end": "<line>:<hash>", "content": "..."}
+  Delete:      {"start": "<line>:<hash>", "content": ""}
+Per-file results: each file is processed independently. A hash mismatch on one file does NOT block the others.
+Hash mismatch → file changed, re-read THAT file and retry it (other files in the batch already applied).
 Large files: tilth_read shows outline — use section to get hashlined content.
-Pass diff: true to see a compact before/after diff in the response.
+Pass diff: true to see a compact before/after diff per file.
 After editing a function signature, tilth_edit shows callers that may need updating.
 DO NOT use the host Edit tool. Use tilth_edit for all edits.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "rand",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -262,6 +275,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -269,7 +300,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -336,7 +367,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -410,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -471,6 +508,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -500,9 +552,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -656,6 +743,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,10 +784,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -705,6 +818,7 @@ dependencies = [
  "clap_complete",
  "crossbeam-channel",
  "dashmap",
+ "fastbloom",
  "globset",
  "grep-regex",
  "grep-searcher",
@@ -716,7 +830,9 @@ dependencies = [
  "serde",
  "serde_json",
  "streaming-iterator",
+ "strsim",
  "tempfile",
+ "thiserror",
  "toml",
  "tree-sitter",
  "tree-sitter-c",
@@ -1146,6 +1262,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,7 +699,7 @@ dependencies = [
 
 [[package]]
 name = "tilth"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -694,6 +703,7 @@ version = "0.6.1"
 dependencies = [
  "clap",
  "clap_complete",
+ "crossbeam-channel",
  "dashmap",
  "globset",
  "grep-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.6.3"
+version = "0.7.0"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,11 @@ memmap2 = "0.9"
 # Parallelism
 rayon = "1"
 
+# Channel with select! for timeout wrapper (sibling of crossbeam-deque/-epoch/-utils
+# already present as rayon transitive deps; closer-to-Java-Future ergonomics than
+# std::sync::mpsc::recv_timeout).
+crossbeam-channel = "0.5"
+
 # Concurrent cache
 dashmap = "6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,15 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 
+# Error types
+thiserror = "2"
+
+# Bloom filter (fast SIMD-optimized impl)
+fastbloom = "0.17"
+
+# String similarity (fuzzy symbol-rename detection)
+strsim = "0.11"
+
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.6.3",
+  "version": "0.7.0",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"

--- a/src/diff/matching.rs
+++ b/src/diff/matching.rs
@@ -219,7 +219,7 @@ pub(crate) fn match_symbols(old: &[DiffSymbol], new: &[DiffSymbol]) -> Vec<Symbo
             if max_len == 0 || (min_len as f32 / max_len as f32) < 0.8 {
                 continue;
             }
-            let score = jaccard_similarity(&old[oi].source_text, &new[ni].source_text);
+            let score = strsim::sorensen_dice(&old[oi].source_text, &new[ni].source_text) as f32;
             if score >= 0.8 {
                 candidates.push((oi, ni, score));
             }
@@ -486,20 +486,6 @@ fn trim_ascii(bytes: &[u8]) -> &[u8] {
         .rposition(|b| !b.is_ascii_whitespace())
         .map_or(start, |p| p + 1);
     &bytes[start..end]
-}
-
-fn jaccard_similarity(a: &str, b: &str) -> f32 {
-    let set_a: HashSet<&str> = a.split_whitespace().collect();
-    let set_b: HashSet<&str> = b.split_whitespace().collect();
-    let intersection = set_a.intersection(&set_b).count();
-    let union = set_a.union(&set_b).count();
-    if union == 0 {
-        return 0.0;
-    }
-    #[allow(clippy::cast_precision_loss)]
-    {
-        intersection as f32 / union as f32
-    }
 }
 
 // ---------------------------------------------------------------------------

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -7,6 +7,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use rayon::prelude::*;
+
 use crate::types::OutlineKind;
 
 #[derive(Debug)]
@@ -242,7 +244,7 @@ pub fn diff(
 
     // 2. Build structural overlays.
     let mut overlays: Vec<FileOverlay> = file_diffs
-        .iter()
+        .par_iter()
         .map(|fd| overlay::compute_overlay(fd, source))
         .collect();
 

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -1,9 +1,14 @@
 use std::fmt::Write as _;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use rayon::prelude::*;
 
 use crate::error::TilthError;
 use crate::format;
+use crate::index::bloom::BloomFilterCache;
+use crate::session::Session;
 
 /// A single edit operation targeting a line range by hash anchors.
 #[derive(Debug, Clone)]
@@ -13,6 +18,14 @@ pub struct Edit {
     pub end_line: usize,
     pub end_hash: u16,
     pub content: String,
+}
+
+/// One file's worth of work for a batch `tilth_edit`. Parse errors are deferred
+/// onto the task so a malformed entry surfaces as a per-file failure instead
+/// of aborting the whole batch.
+pub enum FileEditTask {
+    Ready { path: PathBuf, edits: Vec<Edit> },
+    ParseError { label: String, msg: String },
 }
 
 /// Per-edit diff: old lines removed vs new lines added.
@@ -294,6 +307,84 @@ fn format_diffs(diffs: &[EditDiff]) -> String {
     }
 
     out
+}
+
+/// Apply a batch of file edits in parallel.
+///
+/// Each task is processed independently — a hash mismatch, parse error, or
+/// I/O failure on one file does not block siblings. Output is a series of
+/// `## <path>` sections joined with `---`. Returns `Err` only when every
+/// file failed (so the MCP response sets `isError: true`). Output ordering
+/// matches the input `tasks` — rayon's `par_iter().collect()` preserves
+/// index order even though execution order is not deterministic.
+pub fn apply_batch(
+    tasks: Vec<FileEditTask>,
+    session: &Session,
+    bloom: &Arc<BloomFilterCache>,
+    show_diff: bool,
+) -> Result<String, String> {
+    let outcomes: Vec<(String, bool)> = tasks
+        .into_par_iter()
+        .map(|task| match task {
+            FileEditTask::ParseError { label, msg } => (format!("## {label}\nerror: {msg}"), false),
+            FileEditTask::Ready { path, edits } => {
+                session.record_read(&path);
+                let header = format!("## {}", path.display());
+                match apply_one(&path, &edits, bloom, show_diff) {
+                    Ok(body) if body.is_empty() => (header, true),
+                    Ok(body) => (format!("{header}\n{body}"), true),
+                    Err(msg) => (format!("{header}\n{msg}"), false),
+                }
+            }
+        })
+        .collect();
+
+    let success_count = outcomes.iter().filter(|(_, ok)| *ok).count();
+    let combined = outcomes
+        .into_iter()
+        .map(|(s, _)| s)
+        .collect::<Vec<_>>()
+        .join("\n\n---\n\n");
+
+    if success_count == 0 {
+        Err(combined)
+    } else {
+        Ok(combined)
+    }
+}
+
+fn apply_one(
+    path: &Path,
+    edits: &[Edit],
+    bloom: &Arc<BloomFilterCache>,
+    show_diff: bool,
+) -> Result<String, String> {
+    match apply_edits(path, edits).map_err(|e| e.to_string())? {
+        EditResult::Applied { diff, context } => {
+            let mut output = String::new();
+            if show_diff && !diff.is_empty() {
+                output.push_str(&diff);
+                if !context.is_empty() {
+                    output.push_str("\n\n");
+                }
+            }
+            if !context.is_empty() {
+                output.push_str(&context);
+            }
+            let abs_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
+            let scope = crate::lang::package_root(&abs_path).map_or_else(
+                || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
+                Path::to_path_buf,
+            );
+            if let Some(blast) = crate::search::blast::blast_radius(path, edits, &scope, bloom) {
+                output.push_str(&blast);
+            }
+            Ok(output)
+        }
+        EditResult::HashMismatch(msg) => Err(format!(
+            "hash mismatch — file changed since last read:\n\n{msg}"
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -8,7 +8,6 @@ use rayon::prelude::*;
 use crate::error::TilthError;
 use crate::format;
 use crate::index::bloom::BloomFilterCache;
-use crate::session::Session;
 
 /// A single edit operation targeting a line range by hash anchors.
 #[derive(Debug, Clone)]
@@ -41,7 +40,7 @@ struct EditDiff {
 
 /// Result of applying edits to a file.
 #[derive(Debug)]
-pub enum EditResult {
+enum EditResult {
     /// All edits applied successfully.
     Applied {
         /// Compact diff showing `-`/`+` lines per edit site.
@@ -61,7 +60,7 @@ pub enum EditResult {
 /// 4. Splice replacements
 /// 5. Write file
 /// 6. Return hashlined context around edit sites
-pub fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
+fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
     if edits.is_empty() {
         return Ok(EditResult::Applied {
             diff: String::new(),
@@ -319,41 +318,46 @@ fn format_diffs(diffs: &[EditDiff]) -> String {
 /// index order even though execution order is not deterministic.
 pub fn apply_batch(
     tasks: Vec<FileEditTask>,
-    session: &Session,
     bloom: &Arc<BloomFilterCache>,
     show_diff: bool,
 ) -> Result<String, String> {
     let outcomes: Vec<(String, bool)> = tasks
         .into_par_iter()
-        .map(|task| match task {
-            FileEditTask::ParseError { label, msg } => (format!("## {label}\nerror: {msg}"), false),
-            FileEditTask::Ready { path, edits } => {
-                session.record_read(&path);
-                let header = format!("## {}", path.display());
-                match apply_one(&path, &edits, bloom, show_diff) {
-                    Ok(body) if body.is_empty() => (header, true),
-                    Ok(body) => (format!("{header}\n{body}"), true),
-                    Err(msg) => (format!("{header}\n{msg}"), false),
-                }
-            }
-        })
+        .map(|task| apply_one(task, bloom, show_diff))
         .collect();
 
-    let success_count = outcomes.iter().filter(|(_, ok)| *ok).count();
+    let any_success = outcomes.iter().any(|(_, ok)| *ok);
     let combined = outcomes
         .into_iter()
         .map(|(s, _)| s)
         .collect::<Vec<_>>()
         .join("\n\n---\n\n");
 
-    if success_count == 0 {
-        Err(combined)
-    } else {
+    if any_success {
         Ok(combined)
+    } else {
+        Err(combined)
     }
 }
 
-fn apply_one(
+/// Process one task into a `(section, success)` tuple. Kept separate so the
+/// parallel closure stays trivial and per-file logic is testable in isolation.
+fn apply_one(task: FileEditTask, bloom: &Arc<BloomFilterCache>, show_diff: bool) -> (String, bool) {
+    let (path, edits) = match task {
+        FileEditTask::ParseError { label, msg } => {
+            return (format!("## {label}\nerror: {msg}"), false);
+        }
+        FileEditTask::Ready { path, edits } => (path, edits),
+    };
+    let header = format!("## {}", path.display());
+    match render_applied(&path, &edits, bloom, show_diff) {
+        Ok(body) if body.is_empty() => (header, true),
+        Ok(body) => (format!("{header}\n{body}"), true),
+        Err(msg) => (format!("{header}\n{msg}"), false),
+    }
+}
+
+fn render_applied(
     path: &Path,
     edits: &[Edit],
     bloom: &Arc<BloomFilterCache>,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,56 +1,27 @@
 use std::path::PathBuf;
 
+use thiserror::Error;
+
 /// Every error tilth can produce. Displayed as user-facing messages with suggestions.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TilthError {
+    #[error("not found: {}{}", path.display(), suggestion.as_deref().map_or(String::new(), |s| format!(" — did you mean: {s}")))]
     NotFound {
         path: PathBuf,
         suggestion: Option<String>,
     },
-    PermissionDenied {
-        path: PathBuf,
-    },
-    InvalidQuery {
-        query: String,
-        reason: String,
-    },
+    #[error("{} [permission denied]", path.display())]
+    PermissionDenied { path: PathBuf },
+    #[error("invalid query \"{query}\": {reason}")]
+    InvalidQuery { query: String, reason: String },
+    #[error("{}: {source}", path.display())]
     IoError {
         path: PathBuf,
         source: std::io::Error,
     },
-    ParseError {
-        path: PathBuf,
-        reason: String,
-    },
+    #[error("parse error in {}: {reason}", path.display())]
+    ParseError { path: PathBuf, reason: String },
 }
-
-impl std::fmt::Display for TilthError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound { path, suggestion } => {
-                write!(f, "not found: {}", path.display())?;
-                if let Some(s) = suggestion {
-                    write!(f, " — did you mean: {s}")?;
-                }
-                Ok(())
-            }
-            Self::PermissionDenied { path } => {
-                write!(f, "{} [permission denied]", path.display())
-            }
-            Self::InvalidQuery { query, reason } => {
-                write!(f, "invalid query \"{query}\": {reason}")
-            }
-            Self::IoError { path, source } => {
-                write!(f, "{}: {source}", path.display())
-            }
-            Self::ParseError { path, reason } => {
-                write!(f, "parse error in {}: {reason}", path.display())
-            }
-        }
-    }
-}
-
-impl std::error::Error for TilthError {}
 
 impl TilthError {
     /// Exit code matching the spec.

--- a/src/index/bloom.rs
+++ b/src/index/bloom.rs
@@ -7,127 +7,11 @@
 //! Identifier extraction uses a simple byte-level state machine -- no
 //! tree-sitter needed -- making it fast enough to run on every uncached file.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use dashmap::DashMap;
-
-// ---------------------------------------------------------------------------
-// BloomFilter
-// ---------------------------------------------------------------------------
-
-/// A probabilistic set membership data structure.
-///
-/// Supports `insert` and `contains`. `contains` may return false positives
-/// but never false negatives: if it returns `false`, the item is definitely
-/// absent.
-pub struct BloomFilter {
-    bits: Vec<u64>,
-    num_hashes: u8,
-    num_bits: usize,
-}
-
-impl BloomFilter {
-    /// Create a new Bloom filter sized for `expected_items` with the given
-    /// target false-positive rate.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `expected_items` is 0 or `target_fpr` is not in (0, 1).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tilth::index::bloom::BloomFilter;
-    ///
-    /// let bf = BloomFilter::new(100, 0.01);
-    /// assert!(!bf.contains("hello"));
-    /// ```
-    #[must_use]
-    #[allow(clippy::cast_precision_loss)] // expected_items fits in f64 mantissa for practical sizes
-    pub fn new(expected_items: usize, target_fpr: f64) -> Self {
-        assert!(expected_items > 0, "expected_items must be > 0");
-        assert!(
-            target_fpr > 0.0 && target_fpr < 1.0,
-            "target_fpr must be in (0, 1)"
-        );
-
-        let n = expected_items as f64;
-        let ln2 = std::f64::consts::LN_2;
-
-        // Optimal number of bits: m = -(n * ln(p)) / (ln(2)^2)
-        let m = (-(n * target_fpr.ln()) / (ln2 * ln2)).ceil() as usize;
-        let m = m.max(64); // minimum 1 word
-
-        // Optimal number of hash functions: k = (m/n) * ln(2)
-        #[allow(clippy::cast_precision_loss)]
-        let k = ((m as f64 / n) * ln2).ceil() as u8;
-        let k = k.clamp(1, 32);
-
-        // Round up to full u64 words
-        let num_words = m.div_ceil(64);
-        let num_bits = num_words * 64;
-
-        Self {
-            bits: vec![0u64; num_words],
-            num_hashes: k,
-            num_bits,
-        }
-    }
-
-    /// Insert an item into the filter.
-    pub fn insert(&mut self, item: &str) {
-        let (h1, h2) = double_hash(item);
-        for i in 0..u64::from(self.num_hashes) {
-            let idx = combined_hash(h1, h2, i, self.num_bits);
-            let word = idx / 64;
-            let bit = idx % 64;
-            self.bits[word] |= 1u64 << bit;
-        }
-    }
-
-    /// Check if an item is probably in the filter.
-    ///
-    /// Returns `true` if the item is PROBABLY present, `false` if it is
-    /// DEFINITELY absent.
-    #[must_use]
-    pub fn contains(&self, item: &str) -> bool {
-        let (h1, h2) = double_hash(item);
-        for i in 0..u64::from(self.num_hashes) {
-            let idx = combined_hash(h1, h2, i, self.num_bits);
-            let word = idx / 64;
-            let bit = idx % 64;
-            if self.bits[word] & (1u64 << bit) == 0 {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-/// Compute two independent hashes for double-hashing.
-fn double_hash(item: &str) -> (u64, u64) {
-    let h1 = hash_with_seed(item, 0);
-    let h2 = hash_with_seed(item, 0x517c_c1b7_2722_0a95); // arbitrary non-zero seed
-    (h1, h2)
-}
-
-/// Combine h1 and h2 into the i-th hash value, mapped to `[0, num_bits)`.
-fn combined_hash(h1: u64, h2: u64, i: u64, num_bits: usize) -> usize {
-    // h(i) = h1 + i * h2 (mod num_bits)
-    let hash = h1.wrapping_add(i.wrapping_mul(h2));
-    (hash % num_bits as u64) as usize
-}
-
-/// Hash a string with a given seed using `DefaultHasher`.
-fn hash_with_seed(item: &str, seed: u64) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    seed.hash(&mut hasher);
-    item.hash(&mut hasher);
-    hasher.finish()
-}
+use fastbloom::BloomFilter;
 
 // ---------------------------------------------------------------------------
 // BloomFilterCache
@@ -181,11 +65,10 @@ impl BloomFilterCache {
 
 /// Build a Bloom filter from file content by extracting all identifiers.
 fn build_filter(content: &str) -> BloomFilter {
-    // Count identifiers first to size the filter appropriately.
     let idents: Vec<&str> = extract_identifiers(content).collect();
     let expected = idents.len().max(1);
 
-    let mut filter = BloomFilter::new(expected, 0.01);
+    let mut filter = BloomFilter::with_false_pos(0.01).expected_items(expected);
     for ident in idents {
         filter.insert(ident);
     }
@@ -375,7 +258,7 @@ mod tests {
 
     #[test]
     fn test_basic_membership() {
-        let mut bf = BloomFilter::new(100, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(100);
         bf.insert("foo");
         bf.insert("bar");
         bf.insert("baz");
@@ -387,7 +270,7 @@ mod tests {
 
     #[test]
     fn test_definitely_not_present() {
-        let mut bf = BloomFilter::new(10, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(10);
         bf.insert("alpha");
         bf.insert("beta");
         bf.insert("gamma");
@@ -415,7 +298,7 @@ mod tests {
     #[test]
     fn test_false_positive_rate() {
         let n = 500;
-        let mut bf = BloomFilter::new(n, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(n);
 
         // Insert N items
         for i in 0..n {
@@ -517,17 +400,6 @@ mod tests {
         // Different mtime: should rebuild from new content
         assert!(cache.contains(path, mtime_new, new_content, "new_function"));
         assert!(!cache.contains(path, mtime_new, new_content, "old_function"));
-    }
-
-    #[test]
-    fn test_bloom_filter_sizing() {
-        // Verify the filter creates a reasonable number of bits
-        let bf = BloomFilter::new(100, 0.01);
-        // Optimal: ~960 bits (15 words). Allow some rounding.
-        assert!(bf.num_bits >= 896, "too few bits: {}", bf.num_bits);
-        assert!(bf.num_bits <= 1088, "too many bits: {}", bf.num_bits);
-        assert!(bf.num_hashes >= 5, "too few hashes: {}", bf.num_hashes);
-        assert!(bf.num_hashes <= 10, "too many hashes: {}", bf.num_hashes);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod overview;
 pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod session;
+pub(crate) mod timeout;
 pub(crate) mod types;
 
 use std::path::Path;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,8 +1,6 @@
 use std::fmt::Write as _;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -13,21 +11,30 @@ use crate::cache::OutlineCache;
 use crate::index::bloom::BloomFilterCache;
 use crate::index::SymbolIndex;
 use crate::session::Session;
+use crate::timeout::{self, spawn_with_timeout, SpawnFailure, ThreadTracker};
 
-/// Tracks abandoned threads (timed out but still running). Warns on stderr
-/// when accumulation exceeds threshold to help diagnose resource pressure.
-static ABANDONED_THREADS: AtomicUsize = AtomicUsize::new(0);
-const ABANDONED_THREAD_WARN: usize = 3;
+/// Shared dependencies passed through the request → dispatch pipeline.
+#[derive(Clone)]
+pub(crate) struct Services {
+    pub(crate) cache: Arc<OutlineCache>,
+    pub(crate) session: Arc<Session>,
+    pub(crate) index: Arc<SymbolIndex>,
+    pub(crate) bloom: Arc<BloomFilterCache>,
+    pub(crate) tracker: Arc<ThreadTracker>,
+    pub(crate) edit_mode: bool,
+}
 
-/// Per-request timeout for tool calls. If a tool doesn't respond within this
-/// duration, the MCP server returns a timeout error instead of hanging.
-/// Override with `TILTH_TIMEOUT` env var (seconds). Default: 90s.
-fn request_timeout() -> Duration {
-    let secs = std::env::var("TILTH_TIMEOUT")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(90);
-    Duration::from_secs(secs)
+impl Services {
+    pub(crate) fn new(edit_mode: bool) -> Self {
+        Self {
+            cache: Arc::new(OutlineCache::new()),
+            session: Arc::new(Session::new()),
+            index: Arc::new(SymbolIndex::new()),
+            bloom: Arc::new(BloomFilterCache::new()),
+            tracker: Arc::new(ThreadTracker::new()),
+            edit_mode,
+        }
+    }
 }
 
 // Sent to the LLM via the MCP `instructions` field during initialization.
@@ -120,10 +127,7 @@ pub fn run(edit_mode: bool, scope: Option<&Path>) -> io::Result<()> {
         }
     }
 
-    let cache = Arc::new(OutlineCache::new());
-    let session = Arc::new(Session::new());
-    let symbol_index = Arc::new(SymbolIndex::new());
-    let bloom_cache = Arc::new(BloomFilterCache::new());
+    let services = Services::new(edit_mode);
     let stdin = io::stdin();
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
@@ -182,14 +186,7 @@ pub fn run(edit_mode: bool, scope: Option<&Path>) -> io::Result<()> {
             params,
         };
 
-        let response = handle_request(
-            &req,
-            &cache,
-            &session,
-            &symbol_index,
-            &bloom_cache,
-            edit_mode,
-        );
+        let response = handle_request(&req, &services);
         serde_json::to_writer(&mut stdout, &response)?;
         stdout.write_all(b"\n")?;
         stdout.flush()?;
@@ -285,14 +282,8 @@ struct JsonRpcError {
     message: String,
 }
 
-fn handle_request(
-    req: &JsonRpcRequest,
-    cache: &Arc<OutlineCache>,
-    session: &Arc<Session>,
-    index: &Arc<SymbolIndex>,
-    bloom: &Arc<BloomFilterCache>,
-    edit_mode: bool,
-) -> JsonRpcResponse {
+fn handle_request(req: &JsonRpcRequest, services: &Services) -> JsonRpcResponse {
+    let edit_mode = services.edit_mode;
     match req.method.as_str() {
         "initialize" => {
             let overview = if std::env::var("TILTH_NO_OVERVIEW").is_ok() {
@@ -339,7 +330,7 @@ fn handle_request(
             error: None,
         },
 
-        "tools/call" => handle_tool_call(req, cache, session, index, bloom, edit_mode),
+        "tools/call" => handle_tool_call(req, services),
 
         "ping" => JsonRpcResponse {
             jsonrpc: "2.0",
@@ -364,26 +355,26 @@ fn handle_request(
 // Tool dispatch
 // ---------------------------------------------------------------------------
 
-/// Execute a tool by name with the given arguments. Returns formatted output or error string.
 /// No classifier involved — the caller specifies the tool explicitly.
-pub(crate) fn dispatch_tool(
-    tool: &str,
-    args: &Value,
-    cache: &OutlineCache,
-    session: &Session,
-    index: &Arc<SymbolIndex>,
-    bloom: &Arc<BloomFilterCache>,
-    edit_mode: bool,
-) -> Result<String, String> {
+fn dispatch_tool(services: &Services, tool: &str, args: &Value) -> Result<String, String> {
+    let edit_mode = services.edit_mode;
     match tool {
-        "tilth_read" => tool_read(args, cache, session, edit_mode),
-        "tilth_search" => tool_search(args, cache, session, index, bloom),
-        "tilth_files" => tool_files(args, cache),
-        "tilth_deps" => tool_deps(args, cache, bloom),
+        "tilth_read" => tool_read(args, &services.cache, &services.session, edit_mode),
+        "tilth_search" => tool_search(
+            args,
+            &services.cache,
+            &services.session,
+            &services.index,
+            &services.bloom,
+        ),
+        "tilth_files" => tool_files(args, &services.cache),
+        "tilth_deps" => tool_deps(args, &services.cache, &services.bloom),
         "tilth_diff" => tool_diff(args),
         "tilth_map" => Err("tilth_map is disabled — use tilth_search instead".into()),
-        "tilth_session" => tool_session(args, session),
-        "tilth_edit" if edit_mode => tool_edit(args, session, cache, bloom),
+        "tilth_session" => tool_session(args, &services.session),
+        "tilth_edit" if edit_mode => {
+            tool_edit(args, &services.session, &services.cache, &services.bloom)
+        }
         _ => Err(format!("unknown tool: {tool}")),
     }
 }
@@ -396,7 +387,7 @@ fn tool_read(
 ) -> Result<String, String> {
     let budget = args.get("budget").and_then(serde_json::Value::as_u64);
 
-    // Multi-file batch read (capped at 20 to bound I/O)
+    // Multi-file batch read (capped at 20 to bound I/O).
     if let Some(paths_arr) = args.get("paths").and_then(|v| v.as_array()) {
         if paths_arr.len() > 20 {
             return Err(format!(
@@ -405,37 +396,16 @@ fn tool_read(
             ));
         }
 
-        // Aggregate deadline for batch reads: 60s default, override with TILTH_BATCH_TIMEOUT
-        // Note: deadline is checked between files, so a single massive file could still
-        // exceed it. The per-request timeout (handle_tool_call) catches that case.
-        let batch_timeout = std::env::var("TILTH_BATCH_TIMEOUT")
-            .ok()
-            .and_then(|v| v.parse::<u64>().ok())
-            .unwrap_or(60);
-        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(batch_timeout);
+        let paths: Vec<PathBuf> = paths_arr
+            .iter()
+            .map(|p| {
+                p.as_str()
+                    .ok_or("paths must be an array of strings")
+                    .map(PathBuf::from)
+            })
+            .collect::<Result<_, _>>()?;
 
-        let mut results = Vec::with_capacity(paths_arr.len());
-        for (i, p) in paths_arr.iter().enumerate() {
-            // Check deadline before each file
-            if std::time::Instant::now() > deadline {
-                results.push(format!(
-                    "# batch read stopped — deadline exceeded after {}/{} files. \
-                     Reduce batch size or set TILTH_BATCH_TIMEOUT=<seconds>.",
-                    i,
-                    paths_arr.len()
-                ));
-                break;
-            }
-
-            let path_str = p.as_str().ok_or("paths must be an array of strings")?;
-            let path = PathBuf::from(path_str);
-            session.record_read(&path);
-            match crate::read::read_file(&path, None, false, cache, edit_mode) {
-                Ok(output) => results.push(output),
-                Err(e) => results.push(format!("# {} — error: {}", path.display(), e)),
-            }
-        }
-        let combined = results.join("\n\n");
+        let combined = crate::read::read_batch(&paths, cache, session, edit_mode);
         return Ok(apply_budget(combined, budget));
     }
 
@@ -752,99 +722,66 @@ fn apply_budget(output: String, budget: Option<u64>) -> String {
 // MCP tool call handler
 // ---------------------------------------------------------------------------
 
-fn handle_tool_call(
-    req: &JsonRpcRequest,
-    cache: &Arc<OutlineCache>,
-    session: &Arc<Session>,
-    index: &Arc<SymbolIndex>,
-    bloom: &Arc<BloomFilterCache>,
-    edit_mode: bool,
-) -> JsonRpcResponse {
+fn handle_tool_call(req: &JsonRpcRequest, services: &Services) -> JsonRpcResponse {
     let params = &req.params;
     let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let args = params.get("arguments").unwrap_or(&Value::Null);
 
-    // Clone values needed by the worker thread
-    let tool_name_owned = tool_name.to_string();
-    let args_owned = args.clone();
-    let cache_clone = Arc::clone(cache);
-    let session_clone = Arc::clone(session);
-    let index_clone = Arc::clone(index);
-    let bloom_clone = Arc::clone(bloom);
-
-    let (tx, rx) = mpsc::channel();
-    let timeout = request_timeout();
-
-    let handle = std::thread::spawn(move || {
-        let result = dispatch_tool(
-            &tool_name_owned,
-            &args_owned,
-            &cache_clone,
-            &session_clone,
-            &index_clone,
-            &bloom_clone,
-            edit_mode,
-        );
-        let _ = tx.send(result);
-    });
-
-    let result = match rx.recv_timeout(timeout) {
-        Ok(result) => {
-            // Thread finished in time — join it to reclaim resources
-            let _ = handle.join();
-            result
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            // Thread is still running — we can't safely kill it, but we return
-            // an error to the client immediately. The thread will finish in the
-            // background and its result will be dropped.
-            //
-            // Note: we intentionally do NOT join here to avoid blocking the
-            // main loop. The thread will complete and exit on its own.
-            let abandoned = ABANDONED_THREADS.fetch_add(1, Ordering::Relaxed) + 1;
-            if abandoned >= ABANDONED_THREAD_WARN {
-                eprintln!(
-                    "tilth: warning: {abandoned} abandoned threads still running. \
-                     Consider reducing scope or increasing TILTH_TIMEOUT."
-                );
-            }
-            Err(format!(
-                "tool timed out after {}s — the operation took too long. \
-                 Try: reduce scope, use section instead of full, or set \
-                 TILTH_TIMEOUT=<seconds> to increase the limit.",
-                timeout.as_secs()
-            ))
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            // Thread panicked — the channel was dropped without sending
-            Err("tool panicked during execution".into())
-        }
+    let result = if services.tracker.is_at_cap() {
+        Err(
+            "server busy: too many prior operations still running after timeout. \
+             Wait or set TILTH_TIMEOUT=<seconds> higher."
+                .into(),
+        )
+    } else {
+        run_tool_with_timeout(services, tool_name, args, timeout::request_timeout())
     };
 
+    build_response(req.id.as_ref(), result)
+}
+
+fn build_response(id: Option<&Value>, result: Result<String, String>) -> JsonRpcResponse {
+    let (text, is_error) = match result {
+        Ok(output) => (output, false),
+        Err(e) => (e, true),
+    };
+    let mut payload = serde_json::json!({
+        "content": [{ "type": "text", "text": text }]
+    });
+    if is_error {
+        payload["isError"] = Value::Bool(true);
+    }
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id: id.cloned(),
+        result: Some(payload),
+        error: None,
+    }
+}
+
+fn run_tool_with_timeout(
+    services: &Services,
+    tool_name: &str,
+    args: &Value,
+    timeout: Duration,
+) -> Result<String, String> {
+    let services_worker = services.clone();
+    let tool = tool_name.to_string();
+    let args_owned = args.clone();
+
+    let result = spawn_with_timeout(&services.tracker, timeout, move || {
+        dispatch_tool(&services_worker, &tool, &args_owned)
+    });
+
     match result {
-        Ok(output) => JsonRpcResponse {
-            jsonrpc: "2.0",
-            id: req.id.clone(),
-            result: Some(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            })),
-            error: None,
-        },
-        Err(e) => JsonRpcResponse {
-            jsonrpc: "2.0",
-            id: req.id.clone(),
-            result: Some(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": e
-                }],
-                "isError": true
-            })),
-            error: None,
-        },
+        Ok(inner) => inner,
+        Err(SpawnFailure::Timeout) => Err(format!(
+            "tool timed out after {}s — the operation took too long. \
+             Try: reduce scope, use section instead of full, or set \
+             TILTH_TIMEOUT=<seconds> to increase the limit.",
+            timeout.as_secs()
+        )),
+        Err(SpawnFailure::Panic) => Err("tool panicked during execution".into()),
     }
 }
 
@@ -1293,5 +1230,86 @@ mod tests {
         let root_canon = root.unwrap().canonicalize().unwrap();
         let expected_canon = project_path.canonicalize().unwrap();
         assert_eq!(root_canon, expected_canon);
+    }
+
+    fn services_with_tracker(tracker: Arc<ThreadTracker>) -> Services {
+        Services {
+            cache: Arc::new(OutlineCache::new()),
+            session: Arc::new(Session::new()),
+            index: Arc::new(SymbolIndex::new()),
+            bloom: Arc::new(BloomFilterCache::new()),
+            tracker,
+            edit_mode: false,
+        }
+    }
+
+    #[test]
+    fn abandoned_hard_cap_returns_server_busy() {
+        let tracker = Arc::new(ThreadTracker::new());
+        tracker.saturate();
+        let services = services_with_tracker(tracker);
+
+        let req = JsonRpcRequest {
+            _jsonrpc: "2.0".into(),
+            id: Some(serde_json::json!(1)),
+            method: "tools/call".into(),
+            params: serde_json::json!({
+                "name": "tilth_files",
+                "arguments": { "pattern": "*.rs" }
+            }),
+        };
+
+        let resp = handle_tool_call(&req, &services);
+
+        let result = resp.result.expect("response must have a result field");
+        let is_error = result
+            .get("isError")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false);
+        assert!(is_error, "response must have isError: true");
+
+        let text = result["content"][0]["text"].as_str().unwrap_or("");
+        assert!(
+            text.contains("server busy"),
+            "error message must contain 'server busy', got: {text}"
+        );
+        assert!(
+            text.contains("TILTH_TIMEOUT"),
+            "error message must include TILTH_TIMEOUT hint, got: {text}"
+        );
+    }
+
+    /// Batch reads must return the content of every submitted path — no file
+    /// is dropped or reordered on the way through the tool handler.
+    #[test]
+    fn batch_read_returns_all_files() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_count = 5usize;
+
+        let paths: Vec<PathBuf> = (0..file_count)
+            .map(|i| {
+                let p = dir.path().join(format!("file{i}.txt"));
+                std::fs::write(&p, format!("content-of-file-{i}")).unwrap();
+                p
+            })
+            .collect();
+
+        let paths_json: Vec<serde_json::Value> = paths
+            .iter()
+            .map(|p| serde_json::json!(p.to_str().unwrap()))
+            .collect();
+
+        let args = serde_json::json!({ "paths": paths_json });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let result = tool_read(&args, &cache, &session, false).expect("batch read must succeed");
+
+        for i in 0..file_count {
+            assert!(
+                result.contains(&format!("content-of-file-{i}")),
+                "output must contain content of file {i}"
+            );
+        }
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -612,21 +612,12 @@ fn tool_session(args: &Value, session: &Session) -> Result<String, String> {
     }
 }
 
-/// One file's worth of work for a batch `tilth_edit`. Parse errors are deferred
-/// onto the task so a malformed entry surfaces as a per-file failure instead
-/// of aborting the whole batch.
-enum FileEditTask {
-    Ready {
-        path: PathBuf,
-        edits: Vec<crate::edit::Edit>,
-    },
-    ParseError {
-        label: String,
-        msg: String,
-    },
-}
+/// Parse one `files[]` entry into a [`crate::edit::FileEditTask`]. Parse errors
+/// are deferred onto the task so a malformed entry surfaces as a per-file
+/// failure instead of aborting the whole batch.
+fn parse_file_edit(index: usize, val: &Value) -> crate::edit::FileEditTask {
+    use crate::edit::FileEditTask;
 
-fn parse_file_edit(index: usize, val: &Value) -> FileEditTask {
     let Some(path_str) = val.get("path").and_then(|v| v.as_str()) else {
         return FileEditTask::ParseError {
             label: format!("files[{index}]"),
@@ -686,44 +677,8 @@ fn parse_file_edit(index: usize, val: &Value) -> FileEditTask {
     }
 }
 
-fn apply_one_file_edit(
-    path: &Path,
-    edits: &[crate::edit::Edit],
-    bloom: &Arc<BloomFilterCache>,
-    show_diff: bool,
-) -> Result<String, String> {
-    match crate::edit::apply_edits(path, edits).map_err(|e| e.to_string())? {
-        crate::edit::EditResult::Applied { diff, context } => {
-            let mut output = String::new();
-            if show_diff && !diff.is_empty() {
-                output.push_str(&diff);
-                if !context.is_empty() {
-                    output.push_str("\n\n");
-                }
-            }
-            if !context.is_empty() {
-                output.push_str(&context);
-            }
-            let abs_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
-            let scope = crate::lang::package_root(&abs_path).map_or_else(
-                || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
-                std::path::Path::to_path_buf,
-            );
-            if let Some(blast) = crate::search::blast::blast_radius(path, edits, &scope, bloom) {
-                output.push_str(&blast);
-            }
-            Ok(output)
-        }
-        crate::edit::EditResult::HashMismatch(msg) => Err(format!(
-            "hash mismatch — file changed since last read:\n\n{msg}"
-        )),
-    }
-}
-
-/// Batch `tilth_edit`. Each file in `files` is processed independently — a
-/// hash mismatch or parse error on one file does not block siblings. Returns
-/// `Ok` if at least one file succeeded; `Err` only when every file failed
-/// (so the MCP response gets `isError: true`).
+/// Batch `tilth_edit`. Parses the `files` array, enforces the 20-file cap,
+/// then delegates to [`crate::edit::apply_batch`] for parallel application.
 fn tool_edit(
     args: &Value,
     session: &Session,
@@ -750,47 +705,13 @@ fn tool_edit(
         .and_then(serde_json::Value::as_bool)
         .unwrap_or(false);
 
-    let tasks: Vec<FileEditTask> = files_val
+    let tasks: Vec<crate::edit::FileEditTask> = files_val
         .iter()
         .enumerate()
         .map(|(i, v)| parse_file_edit(i, v))
         .collect();
 
-    let mut sections: Vec<String> = Vec::with_capacity(tasks.len());
-    let mut success_count = 0usize;
-
-    for task in tasks {
-        match task {
-            FileEditTask::ParseError { label, msg } => {
-                sections.push(format!("## {label}\nerror: {msg}"));
-            }
-            FileEditTask::Ready { path, edits } => {
-                session.record_read(&path);
-                let header = format!("## {}", path.display());
-                match apply_one_file_edit(&path, &edits, bloom, show_diff) {
-                    Ok(body) => {
-                        success_count += 1;
-                        if body.is_empty() {
-                            sections.push(header);
-                        } else {
-                            sections.push(format!("{header}\n{body}"));
-                        }
-                    }
-                    Err(msg) => {
-                        sections.push(format!("{header}\n{msg}"));
-                    }
-                }
-            }
-        }
-    }
-
-    let combined = sections.join("\n\n---\n\n");
-
-    if success_count == 0 {
-        Err(combined)
-    } else {
-        Ok(combined)
-    }
+    crate::edit::apply_batch(tasks, session, bloom, show_diff)
 }
 
 /// Falls back to cwd when scope is invalid, with a warning message.

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -42,6 +42,8 @@ impl Services {
 const SERVER_INSTRUCTIONS: &str = "\
 tilth — code intelligence MCP server. Replaces grep, cat, find, ls with AST-aware equivalents.\n\
 \n\
+ALWAYS BATCH. When you have 2+ files to read, call tilth_read once with paths: [...]. When you have edits to multiple files, call tilth_edit once with files: [...]. Never make N serial calls when one will do — each tool call is a turn.\n\
+\n\
 To explore code, always search first. tilth_search finds definitions, usages, and file locations in one call.\n\
 Usage: tilth_search(query: \"handleRequest\").\n\
 tilth_files is ONLY for listing directory contents when you have no symbol or text to search for.\n\
@@ -64,10 +66,11 @@ tilth_search: Search code — finds definitions, usages, and text. Replaces grep
       <name>  <path>:<start>-<end>  <signature>\n\
   Re-expanding a previously shown definition returns [shown earlier].\n\
 \n\
-tilth_read: Read file content with smart outlining. Replaces cat/head/tail.\n\
+tilth_read: Read one or more files with smart outlining. Replaces cat/head/tail.\n\
+  paths: [\"a.rs\", \"b.rs\"] reads many in one call (max 20). PREFER this over serial single-file reads.\n\
+  path: \"a.rs\" for a single file.\n\
   Small files → full content. Large files → structural outline.\n\
   section: \"<start>-<end>\" or \"<heading text>\"\n\
-  paths: read multiple files in one call.\n\
   Output:\n\
     <line_number> │ <content>                  ← full/section mode\n\
     [<start>-<end>]  <symbol name>             ← outline mode\n\
@@ -93,15 +96,20 @@ DO NOT re-read files already shown in expanded search results.";
 
 const EDIT_MODE_EXTRA: &str = "\n\
 \n\
-tilth_edit: Edit files using hash-anchored lines. Replaces the host Edit tool.\n\
+tilth_edit: Batch edit one or more files using hash-anchored lines. Replaces the host Edit tool.\n\
+  ALWAYS group edits to multiple files into ONE tilth_edit call (max 20 files). Never call tilth_edit twice in a row.\n\
   tilth_read → copy anchors (<line>:<hash>) (BOTH line and hash required) → pass to tilth_edit.\n\
   tilth_search does NOT provide hashes — you MUST tilth_read the file or section first.\n\
-  Single line: {\"start\": \"<line>:<hash>\", \"content\": \"<new code>\"}\n\
-  Range: {\"start\": \"<line>:<hash>\", \"end\": \"<line>:<hash>\", \"content\": \"...\"}\n\
-  Delete: {\"start\": \"<line>:<hash>\", \"content\": \"\"}\n\
-  Hash mismatch → file changed, re-read and retry.\n\
+  Shape: {\"files\": [{\"path\": \"a.rs\", \"edits\": [...]}, {\"path\": \"b.rs\", \"edits\": [...]}]}\n\
+  Single file: {\"files\": [{\"path\": \"a.rs\", \"edits\": [{\"start\": \"<line>:<hash>\", \"content\": \"<new code>\"}]}]}\n\
+  Edit forms inside `edits`:\n\
+    Single line: {\"start\": \"<line>:<hash>\", \"content\": \"<new code>\"}\n\
+    Range:       {\"start\": \"<line>:<hash>\", \"end\": \"<line>:<hash>\", \"content\": \"...\"}\n\
+    Delete:      {\"start\": \"<line>:<hash>\", \"content\": \"\"}\n\
+  Per-file results: each file is processed independently. A hash mismatch on one file does NOT block the others.\n\
+  Hash mismatch → file changed, re-read THAT file and retry it (other files in the batch already applied).\n\
   Large files: tilth_read shows outline — use section to get hashlined content.\n\
-  Pass diff: true to see a compact before/after diff in the response.\n\
+  Pass diff: true to see a compact before/after diff per file.\n\
   After editing a function signature, tilth_edit shows callers that may need updating.\n\
 DO NOT use the host Edit tool. Use tilth_edit for all edits.";
 
@@ -604,44 +612,65 @@ fn tool_session(args: &Value, session: &Session) -> Result<String, String> {
     }
 }
 
-fn tool_edit(
-    args: &Value,
-    session: &Session,
-    _cache: &OutlineCache,
-    bloom: &Arc<BloomFilterCache>,
-) -> Result<String, String> {
-    let path_str = args
-        .get("path")
-        .and_then(|v| v.as_str())
-        .ok_or("missing required parameter: path")?;
-    let path = PathBuf::from(path_str);
+/// One file's worth of work for a batch `tilth_edit`. Parse errors are deferred
+/// onto the task so a malformed entry surfaces as a per-file failure instead
+/// of aborting the whole batch.
+enum FileEditTask {
+    Ready {
+        path: PathBuf,
+        edits: Vec<crate::edit::Edit>,
+    },
+    ParseError {
+        label: String,
+        msg: String,
+    },
+}
 
-    let edits_val = args
-        .get("edits")
-        .and_then(|v| v.as_array())
-        .ok_or("missing required parameter: edits")?;
+fn parse_file_edit(index: usize, val: &Value) -> FileEditTask {
+    let Some(path_str) = val.get("path").and_then(|v| v.as_str()) else {
+        return FileEditTask::ParseError {
+            label: format!("files[{index}]"),
+            msg: "missing 'path'".into(),
+        };
+    };
+    let Some(edits_val) = val.get("edits").and_then(|v| v.as_array()) else {
+        return FileEditTask::ParseError {
+            label: path_str.to_string(),
+            msg: "missing 'edits' array".into(),
+        };
+    };
 
     let mut edits = Vec::with_capacity(edits_val.len());
     for (i, e) in edits_val.iter().enumerate() {
-        let start_str = e
-            .get("start")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("edit[{i}]: missing 'start'"))?;
-        let (start_line, start_hash) = crate::format::parse_anchor(start_str)
-            .ok_or_else(|| format!("edit[{i}]: invalid start anchor '{start_str}'"))?;
-
+        let Some(start_str) = e.get("start").and_then(|v| v.as_str()) else {
+            return FileEditTask::ParseError {
+                label: path_str.to_string(),
+                msg: format!("edit[{i}]: missing 'start'"),
+            };
+        };
+        let Some((start_line, start_hash)) = crate::format::parse_anchor(start_str) else {
+            return FileEditTask::ParseError {
+                label: path_str.to_string(),
+                msg: format!("edit[{i}]: invalid start anchor '{start_str}'"),
+            };
+        };
         let (end_line, end_hash) = if let Some(end_str) = e.get("end").and_then(|v| v.as_str()) {
-            crate::format::parse_anchor(end_str)
-                .ok_or_else(|| format!("edit[{i}]: invalid end anchor '{end_str}'"))?
+            let Some(parsed) = crate::format::parse_anchor(end_str) else {
+                return FileEditTask::ParseError {
+                    label: path_str.to_string(),
+                    msg: format!("edit[{i}]: invalid end anchor '{end_str}'"),
+                };
+            };
+            parsed
         } else {
             (start_line, start_hash)
         };
-
-        let content = e
-            .get("content")
-            .and_then(|v| v.as_str())
-            .ok_or_else(|| format!("edit[{i}]: missing 'content'"))?;
-
+        let Some(content) = e.get("content").and_then(|v| v.as_str()) else {
+            return FileEditTask::ParseError {
+                label: path_str.to_string(),
+                msg: format!("edit[{i}]: missing 'content'"),
+            };
+        };
         edits.push(crate::edit::Edit {
             start_line,
             start_hash,
@@ -651,43 +680,116 @@ fn tool_edit(
         });
     }
 
-    let show_diff = args
-        .get("diff")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
+    FileEditTask::Ready {
+        path: PathBuf::from(path_str),
+        edits,
+    }
+}
 
-    session.record_read(&path);
-
-    match crate::edit::apply_edits(&path, &edits).map_err(|e| e.to_string())? {
+fn apply_one_file_edit(
+    path: &Path,
+    edits: &[crate::edit::Edit],
+    bloom: &Arc<BloomFilterCache>,
+    show_diff: bool,
+) -> Result<String, String> {
+    match crate::edit::apply_edits(path, edits).map_err(|e| e.to_string())? {
         crate::edit::EditResult::Applied { diff, context } => {
             let mut output = String::new();
-
             if show_diff && !diff.is_empty() {
                 output.push_str(&diff);
                 if !context.is_empty() {
                     output.push_str("\n\n");
                 }
             }
-
             if !context.is_empty() {
                 output.push_str(&context);
             }
-
-            let abs_path = std::fs::canonicalize(&path).unwrap_or_else(|_| path.clone());
+            let abs_path = std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
             let scope = crate::lang::package_root(&abs_path).map_or_else(
                 || std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")),
                 std::path::Path::to_path_buf,
             );
-
-            if let Some(blast) = crate::search::blast::blast_radius(&path, &edits, &scope, bloom) {
+            if let Some(blast) = crate::search::blast::blast_radius(path, edits, &scope, bloom) {
                 output.push_str(&blast);
             }
-
             Ok(output)
         }
         crate::edit::EditResult::HashMismatch(msg) => Err(format!(
             "hash mismatch — file changed since last read:\n\n{msg}"
         )),
+    }
+}
+
+/// Batch `tilth_edit`. Each file in `files` is processed independently — a
+/// hash mismatch or parse error on one file does not block siblings. Returns
+/// `Ok` if at least one file succeeded; `Err` only when every file failed
+/// (so the MCP response gets `isError: true`).
+fn tool_edit(
+    args: &Value,
+    session: &Session,
+    _cache: &OutlineCache,
+    bloom: &Arc<BloomFilterCache>,
+) -> Result<String, String> {
+    let files_val = args
+        .get("files")
+        .and_then(|v| v.as_array())
+        .ok_or("missing required parameter: files (array of {path, edits})")?;
+
+    if files_val.is_empty() {
+        return Err("files array is empty".into());
+    }
+    if files_val.len() > 20 {
+        return Err(format!(
+            "batch edit limited to 20 files (got {})",
+            files_val.len()
+        ));
+    }
+
+    let show_diff = args
+        .get("diff")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+
+    let tasks: Vec<FileEditTask> = files_val
+        .iter()
+        .enumerate()
+        .map(|(i, v)| parse_file_edit(i, v))
+        .collect();
+
+    let mut sections: Vec<String> = Vec::with_capacity(tasks.len());
+    let mut success_count = 0usize;
+
+    for task in tasks {
+        match task {
+            FileEditTask::ParseError { label, msg } => {
+                sections.push(format!("## {label}\nerror: {msg}"));
+            }
+            FileEditTask::Ready { path, edits } => {
+                session.record_read(&path);
+                let header = format!("## {}", path.display());
+                match apply_one_file_edit(&path, &edits, bloom, show_diff) {
+                    Ok(body) => {
+                        success_count += 1;
+                        if body.is_empty() {
+                            sections.push(header);
+                        } else {
+                            sections.push(format!("{header}\n{body}"));
+                        }
+                    }
+                    Err(msg) => {
+                        sections.push(format!("{header}\n{msg}"));
+                    }
+                }
+            }
+        }
+    }
+
+    let combined = sections.join("\n\n---\n\n");
+
+    if success_count == 0 {
+        Err(combined)
+    } else {
+        Ok(combined)
     }
 }
 
@@ -859,7 +961,9 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "paths": {
                         "type": "array",
                         "items": { "type": "string" },
-                        "description": "Multiple file paths to read in one call. Each file gets independent smart handling. Saves round-trips vs multiple single reads."
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "description": "Multiple file paths to read in one call (max 20). Each file gets independent smart handling. PREFER this over serial single-file reads — saves a turn per extra file."
                     },
                     "section": {
                         "type": "string",
@@ -983,33 +1087,46 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
     if edit_mode {
         tools.push(serde_json::json!({
             "name": "tilth_edit",
-            "description": "Apply edits to a file using hashline anchors from tilth_read. Each edit targets a line range by line:hash anchors. Edits are verified against content hashes and rejected if the file has changed since the last read.",
+            "description": "Batch edit one or more files in one call using hashline anchors from tilth_read. ALWAYS group edits to multiple files into a single tilth_edit call — never call tilth_edit twice in a row. Each file is processed independently (best-effort): a hash mismatch on one file does not block the others; results are reported per file. Max 20 files per call.",
             "inputSchema": {
                 "type": "object",
-                "required": ["path", "edits"],
+                "required": ["files"],
                 "properties": {
-                    "path": {
-                        "type": "string",
-                        "description": "Absolute or relative file path to edit."
-                    },
-                    "edits": {
+                    "files": {
                         "type": "array",
-                        "description": "Array of edit operations, applied atomically.",
+                        "minItems": 1,
+                        "maxItems": 20,
+                        "description": "One entry per file. Use a single-element array for a single-file edit.",
                         "items": {
                             "type": "object",
-                            "required": ["start", "content"],
+                            "required": ["path", "edits"],
                             "properties": {
-                                "start": {
+                                "path": {
                                     "type": "string",
-                                    "description": "Start anchor: 'line:hash' (e.g. '42:a3f'). Hash from tilth_read hashline output."
+                                    "description": "Absolute or relative file path to edit."
                                 },
-                                "end": {
-                                    "type": "string",
-                                    "description": "End anchor: 'line:hash'. If omitted, replaces only the start line."
-                                },
-                                "content": {
-                                    "type": "string",
-                                    "description": "Replacement text (can be multi-line). Empty string to delete the line(s)."
+                                "edits": {
+                                    "type": "array",
+                                    "minItems": 1,
+                                    "description": "Edit operations for this file, applied atomically per file.",
+                                    "items": {
+                                        "type": "object",
+                                        "required": ["start", "content"],
+                                        "properties": {
+                                            "start": {
+                                                "type": "string",
+                                                "description": "Start anchor: 'line:hash' (e.g. '42:a3f'). Hash from tilth_read hashline output."
+                                            },
+                                            "end": {
+                                                "type": "string",
+                                                "description": "End anchor: 'line:hash'. If omitted, replaces only the start line."
+                                            },
+                                            "content": {
+                                                "type": "string",
+                                                "description": "Replacement text (can be multi-line). Empty string to delete the line(s)."
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -1017,7 +1134,7 @@ fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "diff": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Set true to include a compact diff of changes in the response. Useful for batch edits or verifying unexpected results."
+                        "description": "Set true to include a compact diff of changes in the response per file."
                     }
                 }
             }
@@ -1311,5 +1428,175 @@ mod tests {
                 "output must contain content of file {i}"
             );
         }
+    }
+
+    // -- batch tool_edit --------------------------------------------------------
+
+    fn anchor_for(content: &str, line: usize) -> String {
+        let lines: Vec<_> = content.lines().collect();
+        let h = crate::format::line_hash(lines[line - 1].as_bytes());
+        format!("{line}:{h:03x}")
+    }
+
+    fn edit_services() -> (Session, Arc<BloomFilterCache>) {
+        (Session::new(), Arc::new(BloomFilterCache::new()))
+    }
+
+    #[test]
+    fn batch_edit_two_files_succeeds() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_content = "alpha\nbravo\ncharlie\n";
+        let b_content = "uno\ndos\ntres\n";
+        let a = dir.path().join("a.txt");
+        let b = dir.path().join("b.txt");
+        std::fs::write(&a, a_content).unwrap();
+        std::fs::write(&b, b_content).unwrap();
+
+        let args = serde_json::json!({
+            "files": [
+                {
+                    "path": a.to_str().unwrap(),
+                    "edits": [{ "start": anchor_for(a_content, 2), "content": "BRAVO" }]
+                },
+                {
+                    "path": b.to_str().unwrap(),
+                    "edits": [{ "start": anchor_for(b_content, 1), "content": "UNO" }]
+                }
+            ]
+        });
+
+        let (session, bloom) = edit_services();
+        let cache = OutlineCache::new();
+        let out = tool_edit(&args, &session, &cache, &bloom).expect("batch should succeed");
+
+        assert!(
+            out.contains(a.to_str().unwrap()),
+            "must mention file a: {out}"
+        );
+        assert!(
+            out.contains(b.to_str().unwrap()),
+            "must mention file b: {out}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&a).unwrap(),
+            "alpha\nBRAVO\ncharlie\n"
+        );
+        assert_eq!(std::fs::read_to_string(&b).unwrap(), "UNO\ndos\ntres\n");
+    }
+
+    /// A bad-hash failure on file B must not block file A from applying;
+    /// the response is `Ok` because at least one file succeeded, and includes
+    /// both sections separated by `---`.
+    #[test]
+    fn batch_edit_partial_failure_does_not_block_siblings() {
+        let dir = tempfile::tempdir().unwrap();
+        let a_content = "first\nsecond\nthird\n";
+        let b_content = "one\ntwo\nthree\n";
+        let a = dir.path().join("first.txt");
+        let b = dir.path().join("second.txt");
+        std::fs::write(&a, a_content).unwrap();
+        std::fs::write(&b, b_content).unwrap();
+
+        let args = serde_json::json!({
+            "files": [
+                {
+                    "path": a.to_str().unwrap(),
+                    "edits": [{ "start": anchor_for(a_content, 2), "content": "SECOND" }]
+                },
+                {
+                    "path": b.to_str().unwrap(),
+                    "edits": [{ "start": "1:000", "content": "ONE" }]
+                }
+            ]
+        });
+
+        let (session, bloom) = edit_services();
+        let cache = OutlineCache::new();
+        let out =
+            tool_edit(&args, &session, &cache, &bloom).expect("batch is Ok if any file succeeds");
+
+        assert_eq!(
+            std::fs::read_to_string(&a).unwrap(),
+            "first\nSECOND\nthird\n",
+            "first file must have applied"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&b).unwrap(),
+            b_content,
+            "second file must remain untouched"
+        );
+        assert!(
+            out.contains("hash mismatch"),
+            "must report hash mismatch: {out}"
+        );
+        assert!(
+            out.contains("---"),
+            "must separate per-file sections: {out}"
+        );
+    }
+
+    #[test]
+    fn batch_edit_over_limit_rejected() {
+        let tmp = std::env::temp_dir();
+        let mut files = Vec::with_capacity(21);
+        for i in 0..21 {
+            files.push(serde_json::json!({
+                "path": tmp.join(format!("tilth_nonexistent_{i}.txt")).to_str().unwrap(),
+                "edits": [{ "start": "1:000", "content": "x" }]
+            }));
+        }
+        let args = serde_json::json!({ "files": files });
+
+        let (session, bloom) = edit_services();
+        let cache = OutlineCache::new();
+        let err =
+            tool_edit(&args, &session, &cache, &bloom).expect_err("21 files must be rejected");
+        assert!(err.contains("limited to 20"), "must mention limit: {err}");
+    }
+
+    /// All-failed batch returns `Err` so the MCP response sets `isError: true`.
+    #[test]
+    fn batch_edit_all_failed_returns_err() {
+        let tmp = std::env::temp_dir();
+        let p1 = tmp.join("tilth_does_not_exist_xyz_1.txt");
+        let p2 = tmp.join("tilth_does_not_exist_xyz_2.txt");
+        let _ = std::fs::remove_file(&p1);
+        let _ = std::fs::remove_file(&p2);
+
+        let args = serde_json::json!({
+            "files": [
+                {
+                    "path": p1.to_str().unwrap(),
+                    "edits": [{ "start": "1:000", "content": "x" }]
+                },
+                {
+                    "path": p2.to_str().unwrap(),
+                    "edits": [{ "start": "1:000", "content": "x" }]
+                }
+            ]
+        });
+
+        let (session, bloom) = edit_services();
+        let cache = OutlineCache::new();
+        let err = tool_edit(&args, &session, &cache, &bloom).expect_err("all-failed → Err");
+        assert!(
+            err.contains("tilth_does_not_exist_xyz_1"),
+            "must include file 1: {err}"
+        );
+        assert!(
+            err.contains("tilth_does_not_exist_xyz_2"),
+            "must include file 2: {err}"
+        );
+        assert!(err.contains("---"), "must separate sections: {err}");
+    }
+
+    #[test]
+    fn batch_edit_empty_files_array_rejected() {
+        let args = serde_json::json!({ "files": [] });
+        let (session, bloom) = edit_services();
+        let cache = OutlineCache::new();
+        let err = tool_edit(&args, &session, &cache, &bloom)
+            .expect_err("empty files array must be rejected");
+        assert!(err.contains("empty"), "must mention empty: {err}");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -380,9 +380,7 @@ fn dispatch_tool(services: &Services, tool: &str, args: &Value) -> Result<String
         "tilth_diff" => tool_diff(args),
         "tilth_map" => Err("tilth_map is disabled — use tilth_search instead".into()),
         "tilth_session" => tool_session(args, &services.session),
-        "tilth_edit" if edit_mode => {
-            tool_edit(args, &services.session, &services.cache, &services.bloom)
-        }
+        "tilth_edit" if edit_mode => tool_edit(args, &services.session, &services.bloom),
         _ => Err(format!("unknown tool: {tool}")),
     }
 }
@@ -612,9 +610,9 @@ fn tool_session(args: &Value, session: &Session) -> Result<String, String> {
     }
 }
 
-/// Parse one `files[]` entry into a [`crate::edit::FileEditTask`]. Parse errors
-/// are deferred onto the task so a malformed entry surfaces as a per-file
-/// failure instead of aborting the whole batch.
+/// Parse one `files[]` entry. Parse errors are deferred onto the task so a
+/// malformed entry surfaces as a per-file failure instead of aborting the
+/// whole batch.
 fn parse_file_edit(index: usize, val: &Value) -> crate::edit::FileEditTask {
     use crate::edit::FileEditTask;
 
@@ -633,42 +631,15 @@ fn parse_file_edit(index: usize, val: &Value) -> crate::edit::FileEditTask {
 
     let mut edits = Vec::with_capacity(edits_val.len());
     for (i, e) in edits_val.iter().enumerate() {
-        let Some(start_str) = e.get("start").and_then(|v| v.as_str()) else {
-            return FileEditTask::ParseError {
-                label: path_str.to_string(),
-                msg: format!("edit[{i}]: missing 'start'"),
-            };
-        };
-        let Some((start_line, start_hash)) = crate::format::parse_anchor(start_str) else {
-            return FileEditTask::ParseError {
-                label: path_str.to_string(),
-                msg: format!("edit[{i}]: invalid start anchor '{start_str}'"),
-            };
-        };
-        let (end_line, end_hash) = if let Some(end_str) = e.get("end").and_then(|v| v.as_str()) {
-            let Some(parsed) = crate::format::parse_anchor(end_str) else {
+        match parse_edit_entry(i, e) {
+            Ok(edit) => edits.push(edit),
+            Err(msg) => {
                 return FileEditTask::ParseError {
                     label: path_str.to_string(),
-                    msg: format!("edit[{i}]: invalid end anchor '{end_str}'"),
+                    msg,
                 };
-            };
-            parsed
-        } else {
-            (start_line, start_hash)
-        };
-        let Some(content) = e.get("content").and_then(|v| v.as_str()) else {
-            return FileEditTask::ParseError {
-                label: path_str.to_string(),
-                msg: format!("edit[{i}]: missing 'content'"),
-            };
-        };
-        edits.push(crate::edit::Edit {
-            start_line,
-            start_hash,
-            end_line,
-            end_hash,
-            content: content.to_string(),
-        });
+            }
+        }
     }
 
     FileEditTask::Ready {
@@ -677,12 +648,35 @@ fn parse_file_edit(index: usize, val: &Value) -> crate::edit::FileEditTask {
     }
 }
 
-/// Batch `tilth_edit`. Parses the `files` array, enforces the 20-file cap,
-/// then delegates to [`crate::edit::apply_batch`] for parallel application.
+/// Parse a single `edits[]` entry. Flat early-returns keep nesting shallow.
+fn parse_edit_entry(i: usize, e: &Value) -> Result<crate::edit::Edit, String> {
+    let start_str = e
+        .get("start")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("edit[{i}]: missing 'start'"))?;
+    let (start_line, start_hash) = crate::format::parse_anchor(start_str)
+        .ok_or_else(|| format!("edit[{i}]: invalid start anchor '{start_str}'"))?;
+    let (end_line, end_hash) = match e.get("end").and_then(|v| v.as_str()) {
+        Some(end_str) => crate::format::parse_anchor(end_str)
+            .ok_or_else(|| format!("edit[{i}]: invalid end anchor '{end_str}'"))?,
+        None => (start_line, start_hash),
+    };
+    let content = e
+        .get("content")
+        .and_then(|v| v.as_str())
+        .ok_or_else(|| format!("edit[{i}]: missing 'content'"))?;
+    Ok(crate::edit::Edit {
+        start_line,
+        start_hash,
+        end_line,
+        end_hash,
+        content: content.to_string(),
+    })
+}
+
 fn tool_edit(
     args: &Value,
     session: &Session,
-    _cache: &OutlineCache,
     bloom: &Arc<BloomFilterCache>,
 ) -> Result<String, String> {
     let files_val = args
@@ -711,7 +705,13 @@ fn tool_edit(
         .map(|(i, v)| parse_file_edit(i, v))
         .collect();
 
-    crate::edit::apply_batch(tasks, session, bloom, show_diff)
+    for task in &tasks {
+        if let crate::edit::FileEditTask::Ready { path, .. } = task {
+            session.record_read(path);
+        }
+    }
+
+    crate::edit::apply_batch(tasks, bloom, show_diff)
 }
 
 /// Falls back to cwd when scope is invalid, with a warning message.
@@ -1387,8 +1387,7 @@ mod tests {
         });
 
         let (session, bloom) = edit_services();
-        let cache = OutlineCache::new();
-        let out = tool_edit(&args, &session, &cache, &bloom).expect("batch should succeed");
+        let out = tool_edit(&args, &session, &bloom).expect("batch should succeed");
 
         assert!(
             out.contains(a.to_str().unwrap()),
@@ -1398,11 +1397,18 @@ mod tests {
             out.contains(b.to_str().unwrap()),
             "must mention file b: {out}"
         );
+        assert!(
+            !out.contains("error:") && !out.contains("hash mismatch"),
+            "successful batch must not contain error markers: {out}"
+        );
         assert_eq!(
-            std::fs::read_to_string(&a).unwrap(),
+            std::fs::read_to_string(&a).expect("file a should be readable"),
             "alpha\nBRAVO\ncharlie\n"
         );
-        assert_eq!(std::fs::read_to_string(&b).unwrap(), "UNO\ndos\ntres\n");
+        assert_eq!(
+            std::fs::read_to_string(&b).expect("file b should be readable"),
+            "UNO\ndos\ntres\n"
+        );
     }
 
     /// A bad-hash failure on file B must not block file A from applying;
@@ -1432,27 +1438,30 @@ mod tests {
         });
 
         let (session, bloom) = edit_services();
-        let cache = OutlineCache::new();
-        let out =
-            tool_edit(&args, &session, &cache, &bloom).expect("batch is Ok if any file succeeds");
+        let out = tool_edit(&args, &session, &bloom).expect("batch is Ok if any file succeeds");
 
         assert_eq!(
-            std::fs::read_to_string(&a).unwrap(),
+            std::fs::read_to_string(&a).expect("file a should be readable"),
             "first\nSECOND\nthird\n",
             "first file must have applied"
         );
         assert_eq!(
-            std::fs::read_to_string(&b).unwrap(),
+            std::fs::read_to_string(&b).expect("file b should be readable"),
             b_content,
             "second file must remain untouched"
         );
         assert!(
-            out.contains("hash mismatch"),
-            "must report hash mismatch: {out}"
-        );
-        assert!(
             out.contains("---"),
             "must separate per-file sections: {out}"
+        );
+        let (a_section, b_section) = out.split_once("\n\n---\n\n").expect("two sections");
+        assert!(
+            !a_section.contains("hash mismatch"),
+            "file a's section must not report hash mismatch: {a_section}"
+        );
+        assert!(
+            b_section.contains("hash mismatch"),
+            "file b's section must report hash mismatch: {b_section}"
         );
     }
 
@@ -1469,9 +1478,7 @@ mod tests {
         let args = serde_json::json!({ "files": files });
 
         let (session, bloom) = edit_services();
-        let cache = OutlineCache::new();
-        let err =
-            tool_edit(&args, &session, &cache, &bloom).expect_err("21 files must be rejected");
+        let err = tool_edit(&args, &session, &bloom).expect_err("21 files must be rejected");
         assert!(err.contains("limited to 20"), "must mention limit: {err}");
     }
 
@@ -1498,8 +1505,7 @@ mod tests {
         });
 
         let (session, bloom) = edit_services();
-        let cache = OutlineCache::new();
-        let err = tool_edit(&args, &session, &cache, &bloom).expect_err("all-failed → Err");
+        let err = tool_edit(&args, &session, &bloom).expect_err("all-failed → Err");
         assert!(
             err.contains("tilth_does_not_exist_xyz_1"),
             "must include file 1: {err}"
@@ -1515,9 +1521,8 @@ mod tests {
     fn batch_edit_empty_files_array_rejected() {
         let args = serde_json::json!({ "files": [] });
         let (session, bloom) = edit_services();
-        let cache = OutlineCache::new();
-        let err = tool_edit(&args, &session, &cache, &bloom)
-            .expect_err("empty files array must be rejected");
+        let err =
+            tool_edit(&args, &session, &bloom).expect_err("empty files array must be rejected");
         assert!(err.contains("empty"), "must mention empty: {err}");
     }
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -5,11 +5,13 @@ use std::fs;
 use std::path::Path;
 
 use memmap2::Mmap;
+use rayon::prelude::*;
 
 use crate::cache::OutlineCache;
 use crate::error::TilthError;
 use crate::format;
 use crate::lang::detect_file_type;
+use crate::session::Session;
 use crate::types::{estimate_tokens, FileType, ViewMode};
 
 pub(crate) const TOKEN_THRESHOLD: u64 = 6_000;
@@ -24,6 +26,30 @@ fn full_read_size_cap() -> u64 {
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .unwrap_or(2_000_000)
+}
+
+/// Read many files in parallel. Each file's output follows the same smart-view
+/// rules as [`read_file`]; errors are inlined as `# <path> — error: <msg>` so
+/// one bad path never aborts the batch. Output ordering matches the input
+/// `paths` — rayon's `par_iter().collect()` preserves index order even though
+/// execution order is not deterministic.
+pub(crate) fn read_batch(
+    paths: &[std::path::PathBuf],
+    cache: &OutlineCache,
+    session: &Session,
+    edit_mode: bool,
+) -> String {
+    let results: Vec<String> = paths
+        .par_iter()
+        .map(|path| {
+            session.record_read(path);
+            match read_file(path, None, false, cache, edit_mode) {
+                Ok(output) => output,
+                Err(e) => format!("# {} — error: {}", path.display(), e),
+            }
+        })
+        .collect();
+    results.join("\n\n")
 }
 
 /// Main entry point for read mode. Routes through the decision tree.

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -186,8 +186,7 @@ pub fn read_file(
 /// Would this file produce an outline (rather than full content) in default read mode?
 /// Used by the MCP layer to decide whether to append related-file hints.
 pub fn would_outline(path: &Path) -> bool {
-    std::fs::metadata(path)
-        .is_ok_and(|m| !m.is_dir() && estimate_tokens(m.len()) > TOKEN_THRESHOLD)
+    std::fs::metadata(path).is_ok_and(|m| !m.is_dir() && estimate_tokens(m.len()) > TOKEN_THRESHOLD)
 }
 
 /// Resolve a heading address to a line range in a markdown file.

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,238 @@
+//! Per-request wall-clock timeout wrapper for synchronous tool calls.
+//!
+//! Rust has no sync-world equivalent of Java's `Future.get(timeout, unit)`, so
+//! we spawn a fresh thread per call, wait on a `crossbeam_channel` bounded(1)
+//! with `select! { default(timeout) => ... }`, and detach the worker on timeout.
+//!
+//! Because Rust cannot forcibly cancel a running thread, a timed-out worker
+//! keeps running until its `FnOnce` completes naturally. A bounded counter
+//! (`ThreadTracker`) tracks how many detached workers are still in flight and
+//! refuses new work at [`MAX_ABANDONED_THREADS`] to prevent unbounded thread
+//! accumulation on pathologically slow operations.
+//!
+//! [`ThreadCoord`] is a `RUNNING` → (`TIMED_OUT` | `FINISHED`) CAS state
+//! machine that guarantees the tracker is incremented/decremented exactly
+//! once per spawn even when the worker's channel send races the main
+//! thread's deadline.
+
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::{bounded, select, RecvError};
+
+const ABANDONED_THREAD_WARN: usize = 3;
+/// Hard cap: refuse new work when this many prior threads are still running
+/// after timeout. Prevents unbounded thread accumulation on stuck operations.
+const MAX_ABANDONED_THREADS: usize = 8;
+
+/// Live count of threads that timed out and are still running in the background.
+/// Owned by `Services`, so tests instantiate their own instance rather than
+/// serializing on a global.
+pub(crate) struct ThreadTracker {
+    count: AtomicUsize,
+}
+
+impl ThreadTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn is_at_cap(&self) -> bool {
+        self.count.load(Ordering::Relaxed) >= MAX_ABANDONED_THREADS
+    }
+
+    fn record_timeout(&self) -> usize {
+        self.count.fetch_add(1, Ordering::Relaxed) + 1
+    }
+
+    fn record_finish_after_timeout(&self) {
+        self.count.fetch_sub(1, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    /// Pre-load the counter to the hard cap so callers can assert the
+    /// `is_at_cap()` branch without launching real timeouts.
+    #[cfg(test)]
+    pub(crate) fn saturate(&self) {
+        self.count.store(MAX_ABANDONED_THREADS, Ordering::Relaxed);
+    }
+}
+
+/// Per-request coordination between the main thread and the worker thread.
+/// Exactly one of `claim_timeout` / `claim_finish` wins, so the tracker count
+/// is updated at most once per spawn even when a worker's send and the main
+/// thread's `select!` deadline race.
+struct ThreadCoord(AtomicU8);
+
+impl ThreadCoord {
+    const RUNNING: u8 = 0;
+    const TIMED_OUT: u8 = 1;
+    const FINISHED: u8 = 2;
+
+    fn new() -> Self {
+        Self(AtomicU8::new(Self::RUNNING))
+    }
+
+    /// Main-thread side. Returns true if we transitioned `RUNNING` → `TIMED_OUT`;
+    /// the caller should then increment the tracker. False means the worker
+    /// already reached `FINISHED` — no counter change needed.
+    fn claim_timeout(&self) -> bool {
+        self.0
+            .compare_exchange(
+                Self::RUNNING,
+                Self::TIMED_OUT,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    /// Worker-thread side. Returns true if we transitioned `RUNNING` → `FINISHED`;
+    /// no counter change needed. False means the main thread already flipped
+    /// to `TIMED_OUT` and incremented — the caller must decrement to undo it.
+    fn claim_finish(&self) -> bool {
+        self.0
+            .compare_exchange(
+                Self::RUNNING,
+                Self::FINISHED,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum SpawnFailure {
+    Timeout,
+    Panic,
+}
+
+/// Per-request timeout for tool calls. If a tool doesn't respond within this
+/// duration, the MCP server returns a timeout error instead of hanging.
+/// Override with `TILTH_TIMEOUT` env var (seconds). Default: 90s.
+pub(crate) fn request_timeout() -> Duration {
+    let secs = std::env::var("TILTH_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(90);
+    Duration::from_secs(secs)
+}
+
+/// Run an arbitrary closure on a fresh thread with a wall-clock timeout.
+/// Returns `Ok(result)` on success. On timeout, returns `Err(SpawnFailure::Timeout)`
+/// and detaches the worker; the tracker is incremented and the worker will
+/// decrement it when it eventually exits. On worker panic, returns `Err(Panic)`.
+pub(crate) fn spawn_with_timeout<F, R>(
+    tracker: &Arc<ThreadTracker>,
+    timeout: Duration,
+    work: F,
+) -> Result<R, SpawnFailure>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (tx, rx) = bounded::<R>(1);
+    let coord = Arc::new(ThreadCoord::new());
+    let coord_worker = Arc::clone(&coord);
+    let tracker_worker = Arc::clone(tracker);
+
+    let handle = std::thread::spawn(move || {
+        // catch_unwind ensures claim_finish / record_finish_after_timeout run
+        // even if work() panics after the main thread has already timed out.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(work));
+        if let Ok(val) = result {
+            let _ = tx.send(val);
+        }
+        // tx is dropped here on panic, so main thread gets RecvError.
+        if !coord_worker.claim_finish() {
+            tracker_worker.record_finish_after_timeout();
+        }
+    });
+
+    select! {
+        recv(rx) -> msg => match msg {
+            Ok(result) => {
+                let _ = handle.join();
+                Ok(result)
+            }
+            Err(RecvError) => Err(SpawnFailure::Panic),
+        },
+        default(timeout) => {
+            // Increment before the CAS so the worker can never observe TIMED_OUT
+            // and call fetch_sub before the fetch_add, which would underflow.
+            // If the worker already claimed FINISHED, roll back the increment.
+            let n = tracker.record_timeout();
+            if coord.claim_timeout() {
+                if n >= ABANDONED_THREAD_WARN {
+                    eprintln!(
+                        "tilth: warning: {n} abandoned threads still running. \
+                         Consider reducing scope or increasing TILTH_TIMEOUT."
+                    );
+                }
+            } else {
+                tracker.record_finish_after_timeout();
+            }
+            Err(SpawnFailure::Timeout)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-var tests so parallel `cargo test` execution doesn't
+    /// race on process-global `TILTH_TIMEOUT`. Any test that mutates this
+    /// env var must take this lock for its duration.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Drives the real CAS path: a short-timeout `spawn_with_timeout` call
+    /// races against a worker that sleeps past the deadline. The main thread
+    /// must win the CAS (increment), and the worker must observe the lost CAS
+    /// when it eventually exits (decrement). Ends with the counter back at zero.
+    #[test]
+    fn abandoned_counter_roundtrips_through_cas() {
+        let tracker = Arc::new(ThreadTracker::new());
+        assert_eq!(tracker.current(), 0);
+
+        let result: Result<(), SpawnFailure> =
+            spawn_with_timeout(&tracker, Duration::from_millis(20), || {
+                std::thread::sleep(Duration::from_millis(200));
+            });
+
+        assert_eq!(result, Err(SpawnFailure::Timeout));
+        assert_eq!(tracker.current(), 1, "timeout must increment tracker");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while tracker.current() > 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(tracker.current(), 0, "worker exit must decrement tracker");
+    }
+
+    #[test]
+    fn fast_work_returns_ok_without_counter_change() {
+        let tracker = Arc::new(ThreadTracker::new());
+        let result = spawn_with_timeout(&tracker, Duration::from_secs(5), || 42_i32);
+        assert_eq!(result.expect("fast work should not timeout"), 42);
+        assert_eq!(tracker.current(), 0);
+    }
+
+    #[test]
+    fn request_timeout_reads_env() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("TILTH_TIMEOUT", "7");
+        assert_eq!(request_timeout(), Duration::from_secs(7));
+        std::env::remove_var("TILTH_TIMEOUT");
+        assert_eq!(request_timeout(), Duration::from_secs(90));
+    }
+}

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -171,7 +171,7 @@ where
             // If the worker already claimed FINISHED, roll back the increment.
             let n = tracker.record_timeout();
             if coord.claim_timeout() {
-                if n >= ABANDONED_THREAD_WARN {
+                if n == ABANDONED_THREAD_WARN {
                     eprintln!(
                         "tilth: warning: {n} abandoned threads still running. \
                          Consider reducing scope or increasing TILTH_TIMEOUT."


### PR DESCRIPTION
## Summary

NIH audit findings — replace hand-rolled implementations with maintained crates.

- **`thiserror` v2** in `error.rs` — derive `Display`/`Error`, drops 25 lines of mechanical `write!` formatting.
- **`fastbloom` v0.17** in `index/bloom.rs` — drop hand-rolled `BloomFilter` (~105 LOC: `double_hash`, `combined_hash`, `hash_with_seed`, optimal-bit math). `BloomFilterCache` wraps `fastbloom::BloomFilter`, which is SIMD-optimized and the de facto Rust crate. The `extract_identifiers` byte state machine (the unique-to-tilth piece) stays.
- **`strsim` v0.11** in `diff/matching.rs` — replace `jaccard_similarity` (whitespace-set Jaccard) with `strsim::sorensen_dice` (character-bigram). Same `0.0..=1.0` range, same `0.8` fuzzy threshold.

Net: **+165 / -191** across 5 files (incl. Cargo.lock).

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo test` — 248 passed (incl. all bloom + matching tests, including `fuzzy_match` and `below_fuzzy_threshold` which exercise the threshold)
- [x] `cargo fmt --check` clean

## Notes

- Drop `test_bloom_filter_sizing` — asserted private fields (`num_bits`, `num_hashes`) of the removed hand-rolled `BloomFilter` type. Equivalent guarantees are now part of fastbloom's own test suite.
- Sørensen-Dice on character bigrams is semantically distinct from token Jaccard, but the existing `fuzzy_match`/`below_fuzzy_threshold` tests pass at the same `0.8` threshold — the prefilter (size-ratio < 0.8 skips) keeps the candidate set small enough that bigram similarity behaves comparably for rename detection.