### PR TITLE
refactor(mcp): extract per-request timeout into its own module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -739,6 +748,7 @@ version = "0.8.1"
 dependencies = [
  "clap",
  "clap_complete",
+ "crossbeam-channel",
  "dashmap",
  "globset",
  "grep-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,6 +54,11 @@ memmap2 = "0.9"
 # Parallelism
 rayon = "1"
 
+# Channel with select! for the timeout wrapper (sibling of crossbeam-deque/-utils
+# already pulled in transitively by rayon; gives the closer-to-Java-Future
+# ergonomics that std::sync::mpsc::recv_timeout cannot express on multiple arms).
+crossbeam-channel = "0.5"
+
 # Concurrent cache
 dashmap = "6"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,6 +29,7 @@ pub mod overview;
 pub(crate) mod read;
 pub(crate) mod search;
 pub(crate) mod session;
+pub(crate) mod timeout;
 pub(crate) mod types;
 
 use std::path::Path;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,10 +1,7 @@
 use std::fmt::Write as _;
 use std::io::{self, BufRead, Write};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicUsize, Ordering};
-use std::sync::mpsc;
 use std::sync::Arc;
-use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
@@ -12,6 +9,7 @@ use serde_json::Value;
 use crate::cache::OutlineCache;
 use crate::index::bloom::BloomFilterCache;
 use crate::session::Session;
+use crate::timeout::{self, spawn_with_timeout, SpawnFailure, ThreadTracker};
 
 /// Shared dependencies passed through the request → dispatch pipeline.
 #[derive(Clone)]
@@ -19,6 +17,7 @@ pub(crate) struct Services {
     cache: Arc<OutlineCache>,
     session: Arc<Session>,
     bloom: Arc<BloomFilterCache>,
+    tracker: Arc<ThreadTracker>,
     edit_mode: bool,
 }
 
@@ -28,6 +27,7 @@ impl Services {
             cache: Arc::new(OutlineCache::new()),
             session: Arc::new(Session::new()),
             bloom: Arc::new(BloomFilterCache::new()),
+            tracker: Arc::new(ThreadTracker::new()),
             edit_mode,
         }
     }
@@ -44,25 +44,13 @@ impl Services {
         &self.bloom
     }
 
+    pub(crate) fn tracker(&self) -> &Arc<ThreadTracker> {
+        &self.tracker
+    }
+
     pub(crate) fn edit_mode(&self) -> bool {
         self.edit_mode
     }
-}
-
-/// Tracks abandoned threads (timed out but still running). Warns on stderr
-/// when accumulation exceeds threshold to help diagnose resource pressure.
-static ABANDONED_THREADS: AtomicUsize = AtomicUsize::new(0);
-const ABANDONED_THREAD_WARN: usize = 3;
-
-/// Per-request timeout for tool calls. If a tool doesn't respond within this
-/// duration, the MCP server returns a timeout error instead of hanging.
-/// Override with `TILTH_TIMEOUT` env var (seconds). Default: 90s.
-fn request_timeout() -> Duration {
-    let secs = std::env::var("TILTH_TIMEOUT")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(90);
-    Duration::from_secs(secs)
 }
 
 // Sent to the LLM via the MCP `instructions` field during initialization.
@@ -797,76 +785,61 @@ fn handle_tool_call(req: &JsonRpcRequest, services: &Services) -> JsonRpcRespons
     let tool_name = params.get("name").and_then(|v| v.as_str()).unwrap_or("");
     let args = params.get("arguments").unwrap_or(&Value::Null);
 
-    // Clone values needed by the worker thread
-    let tool_name_owned = tool_name.to_string();
-    let args_owned = args.clone();
-    let services_clone = services.clone();
-
-    let (tx, rx) = mpsc::channel();
-    let timeout = request_timeout();
-
-    let handle = std::thread::spawn(move || {
-        let result = dispatch_tool(&tool_name_owned, &args_owned, &services_clone);
-        let _ = tx.send(result);
-    });
-
-    let result = match rx.recv_timeout(timeout) {
-        Ok(result) => {
-            // Thread finished in time — join it to reclaim resources
-            let _ = handle.join();
-            result
-        }
-        Err(mpsc::RecvTimeoutError::Timeout) => {
-            // Thread is still running — we can't safely kill it, but we return
-            // an error to the client immediately. The thread will finish in the
-            // background and its result will be dropped.
-            //
-            // Note: we intentionally do NOT join here to avoid blocking the
-            // main loop. The thread will complete and exit on its own.
-            let abandoned = ABANDONED_THREADS.fetch_add(1, Ordering::Relaxed) + 1;
-            if abandoned >= ABANDONED_THREAD_WARN {
-                eprintln!(
-                    "tilth: warning: {abandoned} abandoned threads still running. \
-                     Consider reducing scope or increasing TILTH_TIMEOUT."
-                );
-            }
-            Err(format!(
-                "tool timed out after {}s — the operation took too long. \
-                 Try: reduce scope, use section instead of full, or set \
-                 TILTH_TIMEOUT=<seconds> to increase the limit.",
-                timeout.as_secs()
-            ))
-        }
-        Err(mpsc::RecvTimeoutError::Disconnected) => {
-            // Thread panicked — the channel was dropped without sending
-            Err("tool panicked during execution".into())
-        }
+    let result = if services.tracker().is_at_cap() {
+        Err(
+            "server busy: too many prior operations still running after timeout. \
+             Wait or set TILTH_TIMEOUT=<seconds> higher."
+                .into(),
+        )
+    } else {
+        run_tool_with_timeout(services, tool_name, args, timeout::request_timeout())
     };
 
-    match result {
-        Ok(output) => JsonRpcResponse {
-            jsonrpc: "2.0",
-            id: req.id.clone(),
-            result: Some(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": output
-                }]
-            })),
-            error: None,
-        },
-        Err(e) => JsonRpcResponse {
-            jsonrpc: "2.0",
-            id: req.id.clone(),
-            result: Some(serde_json::json!({
-                "content": [{
-                    "type": "text",
-                    "text": e
-                }],
-                "isError": true
-            })),
-            error: None,
-        },
+    build_tool_response(req.id.clone(), result)
+}
+
+fn run_tool_with_timeout(
+    services: &Services,
+    tool_name: &str,
+    args: &Value,
+    timeout: std::time::Duration,
+) -> Result<String, String> {
+    let services_worker = services.clone();
+    let tool_name_owned = tool_name.to_string();
+    let args_owned = args.clone();
+
+    let outcome = spawn_with_timeout(services.tracker(), timeout, move || {
+        dispatch_tool(&tool_name_owned, &args_owned, &services_worker)
+    });
+
+    match outcome {
+        Ok(inner) => inner,
+        Err(SpawnFailure::Timeout) => Err(format!(
+            "tool timed out after {}s — the operation took too long. \
+             Try: reduce scope, use section instead of full, or set \
+             TILTH_TIMEOUT=<seconds> to increase the limit.",
+            timeout.as_secs()
+        )),
+        Err(SpawnFailure::Panic) => Err("tool panicked during execution".into()),
+    }
+}
+
+fn build_tool_response(id: Option<Value>, result: Result<String, String>) -> JsonRpcResponse {
+    let (text, is_error) = match result {
+        Ok(output) => (output, false),
+        Err(e) => (e, true),
+    };
+    let mut payload = serde_json::json!({
+        "content": [{ "type": "text", "text": text }]
+    });
+    if is_error {
+        payload["isError"] = Value::Bool(true);
+    }
+    JsonRpcResponse {
+        jsonrpc: "2.0",
+        id,
+        result: Some(payload),
+        error: None,
     }
 }
 

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -1,0 +1,291 @@
+//! Per-request wall-clock timeout wrapper for synchronous tool calls.
+//!
+//! Rust has no sync-world equivalent of Java's `Future.get(timeout, unit)`, so
+//! we spawn a fresh thread per call, wait on a `crossbeam_channel` bounded(1)
+//! with `select! { default(timeout) => ... }`, and detach the worker on timeout.
+//!
+//! Because Rust cannot forcibly cancel a running thread, a timed-out worker
+//! keeps running until its `FnOnce` completes naturally. A bounded counter
+//! ([`ThreadTracker`]) tracks how many detached workers are still in flight and
+//! refuses new work at [`MAX_ABANDONED_THREADS`] to prevent unbounded thread
+//! accumulation on pathologically slow operations.
+//!
+//! [`ThreadCoord`] is a `RUNNING` → (`TIMED_OUT` | `FINISHED`) CAS state
+//! machine that guarantees the tracker is incremented and decremented exactly
+//! once per spawn even when the worker's channel send races the main
+//! thread's deadline.
+
+use std::sync::atomic::{AtomicBool, AtomicU8, AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use crossbeam_channel::{bounded, select, RecvError};
+
+const ABANDONED_THREAD_WARN: usize = 3;
+/// Hard cap: refuse new work when this many prior threads are still running
+/// after timeout. Prevents unbounded thread accumulation on stuck operations.
+const MAX_ABANDONED_THREADS: usize = 8;
+
+/// Live count of threads that timed out and are still running in the background.
+/// Owned by `Services`, so tests instantiate their own instance rather than
+/// serializing on a global.
+pub(crate) struct ThreadTracker {
+    count: AtomicUsize,
+}
+
+impl ThreadTracker {
+    pub(crate) fn new() -> Self {
+        Self {
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    /// `Acquire` ordering pairs with the `Release` increment in `record_timeout`,
+    /// so a thread that observes the new count also observes any state the
+    /// incrementing thread published before it. `Relaxed` would be allowed to
+    /// return a stale value on weakly-ordered architectures (e.g. ARM64).
+    pub(crate) fn is_at_cap(&self) -> bool {
+        self.count.load(Ordering::Acquire) >= MAX_ABANDONED_THREADS
+    }
+
+    fn record_timeout(&self) -> usize {
+        self.count.fetch_add(1, Ordering::Release) + 1
+    }
+
+    fn record_finish_after_timeout(&self) {
+        self.count.fetch_sub(1, Ordering::Release);
+    }
+
+    #[cfg(test)]
+    pub(crate) fn current(&self) -> usize {
+        self.count.load(Ordering::Acquire)
+    }
+
+    /// Pre-load the counter to the hard cap so callers can assert the
+    /// `is_at_cap()` branch without launching real timeouts.
+    #[cfg(test)]
+    pub(crate) fn saturate(&self) {
+        self.count.store(MAX_ABANDONED_THREADS, Ordering::Release);
+    }
+}
+
+/// Per-request coordination between the main thread and the worker thread.
+/// Exactly one of `claim_timeout` / `claim_finish` wins, so the tracker count
+/// is updated at most once per spawn even when a worker's send and the main
+/// thread's `select!` deadline race.
+struct ThreadCoord {
+    state: AtomicU8,
+    /// Set to `true` after the main thread has incremented the tracker. The
+    /// worker thread, if it lost the CAS to `TIMED_OUT`, must wait for this
+    /// flag before decrementing — otherwise it could race ahead of the
+    /// increment and underflow the counter.
+    timeout_acked: AtomicBool,
+}
+
+impl ThreadCoord {
+    const RUNNING: u8 = 0;
+    const TIMED_OUT: u8 = 1;
+    const FINISHED: u8 = 2;
+
+    fn new() -> Self {
+        Self {
+            state: AtomicU8::new(Self::RUNNING),
+            timeout_acked: AtomicBool::new(false),
+        }
+    }
+
+    /// Main-thread side. Returns true if we transitioned `RUNNING` → `TIMED_OUT`;
+    /// the caller must then increment the tracker and call `ack_timeout`.
+    /// False means the worker already reached `FINISHED` — no counter change.
+    fn claim_timeout(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::RUNNING,
+                Self::TIMED_OUT,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    /// Worker-thread side. Returns true if we transitioned `RUNNING` → `FINISHED`;
+    /// no counter change needed. False means the main thread already flipped
+    /// to `TIMED_OUT` and will increment — the caller must wait for
+    /// `timeout_acked` and then decrement to undo it.
+    fn claim_finish(&self) -> bool {
+        self.state
+            .compare_exchange(
+                Self::RUNNING,
+                Self::FINISHED,
+                Ordering::AcqRel,
+                Ordering::Relaxed,
+            )
+            .is_ok()
+    }
+
+    fn ack_timeout(&self) {
+        self.timeout_acked.store(true, Ordering::Release);
+    }
+
+    /// Spin until the main thread signals the tracker increment is visible.
+    /// The main thread runs only a single counter update between `claim_timeout`
+    /// and `ack_timeout`, so this loop terminates promptly in practice.
+    fn wait_for_timeout_ack(&self) {
+        while !self.timeout_acked.load(Ordering::Acquire) {
+            std::hint::spin_loop();
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub(crate) enum SpawnFailure {
+    Timeout,
+    Panic,
+}
+
+/// Per-request timeout for tool calls. If a tool doesn't respond within this
+/// duration, the MCP server returns a timeout error instead of hanging.
+/// Override with `TILTH_TIMEOUT` env var (seconds). Default: 90s.
+pub(crate) fn request_timeout() -> Duration {
+    let secs = std::env::var("TILTH_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .unwrap_or(90);
+    Duration::from_secs(secs)
+}
+
+/// Run an arbitrary closure on a fresh thread with a wall-clock timeout.
+/// Returns `Ok(result)` on success. On timeout, returns `Err(SpawnFailure::Timeout)`
+/// and detaches the worker; the tracker is incremented and the worker will
+/// decrement it when it eventually exits. On worker panic, returns `Err(Panic)`.
+pub(crate) fn spawn_with_timeout<F, R>(
+    tracker: &Arc<ThreadTracker>,
+    timeout: Duration,
+    work: F,
+) -> Result<R, SpawnFailure>
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    let (tx, rx) = bounded::<R>(1);
+    let coord = Arc::new(ThreadCoord::new());
+    let coord_worker = Arc::clone(&coord);
+    let tracker_worker = Arc::clone(tracker);
+
+    let handle = std::thread::spawn(move || {
+        // catch_unwind ensures claim_finish / record_finish_after_timeout run
+        // even if work() panics after the main thread has already timed out.
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(work));
+        if let Ok(val) = result {
+            let _ = tx.send(val);
+        }
+        // tx is dropped here on panic, so main thread gets RecvError.
+        if !coord_worker.claim_finish() {
+            // Main thread already claimed the timeout. It will increment the
+            // tracker before signalling `timeout_acked`; wait for that signal
+            // before decrementing so we cannot underflow the counter.
+            coord_worker.wait_for_timeout_ack();
+            tracker_worker.record_finish_after_timeout();
+        }
+    });
+
+    select! {
+        recv(rx) -> msg => match msg {
+            Ok(result) => {
+                let _ = handle.join();
+                Ok(result)
+            }
+            Err(RecvError) => Err(SpawnFailure::Panic),
+        },
+        default(timeout) => {
+            // Claim the timeout before touching the tracker so a concurrent
+            // `is_at_cap()` cannot observe an inflated count that we then roll
+            // back. If the worker already won the CAS, we leave the tracker
+            // alone entirely.
+            if coord.claim_timeout() {
+                let n = tracker.record_timeout();
+                coord.ack_timeout();
+                if n == ABANDONED_THREAD_WARN {
+                    eprintln!(
+                        "tilth: warning: {n} abandoned threads still running. \
+                         Consider reducing scope or increasing TILTH_TIMEOUT."
+                    );
+                }
+            }
+            Err(SpawnFailure::Timeout)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    /// Serializes env-var tests so parallel `cargo test` execution doesn't
+    /// race on process-global `TILTH_TIMEOUT`. Any test that mutates this
+    /// env var must take this lock for its duration.
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Drives the real CAS path: a short-timeout `spawn_with_timeout` call
+    /// races against a worker that sleeps past the deadline. The main thread
+    /// must win the CAS (increment), and the worker must observe the lost CAS
+    /// when it eventually exits (decrement). Ends with the counter back at zero.
+    #[test]
+    fn abandoned_counter_roundtrips_through_cas() {
+        let tracker = Arc::new(ThreadTracker::new());
+        assert_eq!(tracker.current(), 0);
+
+        let result: Result<(), SpawnFailure> =
+            spawn_with_timeout(&tracker, Duration::from_millis(20), || {
+                std::thread::sleep(Duration::from_millis(200));
+            });
+
+        assert_eq!(result, Err(SpawnFailure::Timeout));
+        assert_eq!(tracker.current(), 1, "timeout must increment tracker");
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        while tracker.current() > 0 && std::time::Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(tracker.current(), 0, "worker exit must decrement tracker");
+    }
+
+    #[test]
+    fn fast_work_returns_ok_without_counter_change() {
+        let tracker = Arc::new(ThreadTracker::new());
+        let result = spawn_with_timeout(&tracker, Duration::from_secs(5), || 42_i32);
+        assert_eq!(result.expect("fast work should not timeout"), 42);
+        assert_eq!(tracker.current(), 0);
+    }
+
+    #[test]
+    fn worker_panic_surfaces_as_panic_failure() {
+        let tracker = Arc::new(ThreadTracker::new());
+        let result: Result<(), SpawnFailure> =
+            spawn_with_timeout(&tracker, Duration::from_secs(5), || {
+                panic!("boom");
+            });
+        assert_eq!(result, Err(SpawnFailure::Panic));
+        assert_eq!(tracker.current(), 0, "panic must not leak a tracker slot");
+    }
+
+    #[test]
+    fn saturated_tracker_reports_at_cap() {
+        let tracker = Arc::new(ThreadTracker::new());
+        assert!(!tracker.is_at_cap());
+        tracker.saturate();
+        assert!(tracker.is_at_cap());
+    }
+
+    #[test]
+    fn request_timeout_reads_env() {
+        let _guard = ENV_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        std::env::set_var("TILTH_TIMEOUT", "7");
+        assert_eq!(request_timeout(), Duration::from_secs(7));
+        std::env::remove_var("TILTH_TIMEOUT");
+        assert_eq!(request_timeout(), Duration::from_secs(90));
+    }
+}

--- a/src/timeout.rs
+++ b/src/timeout.rs
@@ -21,6 +21,12 @@ use std::time::Duration;
 
 use crossbeam_channel::{bounded, select, RecvError};
 
+/// Warn-once threshold: print a single stderr line the first time the
+/// abandoned-thread count crosses this value. The deadline arm checks
+/// `if n == ABANDONED_THREAD_WARN { ... }` — deliberately `==`, not `>=`, so
+/// the operator gets one signal at the threshold rather than a flood as each
+/// subsequent timeout piles on. The hard cap at [`MAX_ABANDONED_THREADS`]
+/// stops accepting work entirely, so silence past this point is bounded.
 const ABANDONED_THREAD_WARN: usize = 3;
 /// Hard cap: refuse new work when this many prior threads are still running
 /// after timeout. Prevents unbounded thread accumulation on stuck operations.
@@ -40,20 +46,27 @@ impl ThreadTracker {
         }
     }
 
-    /// `Acquire` ordering pairs with the `Release` increment in `record_timeout`,
-    /// so a thread that observes the new count also observes any state the
-    /// incrementing thread published before it. `Relaxed` would be allowed to
-    /// return a stale value on weakly-ordered architectures (e.g. ARM64).
+    /// `Acquire` here pairs with the `AcqRel` RMWs in `record_timeout` and
+    /// `record_finish_after_timeout`. `Relaxed` would suffice for the counter
+    /// value alone (atomic RMWs are atomic at any ordering); we pay the cheap
+    /// upgrade so the pairing is canonical and the next reader doesn't have
+    /// to re-derive that the value is consistent with the rest of the spawn
+    /// state machine.
     pub(crate) fn is_at_cap(&self) -> bool {
         self.count.load(Ordering::Acquire) >= MAX_ABANDONED_THREADS
     }
 
+    /// `AcqRel` is the canonical pessimistic ordering for an RMW that's read
+    /// from another thread: documents intent better than `Release` alone, and
+    /// guarantees the RMW sees any prior `Release` write to this atomic before
+    /// computing its new value. The cost is negligible on x86 and one extra
+    /// barrier on weakly-ordered architectures.
     fn record_timeout(&self) -> usize {
-        self.count.fetch_add(1, Ordering::Release) + 1
+        self.count.fetch_add(1, Ordering::AcqRel) + 1
     }
 
     fn record_finish_after_timeout(&self) {
-        self.count.fetch_sub(1, Ordering::Release);
+        self.count.fetch_sub(1, Ordering::AcqRel);
     }
 
     #[cfg(test)]
@@ -130,14 +143,26 @@ impl ThreadCoord {
     /// Spin until the main thread signals the tracker increment is visible.
     /// The main thread runs only a single counter update between `claim_timeout`
     /// and `ack_timeout`, so this loop terminates promptly in practice.
+    ///
+    /// `spin_loop()` is a CPU pipeline hint, not a scheduler yield — on a
+    /// single-CPU container where the worker was scheduled before the main
+    /// thread, a pure spin would burn the worker's full quantum (~10ms) before
+    /// the main thread gets a turn to set the flag. The trailing `yield_now()`
+    /// surrenders the rest of the quantum so the ack becomes visible in tens
+    /// of microseconds instead.
     fn wait_for_timeout_ack(&self) {
         while !self.timeout_acked.load(Ordering::Acquire) {
             std::hint::spin_loop();
+            std::thread::yield_now();
         }
     }
 }
 
+/// Reasons a `spawn_with_timeout` call did not return a value. Marked
+/// `#[non_exhaustive]` so a future failure mode (e.g. OS-level thread spawn
+/// failure) can be added without churning every call site.
 #[derive(Debug, PartialEq)]
+#[non_exhaustive]
 pub(crate) enum SpawnFailure {
     Timeout,
     Panic,
@@ -244,7 +269,7 @@ mod tests {
         assert_eq!(result, Err(SpawnFailure::Timeout));
         assert_eq!(tracker.current(), 1, "timeout must increment tracker");
 
-        let deadline = std::time::Instant::now() + Duration::from_secs(2);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while tracker.current() > 0 && std::time::Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(10));
         }


### PR DESCRIPTION
## Summary

Part 2 of the #61 split (after #63's `Services` refactor). Extracts the inline `mpsc::recv_timeout` machinery in `handle_tool_call` into a dedicated `src/timeout.rs` backed by `crossbeam-channel`'s `select! { default(timeout) => ... }` — the sync-world equivalent of Java's `Future.get(timeout, unit)`.

`ThreadTracker` is now owned by `Services` rather than a static global, so unit tests instantiate their own and don't serialise on shared state.

No behaviour change for the happy path: same 90s default, same `TILTH_TIMEOUT` env override, same client-visible "tool timed out" / "tool panicked" messages. New: an upfront `tracker.is_at_cap()` check in `handle_tool_call` refuses new work cleanly under sustained pressure instead of piling on more abandoned threads.

## What I changed vs. the original #61 draft

The two timeout-module concerns from your #61 review are addressed here:

- **#6 (Ordering on `is_at_cap`)** — `ThreadTracker::is_at_cap` now uses `Ordering::Acquire`. It pairs with the `AcqRel` RMWs in `record_timeout` / `record_finish_after_timeout`, so a load that observes the new count also observes any state the incrementing thread published before it.
- **#7 (increment-before-CAS false rejection)** — the deadline arm now CAS-claims the timeout *before* touching the tracker (was: increment, then CAS, then conditionally roll back). The worker, if it lost the CAS, spins on a new `timeout_acked` `AtomicBool` before decrementing — so the tracker can never go negative and a concurrent `is_at_cap()` can never observe an inflated count that's about to roll back. Closes the false-rejection window near the hard cap.

I left #5 (`TILTH_BATCH_TIMEOUT` removal) for the batch-edit / read-parallelisation extraction since that's where it lives.

## Review round 2 fixes (applied in `49370e1`)

- RMWs on the abandoned-thread counter switched from `Release` to `AcqRel` — canonical pessimistic ordering for an RMW that's read from another thread. Doc-comment on `is_at_cap` updated to match.
- `wait_for_timeout_ack` spin loop now calls `std::thread::yield_now()` after `spin_loop()` so a worker scheduled before the main thread on a single-CPU container surrenders the rest of its quantum instead of burning ~10ms before the ack becomes visible.
- `ABANDONED_THREAD_WARN`'s deadline check uses `==` (not `>=`) deliberately — warn once at the threshold, hard-cap stops accepting work past it. The constant's doc-comment now calls this out so a future maintainer doesn't "fix" it back to `>=`.
- `SpawnFailure` is `#[non_exhaustive]` so a future failure mode (e.g. OS-level thread spawn failure) can be added without churning every call site.
- `abandoned_counter_roundtrips_through_cas` deadline relaxed 2s → 5s to reduce flake risk on contended runners.

## Files

- `src/timeout.rs` (new, +316) — `ThreadTracker`, `ThreadCoord`, `spawn_with_timeout`, `request_timeout`, plus 5 unit tests.
- `src/mcp.rs` — drops the inline `mpsc` plumbing; `handle_tool_call` shrinks to a cap-check + `run_tool_with_timeout` + `build_tool_response` split. `Services` gains a private `tracker: Arc<ThreadTracker>` field with a `pub(crate) fn tracker()` accessor matching the encapsulation pattern from #63.
- `src/lib.rs` — registers the new `pub(crate) mod timeout`.
- `Cargo.toml` / `Cargo.lock` — adds `crossbeam-channel = "0.5"`.

No version bump.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 349 pass (5 in `timeout::tests`: CAS roundtrip, fast path, panic surfacing, saturated tracker, env parsing)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
