### PR TITLE
perf(diff): parallelise overlay construction across files

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -7,6 +7,8 @@ use std::collections::HashSet;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use rayon::prelude::*;
+
 use crate::types::OutlineKind;
 
 #[derive(Debug)]
@@ -240,9 +242,12 @@ pub fn diff(
         return Ok("No changes.".to_string());
     }
 
-    // 2. Build structural overlays.
+    // 2. Build structural overlays in parallel — each FileDiff is independent
+    // and `compute_overlay` constructs its own tree-sitter parser per call
+    // (see `lang::outline::get_outline_entries`), so no shared mutable state
+    // crosses worker boundaries.
     let mut overlays: Vec<FileOverlay> = file_diffs
-        .iter()
+        .par_iter()
         .map(|fd| overlay::compute_overlay(fd, source))
         .collect();
 


### PR DESCRIPTION
## Summary

Part 4 of the #61 split — the diff-overlay half of the rayon parallelisation. Independent of #82 (timeout) and the upcoming batch-edit PR; touches only `src/diff/mod.rs` (+7 / −2).

\`compute_overlay\` is pure per-\`FileDiff\` work: each file independently fetches old/new content, runs tree-sitter, and matches symbols. Switching the overlay build from \`.iter()\` to \`.par_iter()\` lets multi-file diffs fan out across cores — a meaningful win on large PRs where each file does non-trivial AST work.

## Thread safety

\`compute_overlay\` constructs its own \`tree_sitter::Parser::new()\` per call inside \`lang::outline::get_outline_entries\` — no shared mutable state crosses worker boundaries. Addresses the medium item from your #61 review asking for verification of tree-sitter Send-ness. \`FileDiff\` and \`DiffSource\` are Send+Sync via auto trait derivation.

## Scope

Deliberately narrow:

- Only \`diff::diff()\` — left the per-commit overlay loop in \`diff_log()\` alone since each commit's overlay set is typically small.
- Left the \`tool_read\` batch parallelisation from the original #61 out of this PR pending the deadline-preservation discussion (review item #5 — \"the old behavior was better for large batches on slow filesystems\"). Happy to do it as a follow-up that keeps the cooperative \`TILTH_BATCH_TIMEOUT\` deadline AND addresses #3 (Mutex contention on \`session.record_read\`) if you want it.

## Test plan

- [x] \`cargo build\` — clean
- [x] \`cargo test\` — 344 pass
- [x] \`cargo clippy -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)