### PR TITLE
refactor(error): adopt thiserror for Display/Error derives

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -699,6 +699,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "tilth"
 version = "0.8.0"
 dependencies = [
@@ -718,6 +738,7 @@ dependencies = [
  "streaming-iterator",
  "tempfile",
  "terminal_size",
+ "thiserror",
  "toml",
  "tree-sitter",
  "tree-sitter-c",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "0.8"
 
+# Error types
+thiserror = "2"
+
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,56 +1,27 @@
 use std::path::PathBuf;
 
+use thiserror::Error;
+
 /// Every error tilth can produce. Displayed as user-facing messages with suggestions.
-#[derive(Debug)]
+#[derive(Debug, Error)]
 pub enum TilthError {
+    #[error("not found: {}{}", path.display(), suggestion.as_deref().map_or(String::new(), |s| format!(" — did you mean: {s}")))]
     NotFound {
         path: PathBuf,
         suggestion: Option<String>,
     },
-    PermissionDenied {
-        path: PathBuf,
-    },
-    InvalidQuery {
-        query: String,
-        reason: String,
-    },
+    #[error("{} [permission denied]", path.display())]
+    PermissionDenied { path: PathBuf },
+    #[error("invalid query \"{query}\": {reason}")]
+    InvalidQuery { query: String, reason: String },
+    #[error("{}: {source}", path.display())]
     IoError {
         path: PathBuf,
         source: std::io::Error,
     },
-    ParseError {
-        path: PathBuf,
-        reason: String,
-    },
+    #[error("parse error in {}: {reason}", path.display())]
+    ParseError { path: PathBuf, reason: String },
 }
-
-impl std::fmt::Display for TilthError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::NotFound { path, suggestion } => {
-                write!(f, "not found: {}", path.display())?;
-                if let Some(s) = suggestion {
-                    write!(f, " — did you mean: {s}")?;
-                }
-                Ok(())
-            }
-            Self::PermissionDenied { path } => {
-                write!(f, "{} [permission denied]", path.display())
-            }
-            Self::InvalidQuery { query, reason } => {
-                write!(f, "invalid query \"{query}\": {reason}")
-            }
-            Self::IoError { path, source } => {
-                write!(f, "{}: {source}", path.display())
-            }
-            Self::ParseError { path, reason } => {
-                write!(f, "parse error in {}: {reason}", path.display())
-            }
-        }
-    }
-}
-
-impl std::error::Error for TilthError {}
 
 impl TilthError {
     /// Exit code matching the spec.


### PR DESCRIPTION
## Summary

NIH audit finding — replace hand-rolled `Display`/`Error` impls in `src/error.rs` with `thiserror::Error` derives. Each variant gets an inline `#[error(...)]` attribute; the manual `impl Display` block and the empty `impl std::error::Error for TilthError {}` are removed.

Net: **+11 / -40** in `src/error.rs`; one new dependency (`thiserror = "2"`).

This is one of three split PRs extracted from the bundled NIH audit refactor (see closed #81 / paulnsorensen/tilth#9). The other two — `fastbloom` and `strsim` — are independent and will land as their own PRs.

## Dependency health

`thiserror` verified healthy at time of writing (2026-05-08):

| Crate | Latest | Last release | Repo last push | Stars | Recent downloads |
|---|---|---|---|---|---|
| `thiserror` | 2.0.18 | 2026-01-18 | 2026-03-24 | 5.4k | 222.8M |

Maintained by David Tolnay (also `serde`, `syn`, `anyhow`); on the v2.x line with patch releases every 1–2 months. Non-archived, MIT/Apache-2.0, in active stewardship. Zero risk.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 344 passed (3 suites)
- [x] Branch is off latest `origin/main` (post-v0.8.0)

## Why split from #81

#81 bundled three independent NIH-audit changes (`thiserror`, `fastbloom`, `strsim`). Reviewing them separately is easier:

- `thiserror` (this PR) — pure formatting derive, near-zero behavioral risk, well-known crate
- `fastbloom` — drops ~105 LOC of hand-rolled bloom math in favor of a SIMD crate
- `strsim` — replaces the Phase-3 fuzzy-similarity metric in `diff/matching.rs`

The three touch disjoint files (`error.rs` / `index/bloom.rs` / `diff/matching.rs`) and disjoint `Cargo.toml` lines, so they merge in any order without conflict.