### PR TITLE
refactor(bloom): adopt fastbloom for BloomFilter implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -235,6 +235,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastbloom"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef975e30683b2d965054bb0a836f8973857c4ebf6acf274fe46617cd285060d8"
+dependencies = [
+ "foldhash 0.2.0",
+ "libm",
+ "portable-atomic",
+ "rand",
+ "siphasher",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -253,6 +266,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -260,7 +291,7 @@ checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
 ]
@@ -327,7 +358,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -410,6 +441,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5b646652bf6661599e1da8901b3b9522896f01e736bad5f723fe7a3a27f899d"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -477,6 +514,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -506,9 +558,44 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "rayon"
@@ -662,6 +749,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -697,7 +790,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys",
@@ -740,6 +833,7 @@ dependencies = [
  "clap",
  "clap_complete",
  "dashmap",
+ "fastbloom",
  "globset",
  "grep-regex",
  "grep-searcher",
@@ -1197,6 +1291,26 @@ dependencies = [
  "serde_json",
  "unicode-xid",
  "wasmparser",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ toml = "0.8"
 # Error types
 thiserror = "2"
 
+# Bloom filter (fast SIMD-optimized impl)
+fastbloom = "0.17"
+
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 

--- a/src/index/bloom.rs
+++ b/src/index/bloom.rs
@@ -7,127 +7,11 @@
 //! Identifier extraction uses a simple byte-level state machine -- no
 //! tree-sitter needed -- making it fast enough to run on every uncached file.
 
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
 
 use dashmap::DashMap;
-
-// ---------------------------------------------------------------------------
-// BloomFilter
-// ---------------------------------------------------------------------------
-
-/// A probabilistic set membership data structure.
-///
-/// Supports `insert` and `contains`. `contains` may return false positives
-/// but never false negatives: if it returns `false`, the item is definitely
-/// absent.
-pub struct BloomFilter {
-    bits: Vec<u64>,
-    num_hashes: u8,
-    num_bits: usize,
-}
-
-impl BloomFilter {
-    /// Create a new Bloom filter sized for `expected_items` with the given
-    /// target false-positive rate.
-    ///
-    /// # Panics
-    ///
-    /// Panics if `expected_items` is 0 or `target_fpr` is not in (0, 1).
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use tilth::index::bloom::BloomFilter;
-    ///
-    /// let bf = BloomFilter::new(100, 0.01);
-    /// assert!(!bf.contains("hello"));
-    /// ```
-    #[must_use]
-    #[allow(clippy::cast_precision_loss)] // expected_items fits in f64 mantissa for practical sizes
-    pub fn new(expected_items: usize, target_fpr: f64) -> Self {
-        assert!(expected_items > 0, "expected_items must be > 0");
-        assert!(
-            target_fpr > 0.0 && target_fpr < 1.0,
-            "target_fpr must be in (0, 1)"
-        );
-
-        let n = expected_items as f64;
-        let ln2 = std::f64::consts::LN_2;
-
-        // Optimal number of bits: m = -(n * ln(p)) / (ln(2)^2)
-        let m = (-(n * target_fpr.ln()) / (ln2 * ln2)).ceil() as usize;
-        let m = m.max(64); // minimum 1 word
-
-        // Optimal number of hash functions: k = (m/n) * ln(2)
-        #[allow(clippy::cast_precision_loss)]
-        let k = ((m as f64 / n) * ln2).ceil() as u8;
-        let k = k.clamp(1, 32);
-
-        // Round up to full u64 words
-        let num_words = m.div_ceil(64);
-        let num_bits = num_words * 64;
-
-        Self {
-            bits: vec![0u64; num_words],
-            num_hashes: k,
-            num_bits,
-        }
-    }
-
-    /// Insert an item into the filter.
-    pub fn insert(&mut self, item: &str) {
-        let (h1, h2) = double_hash(item);
-        for i in 0..u64::from(self.num_hashes) {
-            let idx = combined_hash(h1, h2, i, self.num_bits);
-            let word = idx / 64;
-            let bit = idx % 64;
-            self.bits[word] |= 1u64 << bit;
-        }
-    }
-
-    /// Check if an item is probably in the filter.
-    ///
-    /// Returns `true` if the item is PROBABLY present, `false` if it is
-    /// DEFINITELY absent.
-    #[must_use]
-    pub fn contains(&self, item: &str) -> bool {
-        let (h1, h2) = double_hash(item);
-        for i in 0..u64::from(self.num_hashes) {
-            let idx = combined_hash(h1, h2, i, self.num_bits);
-            let word = idx / 64;
-            let bit = idx % 64;
-            if self.bits[word] & (1u64 << bit) == 0 {
-                return false;
-            }
-        }
-        true
-    }
-}
-
-/// Compute two independent hashes for double-hashing.
-fn double_hash(item: &str) -> (u64, u64) {
-    let h1 = hash_with_seed(item, 0);
-    let h2 = hash_with_seed(item, 0x517c_c1b7_2722_0a95); // arbitrary non-zero seed
-    (h1, h2)
-}
-
-/// Combine h1 and h2 into the i-th hash value, mapped to `[0, num_bits)`.
-fn combined_hash(h1: u64, h2: u64, i: u64, num_bits: usize) -> usize {
-    // h(i) = h1 + i * h2 (mod num_bits)
-    let hash = h1.wrapping_add(i.wrapping_mul(h2));
-    (hash % num_bits as u64) as usize
-}
-
-/// Hash a string with a given seed using `DefaultHasher`.
-fn hash_with_seed(item: &str, seed: u64) -> u64 {
-    let mut hasher = DefaultHasher::new();
-    seed.hash(&mut hasher);
-    item.hash(&mut hasher);
-    hasher.finish()
-}
+use fastbloom::BloomFilter;
 
 // ---------------------------------------------------------------------------
 // BloomFilterCache
@@ -181,11 +65,12 @@ impl BloomFilterCache {
 
 /// Build a Bloom filter from file content by extracting all identifiers.
 fn build_filter(content: &str) -> BloomFilter {
-    // Count identifiers first to size the filter appropriately.
     let idents: Vec<&str> = extract_identifiers(content).collect();
+    // Sized for total token count, not unique identifiers -- duplicates over-allocate
+    // the filter, so the achieved FPR is well below the 0.01 target in practice.
     let expected = idents.len().max(1);
 
-    let mut filter = BloomFilter::new(expected, 0.01);
+    let mut filter = BloomFilter::with_false_pos(0.01).expected_items(expected);
     for ident in idents {
         filter.insert(ident);
     }
@@ -375,7 +260,7 @@ mod tests {
 
     #[test]
     fn test_basic_membership() {
-        let mut bf = BloomFilter::new(100, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(100);
         bf.insert("foo");
         bf.insert("bar");
         bf.insert("baz");
@@ -387,7 +272,7 @@ mod tests {
 
     #[test]
     fn test_definitely_not_present() {
-        let mut bf = BloomFilter::new(10, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(10);
         bf.insert("alpha");
         bf.insert("beta");
         bf.insert("gamma");
@@ -415,7 +300,7 @@ mod tests {
     #[test]
     fn test_false_positive_rate() {
         let n = 500;
-        let mut bf = BloomFilter::new(n, 0.01);
+        let mut bf = BloomFilter::with_false_pos(0.01).expected_items(n);
 
         // Insert N items
         for i in 0..n {
@@ -517,17 +402,6 @@ mod tests {
         // Different mtime: should rebuild from new content
         assert!(cache.contains(path, mtime_new, new_content, "new_function"));
         assert!(!cache.contains(path, mtime_new, new_content, "old_function"));
-    }
-
-    #[test]
-    fn test_bloom_filter_sizing() {
-        // Verify the filter creates a reasonable number of bits
-        let bf = BloomFilter::new(100, 0.01);
-        // Optimal: ~960 bits (15 words). Allow some rounding.
-        assert!(bf.num_bits >= 896, "too few bits: {}", bf.num_bits);
-        assert!(bf.num_bits <= 1088, "too many bits: {}", bf.num_bits);
-        assert!(bf.num_hashes >= 5, "too few hashes: {}", bf.num_hashes);
-        assert!(bf.num_hashes <= 10, "too many hashes: {}", bf.num_hashes);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

NIH audit finding — drop ~105 LOC of hand-rolled bloom-filter math in `src/index/bloom.rs` (`double_hash`, `combined_hash`, `hash_with_seed`, optimal-bit/hash sizing) in favor of [`fastbloom`](https://crates.io/crates/fastbloom), the SIMD-optimized de facto Rust bloom crate.

The `extract_identifiers` byte state machine — the unique-to-tilth piece — stays. `BloomFilterCache` now wraps `fastbloom::BloomFilter`, constructed via `BloomFilter::with_false_pos(0.01).expected_items(n)`.

Net: **+5 / -133** in `src/index/bloom.rs`; one new dependency (`fastbloom = "0.17"`).

This is one of three split PRs extracted from the bundled NIH audit refactor (see closed #81 / paulnsorensen/tilth#9). The other two — `thiserror` (#86) and `strsim` — are independent and land separately.

## Dependency health

`fastbloom` verified at time of writing (2026-05-08):

| Crate | Latest | Last release | Repo last push | Stars | Recent downloads |
|---|---|---|---|---|---|
| `fastbloom` | 0.17.0 | 2026-03-01 | 2026-03-01 | 348 | 5.0M |

Small project (348 stars), single maintainer, but very active: 0.15 → 0.16 → 0.17 across three weeks in Feb–Mar 2026. Only 4 open issues. The de facto fast Rust bloom crate; alternatives (`bloomfilter`, `growable-bloom-filter`) are unmaintained or niche. Non-archived, MIT/Apache-2.0.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 342 passed (3 suites, all bloom tests including identifier extraction, FPR, and large-scale insertion)
- [x] Branch is off latest `origin/main` (post-v0.8.0)

## Notes

- Drop `test_bloom_filter_sizing` — it asserted private fields (`num_bits`, `num_hashes`) of the removed hand-rolled `BloomFilter` type. Equivalent guarantees are part of fastbloom's own test suite.
- `BloomFilter::new(expected_items, target_fpr)` (old, two-positional-arg constructor) becomes `BloomFilter::with_false_pos(0.01).expected_items(n)` (fastbloom builder pattern).

## Why split from #81

#81 bundled three independent NIH-audit changes. Reviewing them separately is easier — `fastbloom` is the largest and most controversial of the three because of single-maintainer dependency risk, so it deserves its own review thread.

The three split PRs touch disjoint files (`error.rs` / `index/bloom.rs` / `diff/matching.rs`) and disjoint `Cargo.toml` lines, so they merge in any order without conflict.