### PR TITLE
refactor(install): adopt home crate for cross-platform home dir lookup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -343,6 +343,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +717,7 @@ dependencies = [
  "globset",
  "grep-regex",
  "grep-searcher",
+ "home",
  "ignore",
  "memchr",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ toml = "0.8"
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 
+# Cross-platform home directory lookup (cargo-team maintained)
+home = "0.5"
+
 # Terminal size detection (TIOCGWINSZ ioctl, falls back to env vars)
 terminal_size = "0.4"
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -431,20 +431,9 @@ fn resolve_host(host: &str) -> Result<HostInfo, String> {
     }
 }
 
+/// Cross-platform home-directory lookup, with an actionable error message.
 fn home_dir() -> Result<PathBuf, String> {
-    #[cfg(target_os = "windows")]
-    {
-        std::env::var("USERPROFILE")
-            .map(PathBuf::from)
-            .map_err(|_| "USERPROFILE not set".into())
-    }
-
-    #[cfg(not(target_os = "windows"))]
-    {
-        std::env::var("HOME")
-            .map(PathBuf::from)
-            .map_err(|_| "HOME not set".into())
-    }
+    home::home_dir().ok_or_else(|| "home directory not found ($HOME / $USERPROFILE)".into())
 }
 
 /// Merge a tilth server entry into a JSON config under the given servers key.


### PR DESCRIPTION
## Summary

NIH audit follow-up — replace the hand-rolled `cfg(target_os)` split in `home_dir()` (`src/install.rs`) with a thin wrapper around `home::home_dir()`. Same `$HOME` / `$USERPROFILE` precedence, plus correct treatment of an empty `$HOME` (the hand-rolled version returned an empty `PathBuf` and silently joined onto it, producing surprising paths like `./.cargo/...`).

Net: **+2 / -13** in `src/install.rs`; one new dependency (`home = "0.5"`).

This is one of three split PRs extracted from a bundled NIH audit refactor on the development fork (paulnsorensen/tilth#12). The other two — `percent-encoding` and `strsim::levenshtein` — touch disjoint files, so all three can land in any order.

## Dependency health

`home` verified at time of writing (2026-05-08):

| Crate | Latest | Last release | Repo | Recent downloads (90d) | Total downloads | Reverse deps |
|---|---|---|---|---|---|---|
| `home` | 0.5.12 | 2025-10-23 | rust-lang/cargo | 71.6M | 300M | 1,614 |

**Maintained by the cargo team itself** — `home` lives in the `rust-lang/cargo` monorepo and ships from the same release cadence. Used by `sqlx-postgres`, `cargo-audit`, `rustsec`, `cross`, and `toolchain_find`. There is no shorter path to a battle-tested home-dir lookup in the Rust ecosystem.

## Why this is an upgrade

| Concern | Hand-rolled | `home::home_dir()` |
|---|---|---|
| `$HOME` set | works | works |
| `$USERPROFILE` set on Windows | works | works |
| `$HOME` set but empty | returns empty `PathBuf`, then `.join(".cargo/...")` produces `./.cargo/...` | treated as missing → error |
| `$HOME` unset on macOS | falls back to env-var error only | falls back to `getpwuid_r` (matches `cargo`'s behavior) |

The empty-`$HOME` case is the load-bearing one. It's rare but not theoretical — CI runners and chroots sometimes leave `HOME=""` exported, and the silent-relative-path failure mode is the kind of bug you only catch in incident review.

## Wrapper retained

Kept the local `home_dir()` wrapper (4 call sites in `src/install.rs`) rather than inlining `home::home_dir()` everywhere:

- All call sites need a `Result<PathBuf, String>`, not the bare `Option<PathBuf>` the crate returns.
- The wrapper carries an actionable error message that names both `HOME` and `USERPROFILE`, matching the previous diagnostic.
- Matches the project rule of inlining only single-call-site library calls.

```rust
/// Cross-platform home-directory lookup, with an actionable error message.
fn home_dir() -> Result<PathBuf, String> {
    home::home_dir().ok_or_else(|| "home directory not found ($HOME / $USERPROFILE)".into())
}
```

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 339 passed
- [x] Branch is off latest `origin/main` (post-v0.8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)