### PR TITLE
refactor(read): adopt strsim::levenshtein for filename / heading suggestions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -716,6 +716,7 @@ dependencies = [
  "serde",
  "serde_json",
  "streaming-iterator",
+ "strsim",
  "tempfile",
  "terminal_size",
  "toml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,9 @@ toml = "0.8"
 # MCP protocol (JSON-RPC over stdio)
 # (handled manually — no framework needed)
 
+# String similarity (char-aware Levenshtein for filename / heading suggestions)
+strsim = "0.11"
+
 # Terminal size detection (TIOCGWINSZ ioctl, falls back to env vars)
 terminal_size = "0.4"
 

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -546,26 +546,12 @@ fn suggest_similar(path: &Path) -> Option<String> {
 
 /// Levenshtein distance over Unicode scalar values.
 ///
-/// Operates on `char`s, not bytes — a single CJK or emoji glyph is one
-/// edit unit, not 3-4. Byte-level Levenshtein on UTF-8 inflates distances
-/// for non-ASCII content and breaks ranking for international markdown
-/// or filenames. Used by both filename suggestion (`suggest_similar`) and
-/// heading suggestion (`suggest_headings`).
+/// Wraps `strsim::levenshtein`, which iterates `.chars()` so a single CJK
+/// or emoji glyph counts as one edit unit (not 3-4 bytes). Used by both
+/// filename suggestion (`suggest_similar`) and heading suggestion
+/// (`suggest_headings`).
 fn edit_distance(a: &str, b: &str) -> usize {
-    let a: Vec<char> = a.chars().collect();
-    let b: Vec<char> = b.chars().collect();
-    let mut prev: Vec<usize> = (0..=b.len()).collect();
-    let mut curr = vec![0; b.len() + 1];
-
-    for (i, &ca) in a.iter().enumerate() {
-        curr[0] = i + 1;
-        for (j, &cb) in b.iter().enumerate() {
-            let cost = usize::from(ca != cb);
-            curr[j + 1] = (prev[j] + cost).min(prev[j + 1] + 1).min(curr[j] + 1);
-        }
-        std::mem::swap(&mut prev, &mut curr);
-    }
-    prev[b.len()]
+    strsim::levenshtein(a, b)
 }
 
 /// Guess MIME type from extension for binary file headers.
@@ -775,9 +761,10 @@ mod tests {
         );
     }
 
-    /// edit_distance must operate on `char`s so non-ASCII headings rank
-    /// correctly. Byte-level Levenshtein would inflate distances for
-    /// CJK or emoji because those occupy 3–4 bytes per scalar value.
+    /// Filename and heading suggestion rely on Unicode-scalar-level edit
+    /// distance, not byte-level — locks in the contract `strsim::levenshtein`
+    /// provides via its char-iterating wrapper. If `strsim` ever switches
+    /// to a byte-level distance, this test fails loudly.
     #[test]
     fn edit_distance_is_unicode_aware() {
         // 设置 (Settings) and 設定 (Configuration) — different chars,


### PR DESCRIPTION
## Summary

NIH audit follow-up — replace the 16-LOC hand-rolled Wagner-Fischer Levenshtein in `src/read/mod.rs` with a thin wrapper around `strsim::levenshtein`. Two call sites (`suggest_similar` filename suggestion and `suggest_headings` markdown heading suggestion), so the wrapper is kept rather than inlined.

Net: **+8 / -22** in `src/read/mod.rs`; `strsim = \"0.11\"` added to `Cargo.toml`.

This is one of three split PRs extracted from a bundled NIH audit refactor on the development fork (paulnsorensen/tilth#12). The other two — `home` and `percent-encoding` — touch disjoint files, so all three can land in any order.

> **Note on the `Cargo.toml` line.** PR #88 (`refactor-strsim` for `diff/matching.rs` fuzzy symbol matching) also adds `strsim = \"0.11\"`. The two PRs touch disjoint *source* files, so they merge cleanly there; only the `Cargo.toml` block overlaps. Whichever lands first, the second is a one-line rebase to drop the duplicate dep declaration.

## Dependency health

`strsim` verified at time of writing (2026-05-08):

| Crate | Latest | Last release | Repo (last push) | Recent downloads (90d) | Total downloads | Reverse deps |
|---|---|---|---|---|---|---|
| `strsim` | 0.11.1 | 2024-04-02 | rapidfuzz/strsim-rs (2025-11-27) | 143.9M | 768M | 504 |

Version-age looks scary, but the repo moved under the **`rapidfuzz`** org and was pushed 2025-11-27. `clap` itself depends on it for \"did you mean?\" suggestions (28.5M downloads via `clap_builder` alone), so it's already a transitive dep on every `clap`-using project. Stable + feature-complete, not stagnant — there isn't much to release for a small math-defined library at 0.11. Non-archived, MIT.

## Why this is an upgrade

| Concern | Hand-rolled Wagner-Fischer | `strsim::levenshtein` |
|---|---|---|
| Unicode-scalar units (CJK, emoji) | yes (`.chars().collect()`) | yes (`StringWrapper` iterates `.chars()`) |
| Two-row rolling buffer (O(min(m,n)) memory) | yes | yes |
| Maintenance | one project | 504 reverse deps; `clap` ecosystem |
| Tested | one repo's CI | every `clap`/`darling`/`docopt` build |

Behavior parity is preserved by the existing `edit_distance_is_unicode_aware` regression test, which exercises CJK (`设置` vs `設定` = 2), emoji (`🦀` vs `🐙` = 1), and ASCII baseline (`kitten` vs `sitting` = 3). The doc comment is updated to call out the new contract — if `strsim` ever switches to a byte-level distance, the test fails loudly.

## Wrapper retained

Two call sites, so the wrapper stays:

```rust
/// Levenshtein distance over Unicode scalar values.
///
/// Wraps `strsim::levenshtein`, which iterates `.chars()` so a single CJK
/// or emoji glyph counts as one edit unit (not 3-4 bytes). Used by both
/// filename suggestion (`suggest_similar`) and heading suggestion
/// (`suggest_headings`).
fn edit_distance(a: &str, b: &str) -> usize {
    strsim::levenshtein(a, b)
}
```

This matches the project rule of inlining only single-call-site library calls. If a future swap is ever needed, the call sites stay stable.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] `cargo test` — 339 passed (incl. `edit_distance_is_unicode_aware`)
- [x] Branch is off latest `origin/main` (post-v0.8.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)