### PR TITLE
chore: oss-hygiene — dependabot + dep-review + scorecard, harden workflow permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot configuration — version updates only.
+# See: https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+#
+# Ecosystems present in tilth:
+#   - cargo  (root Cargo.toml, the main crate)
+#   - npm    (npm/package.json, the download-proxy wrapper)
+#   - github-actions (workflow action versions)
+# Python under benchmark/ is CI-helper evaluation code — no top-level manifest, so skipped.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      actions-minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    groups:
+      cargo-minor-and-patch:
+        update-types: [minor, patch]
+
+  - package-ecosystem: npm
+    directory: /npm
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,22 @@
+# Dependency Review — gates PRs that introduce vulnerable or
+# disallowed-license dependencies. Public repos: free.
+# Private repos: requires GitHub Advanced Security.
+# See: https://github.com/actions/dependency-review-action
+name: dependency review
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: moderate
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     tags: ["v*"]
 
 permissions:
-  contents: write
+  contents: read
 
 env:
   CARGO_TERM_COLOR: always
@@ -33,6 +33,8 @@ jobs:
 
   build:
     needs: version-check
+    permissions:
+      contents: write # softprops/action-gh-release uploads release assets
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,44 @@
+# OpenSSF Scorecard — runs on push to main and weekly.
+# Publishes results to scorecard.dev (badge data) and uploads SARIF
+# to the repo's Code scanning view.
+# See: https://github.com/ossf/scorecard-action
+name: scorecard
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "26 4 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      id-token: write
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Closes the free supply-chain and workflow-hardening gaps surfaced by an `/oss-hygiene` audit. No paid GitHub features required — everything here is free for public repos.

### Added

- **`.github/dependabot.yml`** — weekly version updates for the three ecosystems present in this repo:
  - `cargo` (root `Cargo.toml`)
  - `npm` (`npm/package.json` — the install wrapper)
  - `github-actions` (keeps action versions current, with minor/patch grouping)
  - Python under `benchmark/` is skipped — it's the evaluation harness, no top-level manifest.
- **`.github/workflows/dependency-review.yml`** — fails PRs that introduce moderate-or-worse vulnerable deps or disallowed licenses. Free on public repos.
- **`.github/workflows/scorecard.yml`** — publishes OpenSSF Scorecard SARIF + badge data. Runs on push to `main` and weekly.

CodeQL is **not** added: Rust isn't supported by `actions/codeql-action`, and the `npm/` surface is just a binary-download proxy — signal would be near-zero.

### Hardened

Per OSSF Scorecard's `Token-Permissions` check:

- **`ci.yml`** — adds top-level `permissions: { contents: read }`. The workflow only reads; no reason to inherit write defaults.
- **`release.yml`** — top-level `contents: write` is too broad. Tightened to `contents: read` and the write scope moved to only the `build` job, which actually needs it for `softprops/action-gh-release`. `version-check`, `publish-crate`, and `publish-npm` inherit read-only — the publish jobs use `CARGO_REGISTRY_TOKEN` / `NPM_TOKEN` secrets, not `GITHUB_TOKEN`, so this is safe.

`Dangerous-Workflow` audit: clean. Neither workflow uses `pull_request_target`.

## Follow-ups (filed as separate issues)

- Enable free GitHub-native security features (Dependabot alerts, secret scanning, push protection).
- Scaffold community standards files (CoC, CONTRIBUTING, SECURITY, issue/PR templates).
- Register for the OpenSSF Best Practices Badge and add the Scorecard badge to the README.

## Test plan

- [ ] CI green on this PR (existing `cargo fmt / clippy / test` job, now with `contents: read`).
- [ ] `dependency-review` job runs on this PR and passes (no new deps were introduced).
- [ ] After merge, `scorecard.yml` runs on `main` and uploads SARIF without error.
- [ ] Dependabot opens grouped PRs for outdated `cargo` / `npm` / `actions` deps within ~24h.
- [ ] Next tagged release still succeeds end-to-end (build matrix + releases + crates.io + npm).

---

🧀 Generated via the `/oss-hygiene` skill from `skillz-that-grillz`.