### PR TITLE
docs: community standards + Scorecard badge

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,42 @@
+name: Bug report
+description: Something tilth does wrong, or differently than the docs say.
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did tilth do, and what did you expect instead?
+      placeholder: |
+        Expected: ...
+        Actual:   ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction
+      description: Minimal steps or commands. A short repo or a paste is fine.
+      placeholder: |
+        1. `tilth foo --bar`
+        2. Look at the output
+      render: shell
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: tilth version
+      placeholder: "Output of `tilth --version`"
+    validations:
+      required: true
+
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      placeholder: "macOS 15.3, Rust 1.84, fish 3.7 — whatever is relevant"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,27 @@
+name: Feature request
+description: A thing tilth doesn't do yet, that you wish it did.
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: The problem
+      description: What are you trying to do that tilth gets in the way of?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed shape
+      description: What would the command, flag, or tool call look like? Rough is fine.
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other ways to solve this, and why they're worse.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- One paragraph. What changed, why. -->
+
+## Test plan
+
+<!-- How to verify this works. CI checks fmt + clippy + test on every push. -->
+
+- [ ] `cargo fmt --check`
+- [ ] `cargo clippy -- -D warnings`
+- [ ] `cargo test`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,7 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+In short: be kind, be patient, assume good faith. Disagreements about code and direction are fine; personal attacks are not.
+
+Report problems by DM to the maintainers via GitHub. Reports stay private.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,35 @@
+# Contributing
+
+Thanks for your interest. tilth is small and intentionally so — clean, focused changes are easiest to land.
+
+## Workflow
+
+1. Fork, branch, change.
+2. Run the gates locally:
+   ```bash
+   cargo fmt --check
+   cargo clippy -- -D warnings
+   cargo test
+   ```
+3. Open a PR. Describe what changed and how to test it.
+
+CI runs the same three commands on every push.
+
+## What helps
+
+- **Small PRs.** Easier to review, easier to merge.
+- **Conventional commits.** `fix: ...`, `feat: ...`, `refactor: ...`, `docs: ...`. The log is the changelog.
+- **A test.** Bug fixes need a regression test. Features need at least one.
+- **Surgical edits.** Don't rewrite surrounding code unrelated to the change.
+
+## Code style
+
+See [CLAUDE.md](./CLAUDE.md) for the project layout and conventions. Match the style of the file you're editing.
+
+## Bigger changes
+
+For anything that adds an MCP tool, changes a tool schema, or restructures a module: open an issue first so we can agree on the shape before you spend time on the implementation.
+
+## License
+
+By contributing, you agree your work is licensed under the project's [MIT License](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # tilth
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/jahala/tilth/badge)](https://scorecard.dev/viewer/?uri=github.com/jahala/tilth)
+
 **Smart code reading for humans and AI agents.** Reduces cost per correct answer by **44%** on Sonnet, **39%** on Opus, and **38%** on Haiku across 160 benchmark runs. ([benchmarks](#benchmarks))
 
 tilth is what happens when you give `ripgrep`, `tree-sitter`, and `cat` a shared brain.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please **don't** open a public issue. Use GitHub's private advisory flow:
+
+→ <https://github.com/jahala/tilth/security/advisories/new>
+
+We'll acknowledge within 72 hours and coordinate disclosure with you.
+
+## Supported versions
+
+Only the latest minor release receives security updates. Older versions don't.


### PR DESCRIPTION
## Summary

Scaffolds the community standards files from issue #97 and adds the OpenSSF Scorecard badge from issue #98 (Best Practices badge pending registration).

Kept tight, light, simple — see [decisions](https://github.com/jahala/tilth/issues/97#issuecomment-...) for shape:
- `SECURITY.md` → GitHub private advisory flow (no separate email)
- `CONTRIBUTING.md` → light tone, points at `CLAUDE.md` + the three local gates (`cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`)
- No CODEOWNERS while solo

## Files

| Path | Lines | Purpose |
|---|---:|---|
| `CODE_OF_CONDUCT.md` | 7 | References Contributor Covenant 2.1 |
| `CONTRIBUTING.md` | 35 | Light workflow + conventions |
| `SECURITY.md` | 13 | Private vuln reporting via GH advisory |
| `.github/ISSUE_TEMPLATE/bug_report.yml` | 42 | What/repro/version/env |
| `.github/ISSUE_TEMPLATE/feature_request.yml` | 27 | Problem/proposal/alternatives |
| `.github/ISSUE_TEMPLATE/config.yml` | 1 | Disable blank issues |
| `.github/PULL_REQUEST_TEMPLATE.md` | 11 | Summary + test plan checklist |
| `README.md` | +2 | Scorecard badge |

138 lines total.

## Closes

- #97 (community standards files)
- Half of #98 (Scorecard badge; Best Practices badge needs maintainer registration at bestpractices.dev)

## Test plan

- [ ] CI passes (`fmt --check`, `clippy -D warnings`, `test`)
- [ ] `dependency-review` passes (zero new deps)
- [ ] Scorecard badge renders in README on merge (already verified scorecard.yml runs cleanly on main)
- [ ] Community Standards health % moves from 42% toward 90%+