### PR TITLE
fix: stop walker at mount boundaries, recognize composer.json (narrowed from #62)

### DIFF
--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -58,6 +58,7 @@ pub(crate) fn package_root(path: &Path) -> Option<&Path> {
         "build.gradle",
         "build.sbt",
         "mix.exs",
+        "composer.json", // PHP / Laravel
     ];
     let mut dir = path;
     loop {

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -90,6 +90,7 @@ pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkPar
     let mut builder = WalkBuilder::new(scope);
     builder
         .follow_links(true)
+        .same_file_system(true) // Stop at mount boundaries (NFS, external volumes).
         .hidden(false)
         .git_ignore(false)
         .git_global(false)
@@ -826,6 +827,7 @@ fn find_basename_fallback(scope: &Path, query_lower: &str) -> Option<PathBuf> {
 
     let walker = ignore::WalkBuilder::new(scope)
         .follow_links(true)
+        .same_file_system(true) // Stop at mount boundaries (NFS, external volumes).
         .hidden(true)
         .git_ignore(true)
         .max_depth(Some(6))


### PR DESCRIPTION
## Summary

Narrowed scope of @quanhavn's NFS-traversal fix in #62 to the two changes we agreed on after review:

- `same_file_system(true)` on the WalkBuilder in `walker()` and `find_basename_fallback()`. Stops traversal at mount boundaries — fixes the OrbStack / NFS / external-volume timeout @quanhavn surfaced.
- `composer.json` added to `MANIFESTS` so PHP/Laravel projects resolve scope correctly.

Dropped from the original PR (per the [April 21 review on #62](https://github.com/jahala/tilth/pull/62)):
- `follow_links(false)` — would break pnpm symlinks, npm/yarn workspaces, macOS `/tmp` (which is `/private/tmp` via symlink). Symlinks within the same filesystem are fine to follow; `same_file_system(true)` alone is enough to stop NFS without these regressions.
- `.git` as a fallback manifest in `package_root()` — wrong layer. `package_root()` finds the language-package root, not the git root. Adding `.git` would expand scope to the entire git repo for any project without a manifest.
- `would_outline` whitespace reformatting in `src/read/mod.rs` — already merged via #79 in v0.6.3.
- Test changes that asserted symlinks were not followed — existing symlink tests stay as-is, since symlink-following IS the wanted behavior (just not across mount boundaries).

@quanhavn — thanks for catching the original issue and the patient sit through the review. The two changes above land your fix; closing #62 with a pointer here.

## Why this replaces #62

@quanhavn's branch is ~4 weeks behind `main` (since 2026-04-20), and rebasing it on current main produces a 38-file conflict diff from intervening work. Cherry-picking the narrow scope onto a fresh branch was cleaner than asking @quanhavn to wrestle with the rebase after the long quiet period. Authorship preserved via `Co-Authored-By` trailer.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test` — 356 pass
- [ ] (Manual, post-merge) Run `tilth foo --scope ~/` on a machine with an NFS / OrbStack mount; verify it completes promptly instead of timing out
- [ ] (Manual, post-merge) Verify PHP/Laravel project: `cd some/laravel/proj/app/Http && tilth Controller --scope .` resolves to the project root via composer.json

## Closes

Closes #62.