### PR TITLE
fix(search): --full raises match cap from 10 to 100

### DIFF
--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -405,7 +405,13 @@ fn compute_blast(overlays: &[FileOverlay]) -> Vec<String> {
     let scope = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let bloom = crate::index::bloom::BloomFilterCache::new();
 
-    match crate::search::callers::find_callers_batch(&sig_changed, &scope, &bloom, None) {
+    match crate::search::callers::find_callers_batch(
+        &sig_changed,
+        &scope,
+        &bloom,
+        None,
+        crate::search::callers::BATCH_EARLY_QUIT,
+    ) {
         Ok(matches) => {
             let mut counts: std::collections::HashMap<String, usize> =
                 std::collections::HashMap::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,6 +45,11 @@ struct ExpandedCtx {
     session: session::Session,
     bloom: index::bloom::BloomFilterCache,
     expand: usize,
+    /// Raises the search match cap (10 → 100). Driven by the explicit `--full`
+    /// flag, NOT by `full = !is_tty`. Piped invocation must preserve the
+    /// concise outline — see the `piped_invocation_does_not_auto_expand`
+    /// pin in `main.rs` for the larger design rule this enforces.
+    full_search: bool,
 }
 
 /// The single public API. Everything flows through here:
@@ -57,10 +62,22 @@ pub fn run(
     glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    run_inner(query, scope, section, budget_tokens, false, 0, glob, cache)
+    run_inner(
+        query,
+        scope,
+        section,
+        budget_tokens,
+        false,
+        0,
+        glob,
+        cache,
+        false,
+    )
 }
 
 /// Full variant — forces full file output, bypassing smart views.
+/// `full_file` covers piped-stdout promotion too; search cap bump never
+/// applies on this path (no expansion = no `run_query_expanded`).
 pub fn run_full(
     query: &str,
     scope: &Path,
@@ -69,10 +86,24 @@ pub fn run_full(
     glob: Option<&str>,
     cache: &OutlineCache,
 ) -> Result<String, TilthError> {
-    run_inner(query, scope, section, budget_tokens, true, 0, glob, cache)
+    run_inner(
+        query,
+        scope,
+        section,
+        budget_tokens,
+        true,
+        0,
+        glob,
+        cache,
+        false,
+    )
 }
 
 /// Run with expanded search — inline source for top N matches.
+/// `full` controls full-file display for `FilePath` queries (driven by
+/// `cli.full || !is_tty`). `cli_full` is the *parsed* `--full` flag and
+/// alone gates the search match-cap bump; piped invocation must not raise
+/// the cap (see `piped_invocation_does_not_auto_expand` pin).
 pub fn run_expanded(
     query: &str,
     scope: &Path,
@@ -82,6 +113,7 @@ pub fn run_expanded(
     expand: usize,
     glob: Option<&str>,
     cache: &OutlineCache,
+    cli_full: bool,
 ) -> Result<String, TilthError> {
     run_inner(
         query,
@@ -92,6 +124,7 @@ pub fn run_expanded(
         expand,
         glob,
         cache,
+        cli_full,
     )
 }
 
@@ -102,11 +135,12 @@ pub fn run_callers(
     expand: usize,
     budget_tokens: Option<u64>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
     let bloom = index::bloom::BloomFilterCache::new();
     let expand = if expand > 0 { expand } else { 2 };
     let output =
-        search::callers::search_callers_expanded(target, scope, &bloom, expand, None, glob)?;
+        search::callers::search_callers_expanded(target, scope, &bloom, expand, None, glob, full)?;
     match budget_tokens {
         Some(b) => Ok(budget::apply(&output, b)),
         None => Ok(output),
@@ -134,6 +168,7 @@ fn run_inner(
     expand: usize,
     glob: Option<&str>,
     cache: &OutlineCache,
+    cli_full: bool,
 ) -> Result<String, TilthError> {
     let query_type = classify(query, scope);
 
@@ -166,7 +201,7 @@ fn run_inner(
             let bloom = index::bloom::BloomFilterCache::new();
             let expand = if expand > 0 { expand } else { 2 };
             let output = search::search_multi_symbol_expanded(
-                &parts, scope, cache, &session, &bloom, expand, None, glob,
+                &parts, scope, cache, &session, &bloom, expand, None, glob, cli_full,
             )?;
             return match budget_tokens {
                 Some(b) => Ok(budget::apply(&output, b)),
@@ -199,6 +234,7 @@ fn run_inner(
                 session: session::Session::new(),
                 bloom: index::bloom::BloomFilterCache::new(),
                 expand,
+                full_search: cli_full,
             };
             run_query_expanded(&query_type, scope, cache, &ctx, glob)?
         }
@@ -230,6 +266,7 @@ fn run_query_expanded(
             ctx.expand,
             None,
             glob,
+            ctx.full_search,
         ),
         QueryType::Concept(text) if text.contains(' ') => search::search_content_expanded(
             text,
@@ -239,6 +276,7 @@ fn run_query_expanded(
             ctx.expand,
             None,
             glob,
+            ctx.full_search,
         ),
         // Single-word Concept and Fallthrough share the same expanded path:
         // both go straight to symbol_expanded, intentionally bypassing the
@@ -253,6 +291,7 @@ fn run_query_expanded(
             ctx.expand,
             None,
             glob,
+            ctx.full_search,
         ),
         QueryType::Content(text) => search::search_content_expanded(
             text,
@@ -262,6 +301,7 @@ fn run_query_expanded(
             ctx.expand,
             None,
             glob,
+            ctx.full_search,
         ),
         QueryType::Regex(pattern) => search::search_regex_expanded(
             pattern,
@@ -271,6 +311,7 @@ fn run_query_expanded(
             ctx.expand,
             None,
             glob,
+            ctx.full_search,
         ),
         // FilePath/Glob never reach here (gated by use_expanded)
         QueryType::FilePath(_) | QueryType::Glob(_) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,7 +284,14 @@ fn main() {
 
     // Callers mode
     if cli.callers {
-        let result = tilth::run_callers(&query, &scope, expand, cli.budget, cli.glob.as_deref());
+        let result = tilth::run_callers(
+            &query,
+            &scope,
+            expand,
+            cli.budget,
+            cli.glob.as_deref(),
+            cli.full,
+        );
         emit_result(result, &query, cli.json, is_tty);
         return;
     }
@@ -321,6 +328,7 @@ fn main() {
             expand,
             cli.glob.as_deref(),
             &cache,
+            cli.full,
         )
     } else if full {
         tilth::run_full(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -528,7 +528,7 @@ fn tool_search(
                 1 => {
                     session.record_search(queries[0]);
                     crate::search::search_symbol_expanded(
-                        queries[0], &scope, cache, session, bloom, expand, context, glob,
+                        queries[0], &scope, cache, session, bloom, expand, context, glob, false,
                     )
                 }
                 2..=5 => {
@@ -536,7 +536,7 @@ fn tool_search(
                         session.record_search(q);
                     }
                     crate::search::search_multi_symbol_expanded(
-                        &queries, &scope, cache, session, bloom, expand, context, glob,
+                        &queries, &scope, cache, session, bloom, expand, context, glob, false,
                     )
                 }
                 _ => {
@@ -550,19 +550,19 @@ fn tool_search(
         "content" => {
             session.record_search(query);
             crate::search::search_content_expanded(
-                query, &scope, cache, session, expand, context, glob,
+                query, &scope, cache, session, expand, context, glob, false,
             )
         }
         "regex" => {
             session.record_search(query);
-            let result = crate::search::content::search(query, &scope, true, context, glob)
+            let result = crate::search::content::search(query, &scope, true, context, glob, false)
                 .map_err(|e| e.to_string())?;
             crate::search::format_raw_result(&result, cache)
         }
         "callers" => {
             session.record_search(query);
             crate::search::callers::search_callers_expanded(
-                query, &scope, bloom, expand, context, glob,
+                query, &scope, bloom, expand, context, glob, false,
             )
         }
         _ => {

--- a/src/search/blast.rs
+++ b/src/search/blast.rs
@@ -82,7 +82,14 @@ pub(crate) fn blast_radius(
 
     let symbol_names: HashSet<String> = touched.iter().map(|t| t.name.clone()).collect();
 
-    let callers = find_callers_batch(&symbol_names, scope, bloom, None).ok()?;
+    let callers = find_callers_batch(
+        &symbol_names,
+        scope,
+        bloom,
+        None,
+        crate::search::callers::BATCH_EARLY_QUIT,
+    )
+    .ok()?;
 
     let canonical = path.canonicalize().ok()?;
     let callers: Vec<(String, CallerMatch)> = callers

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -17,7 +17,12 @@ const IMPACT_FANOUT_THRESHOLD: usize = 10;
 /// Max 2nd-hop results to display.
 const IMPACT_MAX_RESULTS: usize = 15;
 /// Stop the batch caller walk once we have this many raw matches. Generous headroom for dedup + ranking.
-const BATCH_EARLY_QUIT: usize = 50;
+pub(crate) const BATCH_EARLY_QUIT: usize = 50;
+
+/// Match-count cap when `--full` is set. Mirrors the symbol/content search caps.
+const FULL_MAX_MATCHES: usize = 100;
+/// Walker early-quit threshold when `--full` is set.
+const FULL_BATCH_EARLY_QUIT: usize = FULL_MAX_MATCHES * 3;
 
 /// A single caller match — a call site of a target symbol.
 #[derive(Debug)]
@@ -83,6 +88,7 @@ pub(crate) fn find_callers_batch(
     scope: &Path,
     bloom: &crate::index::bloom::BloomFilterCache,
     glob: Option<&str>,
+    early_quit_threshold: usize,
 ) -> Result<Vec<(String, CallerMatch)>, TilthError> {
     let matches: Mutex<Vec<(String, CallerMatch)>> = Mutex::new(Vec::new());
     let found_count = AtomicUsize::new(0);
@@ -95,7 +101,7 @@ pub(crate) fn find_callers_batch(
 
         Box::new(move |entry| {
             // Early termination: enough callers found
-            if found_count.load(Ordering::Relaxed) >= BATCH_EARLY_QUIT {
+            if found_count.load(Ordering::Relaxed) >= early_quit_threshold {
                 return ignore::WalkState::Quit;
             }
 
@@ -277,9 +283,15 @@ pub fn search_callers_expanded(
     expand: usize,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
+    let (max_matches, batch_quit) = if full {
+        (FULL_MAX_MATCHES, FULL_BATCH_EARLY_QUIT)
+    } else {
+        (MAX_MATCHES, BATCH_EARLY_QUIT)
+    };
     let single: HashSet<String> = std::iter::once(target.to_string()).collect();
-    let raw = find_callers_batch(&single, scope, bloom, glob)?;
+    let raw = find_callers_batch(&single, scope, bloom, glob, batch_quit)?;
     let callers: Vec<CallerMatch> = raw.into_iter().map(|(_, m)| m).collect();
 
     if callers.is_empty() {
@@ -300,7 +312,7 @@ pub fn search_callers_expanded(
         .map(|c| c.calling_function.clone())
         .collect();
 
-    sorted_callers.truncate(MAX_MATCHES);
+    sorted_callers.truncate(max_matches);
 
     // Format the output
     let mut output = format!(
@@ -358,7 +370,7 @@ pub fn search_callers_expanded(
     // Use all_caller_names (pre-truncation) for the fan-out threshold check,
     // but search for callers of the full set to capture transitive impact.
     if !all_caller_names.is_empty() && all_caller_names.len() <= IMPACT_FANOUT_THRESHOLD {
-        if let Ok(hop2) = find_callers_batch(&all_caller_names, scope, bloom, glob) {
+        if let Ok(hop2) = find_callers_batch(&all_caller_names, scope, bloom, glob, batch_quit) {
             // Filter out hop-1 matches (same file+line = same call site)
             let hop1_locations: HashSet<(PathBuf, u32)> = sorted_callers
                 .iter()

--- a/src/search/content.rs
+++ b/src/search/content.rs
@@ -13,6 +13,8 @@ use grep_searcher::Searcher;
 
 const MAX_MATCHES: usize = 10;
 const EARLY_QUIT_THRESHOLD: usize = MAX_MATCHES * 3;
+const FULL_MAX_MATCHES: usize = 100;
+const FULL_EARLY_QUIT_THRESHOLD: usize = FULL_MAX_MATCHES * 3;
 const MAX_SEARCH_FILE_SIZE: u64 = 500_000;
 
 /// Content search using ripgrep crates. Literal by default, regex if `is_regex`.
@@ -22,7 +24,13 @@ pub fn search(
     is_regex: bool,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<SearchResult, TilthError> {
+    let (max_matches, early_quit) = if full {
+        (FULL_MAX_MATCHES, FULL_EARLY_QUIT_THRESHOLD)
+    } else {
+        (MAX_MATCHES, EARLY_QUIT_THRESHOLD)
+    };
     let matcher = if is_regex {
         RegexMatcher::new(pattern)
     } else {
@@ -46,7 +54,7 @@ pub fn search(
         let total_found = &total_found;
 
         Box::new(move |entry| {
-            if total_found.load(Ordering::Relaxed) >= EARLY_QUIT_THRESHOLD {
+            if total_found.load(Ordering::Relaxed) >= early_quit {
                 return ignore::WalkState::Quit;
             }
 
@@ -129,7 +137,7 @@ pub fn search(
                 all.extend(file_matches);
             }
 
-            if total_found.load(Ordering::Relaxed) >= EARLY_QUIT_THRESHOLD {
+            if total_found.load(Ordering::Relaxed) >= early_quit {
                 ignore::WalkState::Quit
             } else {
                 ignore::WalkState::Continue
@@ -143,7 +151,7 @@ pub fn search(
         .unwrap_or_else(std::sync::PoisonError::into_inner);
 
     rank::sort(&mut all_matches, pattern, scope, context);
-    all_matches.truncate(MAX_MATCHES);
+    all_matches.truncate(max_matches);
 
     Ok(SearchResult {
         query: pattern.to_string(),

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -172,7 +172,13 @@ pub fn analyze_deps(
 
     let mut used_by = if searched_count > 0 {
         let symbols_set: HashSet<String> = all_names.iter().cloned().collect();
-        let raw_matches = find_callers_batch(&symbols_set, scope, bloom, None)?;
+        let raw_matches = find_callers_batch(
+            &symbols_set,
+            scope,
+            bloom,
+            None,
+            crate::search::callers::BATCH_EARLY_QUIT,
+        )?;
 
         // Group by file path
         let mut by_file: HashMap<PathBuf, Vec<(String, String, u32)>> = HashMap::new();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -154,7 +154,7 @@ pub fn search_symbol(
     cache: &OutlineCache,
     glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let result = symbol::search(query, scope, None, glob)?;
+    let result = symbol::search(query, scope, None, glob, false)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -168,8 +168,9 @@ pub fn search_symbol_expanded(
     expand: usize,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
-    let result = symbol::search(query, scope, context, glob)?;
+    let result = symbol::search(query, scope, context, glob, full)?;
     format_search_result(&result, cache, Some(session), bloom, expand)
 }
 
@@ -182,6 +183,7 @@ pub fn search_multi_symbol_expanded(
     expand: usize,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
     // Shared expand budget: at least 1 slot per query, or explicit expand if higher.
     // expand=0 means no expansion at all.
@@ -194,7 +196,7 @@ pub fn search_multi_symbol_expanded(
     let mut sections = Vec::with_capacity(queries.len());
 
     for query in queries {
-        let result = symbol::search(query, scope, context, glob)?;
+        let result = symbol::search(query, scope, context, glob, full)?;
         let mut out = format::search_header(
             &result.query,
             &result.scope,
@@ -232,7 +234,7 @@ pub fn search_content(
     glob: Option<&str>,
 ) -> Result<String, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    let result = content::search(pattern, scope, is_regex, None, glob)?;
+    let result = content::search(pattern, scope, is_regex, None, glob, false)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -243,7 +245,7 @@ pub fn search_regex(
     cache: &OutlineCache,
     glob: Option<&str>,
 ) -> Result<String, TilthError> {
-    let result = content::search(pattern, scope, true, None, glob)?;
+    let result = content::search(pattern, scope, true, None, glob, false)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, None, &bloom, 0)
 }
@@ -256,9 +258,10 @@ pub fn search_content_expanded(
     expand: usize,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    let result = content::search(pattern, scope, is_regex, context, glob)?;
+    let result = content::search(pattern, scope, is_regex, context, glob, full)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, Some(session), &bloom, expand)
 }
@@ -272,8 +275,9 @@ pub fn search_regex_expanded(
     expand: usize,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<String, TilthError> {
-    let result = content::search(pattern, scope, true, context, glob)?;
+    let result = content::search(pattern, scope, true, context, glob, full)?;
     let bloom = crate::index::bloom::BloomFilterCache::new();
     format_search_result(&result, cache, Some(session), &bloom, expand)
 }
@@ -284,7 +288,7 @@ pub fn search_symbol_raw(
     scope: &Path,
     glob: Option<&str>,
 ) -> Result<SearchResult, TilthError> {
-    symbol::search(query, scope, None, glob)
+    symbol::search(query, scope, None, glob, false)
 }
 
 /// Raw content search — returns structured result for programmatic inspection.
@@ -294,7 +298,7 @@ pub fn search_content_raw(
     glob: Option<&str>,
 ) -> Result<SearchResult, TilthError> {
     let (pattern, is_regex) = parse_pattern(query);
-    content::search(pattern, scope, is_regex, None, glob)
+    content::search(pattern, scope, is_regex, None, glob, false)
 }
 
 /// Raw regex search — returns structured result for programmatic inspection.
@@ -303,7 +307,7 @@ pub fn search_regex_raw(
     scope: &Path,
     glob: Option<&str>,
 ) -> Result<SearchResult, TilthError> {
-    content::search(pattern, scope, true, None, glob)
+    content::search(pattern, scope, true, None, glob, false)
 }
 
 /// Format a raw search result (symbol or content — both use the same pipeline).
@@ -1564,10 +1568,11 @@ mod tests {
     #[test]
     fn content_search_glob_restricts_results() {
         let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-        let all = content::search("TilthError", &scope, false, None, None).expect("search failed");
-        let rs_only = content::search("TilthError", &scope, false, None, Some("*.rs"))
+        let all =
+            content::search("TilthError", &scope, false, None, None, false).expect("search failed");
+        let rs_only = content::search("TilthError", &scope, false, None, Some("*.rs"), false)
             .expect("search with glob failed");
-        let toml_only = content::search("TilthError", &scope, false, None, Some("*.toml"))
+        let toml_only = content::search("TilthError", &scope, false, None, Some("*.toml"), false)
             .expect("search with toml glob failed");
 
         assert!(all.total_found > 0, "unfiltered should find TilthError");
@@ -1589,9 +1594,9 @@ mod tests {
     #[test]
     fn symbol_search_glob_restricts_results() {
         let scope = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
-        let rs_result =
-            symbol::search("walker", &scope, None, Some("*.rs")).expect("symbol search failed");
-        let toml_result = symbol::search("walker", &scope, None, Some("*.toml"))
+        let rs_result = symbol::search("walker", &scope, None, Some("*.rs"), false)
+            .expect("symbol search failed");
+        let toml_result = symbol::search("walker", &scope, None, Some("*.toml"), false)
             .expect("symbol search with toml failed");
 
         assert!(rs_result.total_found > 0, "*.rs should find 'walker'");
@@ -1615,10 +1620,22 @@ mod tests {
         let bloom = crate::index::bloom::BloomFilterCache::new();
         let single: std::collections::HashSet<String> =
             std::iter::once("walker".to_string()).collect();
-        let rs_callers = callers::find_callers_batch(&single, &scope, &bloom, Some("*.rs"))
-            .expect("callers failed");
-        let toml_callers = callers::find_callers_batch(&single, &scope, &bloom, Some("*.toml"))
-            .expect("callers toml failed");
+        let rs_callers = callers::find_callers_batch(
+            &single,
+            &scope,
+            &bloom,
+            Some("*.rs"),
+            callers::BATCH_EARLY_QUIT,
+        )
+        .expect("callers failed");
+        let toml_callers = callers::find_callers_batch(
+            &single,
+            &scope,
+            &bloom,
+            Some("*.toml"),
+            callers::BATCH_EARLY_QUIT,
+        )
+        .expect("callers toml failed");
 
         assert!(
             !rs_callers.is_empty(),
@@ -1730,8 +1747,15 @@ mod tests {
         #[cfg(windows)]
         std::os::windows::fs::symlink_dir(&real_dir, tmp.path().join("linked")).unwrap();
 
-        let result =
-            content::search("unique_symlink_test_symbol", tmp.path(), false, None, None).unwrap();
+        let result = content::search(
+            "unique_symlink_test_symbol",
+            tmp.path(),
+            false,
+            None,
+            None,
+            false,
+        )
+        .unwrap();
         // Should find the symbol in both real/api.rs and linked/api.rs
         assert!(
             result.total_found >= 2,

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -26,6 +26,14 @@ const EARLY_QUIT_THRESHOLD_DEFINITIONS: usize = 50;
 /// Stop walking once we have this many raw usage matches.
 const EARLY_QUIT_THRESHOLD_USAGES: usize = MAX_MATCHES * 3;
 
+/// Match-count cap when `--full` is set. Generous but bounded so a `tilth
+/// foo --full` on a huge repo can't blow up output.
+const FULL_MAX_MATCHES: usize = 100;
+/// Walker early-quit threshold when `--full` is set. Proportional to
+/// `FULL_MAX_MATCHES` the same way the default thresholds are.
+const FULL_EARLY_QUIT_USAGES: usize = FULL_MAX_MATCHES * 3;
+const FULL_EARLY_QUIT_DEFINITIONS: usize = FULL_MAX_MATCHES * 3;
+
 /// Display-side stratum: 0 = code def, 1 = doc-heading def, 2 = usage. Used
 /// as a stable sort key after `rank::sort` so the `MAX_MATCHES` cap can't drop
 /// real code defs in favor of markdown-heading defs of the same query.
@@ -39,12 +47,32 @@ fn stratum_for_display(m: &Match) -> u8 {
 
 /// Symbol search: find definitions via tree-sitter, usages via ripgrep, concurrently.
 /// Merge results, deduplicate, definitions first.
+///
+/// `full` controls the truncation cap and walker early-quit thresholds:
+/// `false` (default) uses the tight defaults that keep agent token budgets
+/// in check; `true` raises both caps so interactive `--full` callers see
+/// every match instead of "... and N more matches."
 pub fn search(
     query: &str,
     scope: &Path,
     context: Option<&Path>,
     glob: Option<&str>,
+    full: bool,
 ) -> Result<SearchResult, TilthError> {
+    let (max_matches, def_threshold, usage_threshold) = if full {
+        (
+            FULL_MAX_MATCHES,
+            FULL_EARLY_QUIT_DEFINITIONS,
+            FULL_EARLY_QUIT_USAGES,
+        )
+    } else {
+        (
+            MAX_MATCHES,
+            EARLY_QUIT_THRESHOLD_DEFINITIONS,
+            EARLY_QUIT_THRESHOLD_USAGES,
+        )
+    };
+
     // Compile regex once, share across both arms
     let word_pattern = format!(r"\b{}\b", regex_syntax::escape(query));
     let matcher = RegexMatcher::new(&word_pattern).map_err(|e| TilthError::InvalidQuery {
@@ -53,8 +81,8 @@ pub fn search(
     })?;
 
     let (defs, usages) = rayon::join(
-        || find_definitions(query, scope, glob),
-        || find_usages(query, &matcher, scope, glob),
+        || find_definitions(query, scope, glob, def_threshold),
+        || find_usages(query, &matcher, scope, glob, usage_threshold),
     );
 
     let defs = defs?;
@@ -103,7 +131,7 @@ pub fn search(
         }
     };
 
-    merged.truncate(MAX_MATCHES);
+    merged.truncate(max_matches);
 
     Ok(SearchResult {
         query: query.to_string(),
@@ -128,6 +156,7 @@ fn find_definitions(
     query: &str,
     scope: &Path,
     glob: Option<&str>,
+    early_quit_threshold: usize,
 ) -> Result<Vec<Match>, TilthError> {
     let matches: Mutex<Vec<Match>> = Mutex::new(Vec::new());
     // Relaxed is correct: walker.run() joins all threads before we read the final value.
@@ -143,7 +172,7 @@ fn find_definitions(
 
         Box::new(move |entry| {
             // Early termination: enough definitions found
-            if found_count.load(Ordering::Relaxed) >= EARLY_QUIT_THRESHOLD_DEFINITIONS {
+            if found_count.load(Ordering::Relaxed) >= early_quit_threshold {
                 return ignore::WalkState::Quit;
             }
 
@@ -481,6 +510,7 @@ fn find_usages(
     matcher: &RegexMatcher,
     scope: &Path,
     glob: Option<&str>,
+    early_quit_threshold: usize,
 ) -> Result<Vec<Match>, TilthError> {
     let matches: Mutex<Vec<Match>> = Mutex::new(Vec::new());
     // Relaxed: same reasoning as find_definitions — approximate early-quit, joined before read
@@ -494,7 +524,7 @@ fn find_usages(
 
         Box::new(move |entry| {
             // Early termination: enough usages found
-            if found_count.load(Ordering::Relaxed) >= EARLY_QUIT_THRESHOLD_USAGES {
+            if found_count.load(Ordering::Relaxed) >= early_quit_threshold {
                 return ignore::WalkState::Quit;
             }
 
@@ -1283,6 +1313,40 @@ Body to end.
             matches.iter().all(|m| m.def_weight >= 60),
             "displayed slice after cap must be all code defs, got {:?}",
             matches.iter().map(|m| m.def_weight).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn full_flag_raises_match_cap() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let scope = dir.path();
+
+        // Create 15 Rust files each defining WidelyUsedThing.
+        for i in 0..15 {
+            let path = scope.join(format!("file_{i:02}.rs"));
+            std::fs::write(&path, format!("pub fn WidelyUsedThing() {{}}\n")).expect("write");
+        }
+
+        let result_default =
+            search("WidelyUsedThing", scope, None, None, false).expect("search default");
+        let result_full = search("WidelyUsedThing", scope, None, None, true).expect("search full");
+
+        // Default cap is 10 — should not exceed it.
+        assert!(
+            result_default.matches.len() <= 10,
+            "default: expected ≤10 matches, got {}",
+            result_default.matches.len()
+        );
+        // Full cap is 100 — all 15 definitions should be visible.
+        assert!(
+            result_full.matches.len() > 10,
+            "full: expected >10 matches, got {}",
+            result_full.matches.len()
+        );
+        // total_found is measured pre-truncation and should be equal.
+        assert_eq!(
+            result_default.total_found, result_full.total_found,
+            "total_found must be the same regardless of full flag"
         );
     }
 }


### PR DESCRIPTION
## Summary

Closes #65.

- `--full` now raises the search/callers match cap from 10 to 100 and proportionally raises the walker early-quit threshold (10 × 3 → 100 × 3 = 300). Without `--full`, behavior is unchanged.
- Cap-bump applies to symbol, content, regex, and callers paths. Default-bounded so a huge-repo `--full` query can't blow up output.
- Gated strictly on the *parsed* `--full` flag — piped invocation (where `main` sets `full = !is_tty`) does NOT bump the cap. This preserves the contract pinned by the existing `piped_invocation_does_not_auto_expand` test: subprocess / pipeline callers (Claude Code's Bash tool, CI scripts, `tilth foo | rg`) keep the concise 10-match outline by default.
- New `cli_full: bool` parameter on `run_expanded` / `run_inner` makes the gating explicit at the type level, instead of conflating two distinct meanings of "full" (file-content display vs search-cap bump).

## Test plan

- [x] `cargo test --release` — 357 + 4 passing; new `symbol::full_flag_raises_match_cap` pins the cap behavior on a synthetic 15-file repo
- [x] `cargo clippy --release -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Smoke test on this repo:
  - `tilth TilthError` → "10 matches" (default cap)
  - `tilth TilthError --full` → "100 matches" (raised cap)
  - `tilth TilthError --expand=2` (piped, no `--full`) → "10 matches" (regression guard — would have been 100 with naive wiring)

🤖 Generated with [Claude Code](https://claude.com/claude-code)