### PR TITLE
chore: bump version to v0.8.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "tilth"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"


### PR DESCRIPTION
## Summary

Patch release. Bumps \`Cargo.toml\` and \`npm/package.json\` to **0.8.3**.

## Included since v0.8.2

| PR | Type | Description |
|----|------|-------------|
| #109 | docs | Community standards + Scorecard badge |
| #110 | fix | Walker stops at mount boundaries (NFS narrow) |
| #111 | fix | \`--full\` raises search match cap from 10 to 100 (issue #65) |
| #113 | chore(deps) | actions/checkout v4 → v6 |
| #114 | chore(deps) | tree-sitter-scala 0.24 → 0.26 |
| #115 | chore(deps) | tree-sitter-python 0.23.6 → 0.25 |
| #116 | chore(ci) | Pin all GitHub Actions by commit SHA (Scorecard fix) |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 357 + 4 passing
- [x] \`cargo clippy --release -- -D warnings\` clean
- [x] \`cargo fmt --check\` clean
- [x] Benchmark spot-check (sonnet × 2 hard tasks × baseline+tilth): 100% correct, tilth −28% cost vs baseline
- [ ] After merge: tag \`v0.8.3\` and push to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)