### PR TITLE
chore: bump version to v0.8.4

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -837,7 +837,7 @@ dependencies = [
 
 [[package]]
 name = "tilth"
-version = "0.8.3"
+version = "0.8.4"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.8.3"
+version = "0.8.4"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.8.3",
+  "version": "0.8.4",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"


### PR DESCRIPTION
## Summary

Patch release.

## Included since v0.8.3

| PR | Type | Description |
|----|------|-------------|
| #118 | feat(fuzz) | cargo-fuzz harness + 3 targets + nightly CI + OSS-Fuzz prep |
|  | fix(edit) | \`normalize_path_key\` is now cwd-race-free and lexically correct for \`..\` (fix landed in #118 during audit) |

## Test plan

- [x] \`cargo build --release\` clean
- [x] \`cargo test --release\` — 362 + 4 passing (was 357 + 4; new tests pin lexical normalization invariants + cwd-race-free guarantee)
- [x] After merge: tag \`v0.8.4\` and push to trigger release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)