### PR TITLE
feat(grok): session dedup + cross-file grouping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -190,12 +190,13 @@ pub fn run_deps(
 /// pair (`src/diff/parse.rs:7`), or a `Type::method` reference.
 pub fn run_grok(target_spec: &str, scope: &Path, full: bool) -> Result<String, TilthError> {
     let bloom = index::bloom::BloomFilterCache::new();
+    let session = session::Session::default();
     let caps = if full {
         search::grok::GrokCaps::full()
     } else {
         search::grok::GrokCaps::default()
     };
-    let result = search::grok::grok(target_spec, scope, &bloom, caps)?;
+    let result = search::grok::grok(target_spec, scope, &bloom, &session, caps)?;
     Ok(search::grok::format_grok(&result, scope))
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -299,7 +299,7 @@ fn dispatch_tool(tool: &str, args: &Value, services: &Services) -> Result<String
         "tilth_search" => tool_search(args, services.cache(), services.session(), services.bloom()),
         "tilth_files" => tool_files(args),
         "tilth_deps" => tool_deps(args, services.bloom()),
-        "tilth_grok" => tool_grok(args, services.bloom()),
+        "tilth_grok" => tool_grok(args, services.bloom(), services.session()),
         "tilth_diff" => tool_diff(args),
         "tilth_session" => tool_session(args, services.session()),
         "tilth_edit" if edit_mode => tool_edit(args, services.session(), services.bloom()),

--- a/src/mcp/tools/grok.rs
+++ b/src/mcp/tools/grok.rs
@@ -3,12 +3,14 @@ use std::sync::Arc;
 use serde_json::Value;
 
 use crate::index::bloom::BloomFilterCache;
+use crate::session::Session;
 
 use super::resolve_scope;
 
 pub(in crate::mcp) fn tool_grok(
     args: &Value,
     bloom: &Arc<BloomFilterCache>,
+    session: &Session,
 ) -> Result<String, String> {
     let target = args
         .get("target")
@@ -22,8 +24,8 @@ pub(in crate::mcp) fn tool_grok(
         crate::search::grok::GrokCaps::default()
     };
 
-    let result =
-        crate::search::grok::grok(target, &scope, bloom, caps).map_err(|e| e.to_string())?;
+    let result = crate::search::grok::grok(target, &scope, bloom, session, caps)
+        .map_err(|e| e.to_string())?;
     let mut output = scope_warning.unwrap_or_default();
     output.push_str(&crate::search::grok::format_grok(&result, &scope));
     Ok(output)

--- a/src/search/grok.rs
+++ b/src/search/grok.rs
@@ -203,6 +203,19 @@ fn find_by_start_line(entries: &[OutlineEntry], line: u32) -> Option<&OutlineEnt
 }
 
 // ---------------------------------------------------------------------------
+// Body-dedup constants.
+// ---------------------------------------------------------------------------
+
+/// Skip dedup for bodies at or below this line count. A small body is already
+/// cheap; degrading it to a pointer saves no meaningful tokens and loses
+/// signal the agent might need.
+const BODY_DEGRADE_THRESHOLD: usize = 15;
+
+/// Number of body lines to keep after the signature when degrading. Enough
+/// to anchor the agent's mental model; few enough to actually save tokens.
+const BODY_PREVIEW_LINES: usize = 3;
+
+// ---------------------------------------------------------------------------
 // A2: bundle assembly
 // ---------------------------------------------------------------------------
 
@@ -298,16 +311,12 @@ pub fn grok(
     target_spec: &str,
     scope: &Path,
     bloom: &BloomFilterCache,
+    session: &crate::session::Session,
     caps: GrokCaps,
 ) -> Result<GrokResult, TilthError> {
     let (target, content, lang) = resolve_with_source(target_spec, scope)?;
     let entries = get_outline_entries(&content, lang);
-    let body = slice_body(
-        &content,
-        target.start_line,
-        target.end_line,
-        caps.max_body_lines,
-    );
+    let body = body_with_dedup(&target, &content, session, caps.max_body_lines);
 
     // --- Callees -----------------------------------------------------------
     let callee_names =
@@ -388,6 +397,13 @@ pub fn grok(
         .collect();
     tests.truncate(caps.max_tests);
 
+    // Record this expansion so a same-session repeat-grok of the same target
+    // degrades to a preview rather than re-inlining the full body. Silently
+    // skipped on metadata failure — the next call will just re-inline normally.
+    if let Ok(mtime) = std::fs::metadata(&target.path).and_then(|md| md.modified()) {
+        session.record_expand(&target.path, target.start_line, mtime);
+    }
+
     Ok(GrokResult {
         target,
         body,
@@ -408,6 +424,53 @@ pub fn grok(
 /// — when the body is longer, keeps the first 2/3 and last 1/3, separated by
 /// an elided-line marker. Returns "" on degenerate ranges or `max_lines == 0`
 /// (used by callers that want to suppress the body section entirely).
+/// Return either the full body slice (un-degraded) or a degraded preview
+/// when the body was already shown in this session AND the file is unchanged.
+///
+/// Degraded format:
+///   <full body line 1>           ← the signature line is part of the body slice
+///   <up to BODY_PREVIEW_LINES more lines>
+///   // [{N}-line body shown earlier — {path}:{line}]
+///
+/// Skips degradation when the body is at or below `BODY_DEGRADE_THRESHOLD` —
+/// the original is already short, degrading saves no meaningful tokens.
+/// Returns the un-degraded body whenever metadata lookup fails, the file's
+/// mtime has changed since the recorded expansion, or this is the first time
+/// we've seen this target. That's the safe fallback.
+fn body_with_dedup(
+    target: &ResolvedTarget,
+    content: &str,
+    session: &crate::session::Session,
+    max_body_lines: usize,
+) -> String {
+    let full = slice_body(content, target.start_line, target.end_line, max_body_lines);
+    let line_count = full.lines().count();
+    if line_count <= BODY_DEGRADE_THRESHOLD {
+        return full;
+    }
+    let Some(current_mtime) = std::fs::metadata(&target.path)
+        .ok()
+        .and_then(|md| md.modified().ok())
+    else {
+        return full;
+    };
+    if !session.is_expanded(&target.path, target.start_line, current_mtime) {
+        return full;
+    }
+    let mut preview = String::new();
+    for line in full.lines().take(BODY_PREVIEW_LINES + 1) {
+        preview.push_str(line);
+        preview.push('\n');
+    }
+    let _ = write!(
+        preview,
+        "// [{line_count}-line body shown earlier — {}:{}]",
+        target.path.display(),
+        target.start_line
+    );
+    preview
+}
+
 fn slice_body(content: &str, start_line: u32, end_line: u32, max_lines: usize) -> String {
     if start_line == 0 || end_line < start_line || max_lines == 0 {
         return String::new();
@@ -513,9 +576,24 @@ pub fn format_grok(result: &GrokResult, scope: &Path) -> String {
             out,
             "\n## callees ({internal_count} internal, {external_count} extern)"
         );
+        // Group internal callees by file so the agent sees the cross-file
+        // dependency structure at a glance. BTreeMap keeps file order stable.
+        let mut by_file: std::collections::BTreeMap<&Path, Vec<&ResolvedCallee>> =
+            std::collections::BTreeMap::new();
         for c in &result.callees_internal {
-            let r = display_rel(&c.file, scope);
-            let _ = writeln!(out, "{:<20} {}:{}", c.name, r, c.start_line);
+            by_file.entry(c.file.as_path()).or_default().push(c);
+        }
+        for (file, mut callees) in by_file {
+            callees.sort_by_key(|c| c.start_line);
+            let _ = writeln!(out, "  {}", display_rel(file, scope));
+            for c in callees {
+                let sig = c.signature.as_deref().unwrap_or("");
+                let _ = writeln!(
+                    out,
+                    "    {:<20} [{}-{}]   {}",
+                    c.name, c.start_line, c.end_line, sig
+                );
+            }
         }
         for ext in &result.callees_external {
             let _ = writeln!(out, "{ext:<20} extern");
@@ -534,10 +612,19 @@ pub fn format_grok(result: &GrokResult, scope: &Path) -> String {
             "\n## callers ({})",
             count_label(result.callers.len(), result.total_callers)
         );
+        // Group callers by file — collapses the common case of multiple
+        // call sites in the same file under one header.
+        let mut by_file: std::collections::BTreeMap<&Path, Vec<&CallerMatch>> =
+            std::collections::BTreeMap::new();
         for m in &result.callers {
-            let r = display_rel(&m.path, scope);
-            let loc = format!("{}:{}", r, m.line);
-            let _ = writeln!(out, "{:<35} in {}()", loc, m.calling_function);
+            by_file.entry(m.path.as_path()).or_default().push(m);
+        }
+        for (file, mut callers) in by_file {
+            callers.sort_by_key(|m| m.line);
+            let _ = writeln!(out, "  {}", display_rel(file, scope));
+            for m in callers {
+                let _ = writeln!(out, "    [{}]   in {}()", m.line, m.calling_function);
+            }
         }
         if result.callers.len() < result.total_callers {
             let _ = writeln!(
@@ -1004,7 +1091,15 @@ fn test_calls_target() {
         write_fixture(tmp.path(), "src/lib.test.rs", tests);
 
         let bloom = BloomFilterCache::default();
-        let result = grok("target_fn", tmp.path(), &bloom, GrokCaps::default()).unwrap();
+        let session = crate::session::Session::default();
+        let result = grok(
+            "target_fn",
+            tmp.path(),
+            &bloom,
+            &session,
+            GrokCaps::default(),
+        )
+        .unwrap();
 
         assert_eq!(result.target.name, "target_fn");
         assert_eq!(result.target.kind, OutlineKind::Function);
@@ -1071,7 +1166,8 @@ pub fn target() {
 ";
         write_fixture(tmp.path(), "src/lib.rs", lib);
         let bloom = BloomFilterCache::default();
-        let result = grok("target", tmp.path(), &bloom, GrokCaps::default()).unwrap();
+        let session = crate::session::Session::default();
+        let result = grok("target", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
         let rendered = format_grok(&result, tmp.path());
 
         assert!(
@@ -1214,7 +1310,15 @@ pub fn target_fn() -> u32 {
 ";
         write_fixture(tmp.path(), "src/lib.rs", lib);
         let bloom = BloomFilterCache::default();
-        let result = grok("target_fn", tmp.path(), &bloom, GrokCaps::default()).unwrap();
+        let session = crate::session::Session::default();
+        let result = grok(
+            "target_fn",
+            tmp.path(),
+            &bloom,
+            &session,
+            GrokCaps::default(),
+        )
+        .unwrap();
         assert!(
             result.body.contains("let x = 42"),
             "body should contain target source, got {:?}",
@@ -1255,7 +1359,8 @@ fn h() {}
             max_tests: 8,
             max_body_lines: 60,
         };
-        let result = grok("target", tmp.path(), &bloom, caps).unwrap();
+        let session = crate::session::Session::default();
+        let result = grok("target", tmp.path(), &bloom, &session, caps).unwrap();
         assert_eq!(result.callees_internal.len(), 3, "callees capped");
         assert_eq!(result.siblings.len(), 2, "siblings capped");
         assert!(
@@ -1263,5 +1368,158 @@ fn h() {}
             "pre-cap total preserved"
         );
         assert!(result.total_siblings >= 8);
+    }
+
+    // ── GROK-DEDUP tests ───────────────────────────────────────────
+
+    /// Source with a body big enough to trigger degradation (> BODY_DEGRADE_THRESHOLD).
+    fn long_body_fixture(name: &str) -> String {
+        let mut s = format!("pub fn {name}() {{\n");
+        for i in 0..20 {
+            s.push_str(&format!("    let v{i} = {i};\n"));
+        }
+        s.push_str("}\n");
+        s
+    }
+
+    #[test]
+    fn grok_repeat_call_degrades_target_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "src/lib.rs", &long_body_fixture("big"));
+        let bloom = BloomFilterCache::default();
+        let session = crate::session::Session::default();
+
+        let r1 = grok("big", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        assert!(
+            !r1.body.contains("shown earlier"),
+            "first call must be full body"
+        );
+
+        let r2 = grok("big", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        assert!(
+            r2.body.contains("shown earlier"),
+            "second call must degrade"
+        );
+        // Degraded body should still anchor with the signature — first line preserved.
+        assert!(r2.body.starts_with("pub fn big()"), "signature preserved");
+    }
+
+    #[test]
+    fn grok_short_body_not_degraded() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fixture(tmp.path(), "src/lib.rs", "pub fn tiny() { 1 }\n");
+        let bloom = BloomFilterCache::default();
+        let session = crate::session::Session::default();
+
+        let r1 = grok("tiny", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        let r2 = grok("tiny", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        assert_eq!(r1.body, r2.body, "sub-threshold body should never degrade");
+        assert!(!r2.body.contains("shown earlier"));
+    }
+
+    #[test]
+    fn grok_stale_after_edit_re_inlines_full_body() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("src/lib.rs");
+        write_fixture(tmp.path(), "src/lib.rs", &long_body_fixture("stale"));
+        let bloom = BloomFilterCache::default();
+        let session = crate::session::Session::default();
+
+        let _ = grok("stale", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+
+        // Bump mtime by overwriting (sleep 10ms to guarantee mtime tick on coarse FS).
+        std::thread::sleep(std::time::Duration::from_millis(10));
+        std::fs::write(&path, long_body_fixture("stale")).unwrap();
+
+        let r2 = grok("stale", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        assert!(
+            !r2.body.contains("shown earlier"),
+            "post-edit re-grok must re-inline full body, got: {}",
+            r2.body
+        );
+    }
+
+    // ── GROK-GROUP tests ───────────────────────────────────────────
+
+    #[test]
+    fn format_groups_callers_by_file() {
+        // The fixture from existing tests already produces 1 caller in 1 file.
+        // Verify the rendered output uses the grouped shape (file header + indented sites).
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = r#"
+pub fn target() { let _ = 1; }
+pub fn caller_a() { target(); }
+pub fn caller_b() { target(); }
+"#;
+        write_fixture(tmp.path(), "src/lib.rs", lib);
+        let bloom = BloomFilterCache::default();
+        let session = crate::session::Session::default();
+        let result = grok("target", tmp.path(), &bloom, &session, GrokCaps::default()).unwrap();
+        let rendered = format_grok(&result, tmp.path());
+
+        // File header appears once, then per-site lines are indented.
+        let callers_block = rendered
+            .split("## callers")
+            .nth(1)
+            .expect("## callers section missing");
+        assert!(
+            callers_block.contains("\n  src/lib.rs\n"),
+            "expected file header in callers block: {callers_block}"
+        );
+        // Per-site lines render as `    [<line>]   in <fn>()`.
+        assert!(
+            callers_block.contains("in caller_a()"),
+            "caller_a should appear: {callers_block}"
+        );
+        assert!(
+            callers_block.contains("in caller_b()"),
+            "caller_b should appear: {callers_block}"
+        );
+    }
+
+    #[test]
+    fn format_groups_callees_by_file() {
+        // target_fn calls helper (same file) and peer (same file). Verify
+        // the single file header collapses both callees under it.
+        let tmp = tempfile::tempdir().unwrap();
+        let lib = r#"
+pub fn helper() -> u32 { 1 }
+pub fn peer() {}
+pub fn target_fn() {
+    let _ = helper();
+    peer();
+}
+"#;
+        write_fixture(tmp.path(), "src/lib.rs", lib);
+        let bloom = BloomFilterCache::default();
+        let session = crate::session::Session::default();
+        let result = grok(
+            "target_fn",
+            tmp.path(),
+            &bloom,
+            &session,
+            GrokCaps::default(),
+        )
+        .unwrap();
+        let rendered = format_grok(&result, tmp.path());
+
+        let callees_block = rendered
+            .split("## callees")
+            .nth(1)
+            .expect("## callees section missing");
+        // Both callees live under the same file header.
+        let lib_pos = callees_block
+            .find("\n  src/lib.rs\n")
+            .expect("file header missing");
+        let helper_pos = callees_block.find("helper").expect("helper missing");
+        let peer_pos = callees_block.find("peer").expect("peer missing");
+        assert!(lib_pos < helper_pos, "file header must precede helper");
+        assert!(lib_pos < peer_pos, "file header must precede peer");
+        // No second `src/lib.rs` header — the grouping collapsed them.
+        let later = &callees_block[lib_pos + 1..];
+        assert!(
+            !later.contains("\n  src/lib.rs\n"),
+            "file header should appear once, not duplicated"
+        );
     }
 }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -605,10 +605,16 @@ fn format_single_match(
     }
 
     if *expand_remaining > 0 {
-        // Check session dedup for definitions with def_range
+        // Check session dedup for definitions with def_range. The mtime
+        // check ensures a post-edit search re-inlines the body rather than
+        // pointing at stale line numbers.
+        let current_mtime = std::fs::metadata(&m.path)
+            .ok()
+            .and_then(|md| md.modified().ok());
         let deduped = m.is_definition
             && m.def_range.is_some()
-            && session.is_some_and(|s| s.is_expanded(&m.path, m.line));
+            && session
+                .is_some_and(|s| current_mtime.is_some_and(|t| s.is_expanded(&m.path, m.line, t)));
 
         if deduped {
             if let Some((start, end)) = m.def_range {
@@ -626,8 +632,8 @@ fn format_single_match(
             if !skip {
                 if let Some((code, content)) = expand_match(m, scope) {
                     if m.is_definition && m.def_range.is_some() {
-                        if let Some(s) = session {
-                            s.record_expand(&m.path, m.line);
+                        if let (Some(s), Some(t)) = (session, current_mtime) {
+                            s.record_expand(&m.path, m.line, t);
                         }
                     }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -1,8 +1,9 @@
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::path::Path;
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Mutex;
+use std::time::SystemTime;
 
 /// Tracks MCP activity across calls.
 /// Stored alongside `OutlineCache` in server state.
@@ -11,7 +12,10 @@ pub struct Session {
     searches: AtomicUsize,
     symbols: Mutex<HashMap<String, usize>>, // query → search count
     dir_hits: Mutex<HashMap<String, usize>>, // dir → count
-    expanded: Mutex<HashSet<String>>,       // "path:line" → expanded status
+    /// `path:line` → file mtime at expand-time. mtime versioning lets
+    /// `is_expanded` detect stale records when the file has been edited
+    /// since the expansion was first shown.
+    expanded: Mutex<HashMap<String, SystemTime>>,
 }
 
 impl Session {
@@ -21,7 +25,7 @@ impl Session {
             searches: AtomicUsize::new(0),
             symbols: Mutex::new(HashMap::new()),
             dir_hits: Mutex::new(HashMap::new()),
-            expanded: Mutex::new(HashSet::new()),
+            expanded: Mutex::new(HashMap::new()),
         }
     }
 
@@ -108,20 +112,24 @@ impl Session {
             .clear();
     }
 
-    pub fn is_expanded(&self, path: &Path, line: u32) -> bool {
+    /// Return true only when this `(path, line)` was previously expanded
+    /// AND the recorded mtime matches `current_mtime`. After-edit re-grok
+    /// falls back to a full re-inline.
+    pub fn is_expanded(&self, path: &Path, line: u32, current_mtime: SystemTime) -> bool {
         let key = format!("{}:{}", path.display(), line);
         self.expanded
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .contains(&key)
+            .get(&key)
+            .is_some_and(|&recorded| recorded == current_mtime)
     }
 
-    pub fn record_expand(&self, path: &Path, line: u32) {
+    pub fn record_expand(&self, path: &Path, line: u32, mtime: SystemTime) {
         let key = format!("{}:{}", path.display(), line);
         self.expanded
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .insert(key);
+            .insert(key, mtime);
     }
 }
 


### PR DESCRIPTION
Two independent wins for `tilth_grok`, ~300 LOC (65 production, 210 tests, 25 formatter changes).

## Session dedup of target body

A same-session repeat-grok of the same target degrades the body to **signature + 3 preview lines + `// [N-line body shown earlier — path:line]`**. The marker is unconditional; the agent always has enough signal to reason even when context compression evicted the earlier mention.

- Threaded `&Session` through `grok()`, `run_grok()`, `tool_grok`, CLI
- Extended `Session::is_expanded` / `record_expand` to be **mtime-versioned** — post-edit re-grok sees mtime mismatch and re-inlines the full body (no stale-pointer lies)
- Threshold `BODY_DEGRADE_THRESHOLD = 15`: small bodies skip dedup entirely (a 4-line getter degrading to a pointer is noise, not savings)
- **Only the target body** is deduped — callees/callers stay full. Their dedup ROI is too low against the staleness risk
- Existing `tilth_search` dedup path migrated to the same mtime-versioned API; behavior identical for unedited files

## Cross-file grouping for callees + callers

Callees and callers now group under a one-line file header. Reveals cross-file dependency structure at a glance — the comprehension benefit a multi-hop walk would give, at **zero added latency** and without giving agents a footgun parameter.

**Before:**
```
## callers (2)
src/mcp/tools/edit.rs:61    in parse_edit_entry()
src/mcp/tools/edit.rs:64    in parse_edit_entry()
```

**After:**
```
## callers (2)
  src/mcp/tools/edit.rs
    [61]   in parse_edit_entry()
    [64]   in parse_edit_entry()
```

`BTreeMap<&Path, ...>` keeps file order deterministic; per-file lists sort by line. External (unresolved) callees still render flat.

## Why this approach

After devil's-advocating my own initial plan:
- **Dropped:** `depth` parameter for transitive walking. Agents would max it out, depth>1 is 3-5× slower for marginal signatures-only value, iterative single-depth grok is more selective
- **Dropped:** pointer-only dedup (`[shown earlier]` with no preview). Risked "pointer to nothing" when context window evicts the original

The mechanism captures the well-known "context compounding" effect: when tool-use chains get shorter, less token spend goes to re-reading accumulated transcript history. Done in tilth's existing architecture — no embeddings, no vector DB, no new infrastructure.

## Test plan

- [x] `cargo build --release` clean
- [x] `cargo test --release` — **401 passed**, 0 failed (was 396, +5 new)
- [x] `cargo clippy -- -D warnings` clean (CI form)
- [x] `cargo fmt --check` clean
- [x] Manual smoke: `tilth grok parse_anchor` on tilth itself — diff against baseline shows ONLY the callers grouping change (intended)

5 new tests:
- `grok_repeat_call_degrades_target_body` — second call gets degraded form
- `grok_short_body_not_degraded` — ≤15-line bodies bypass dedup
- `grok_stale_after_edit_re_inlines_full_body` — mtime check invalidates after edit
- `format_groups_callers_by_file` — single file header for multiple call sites
- `format_groups_callees_by_file` — same for callees

🤖 Generated with [Claude Code](https://claude.com/claude-code)
