### PR TITLE
feat(edit): post-write parse check for tilth_edit

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -49,6 +49,9 @@ enum EditResult {
         diff: String,
         /// Hashlined context around edit sites (existing behavior).
         context: String,
+        /// Rendered `── parse ──` block when the edit introduced new
+        /// tree-sitter `ERROR`/`MISSING` nodes; `None` otherwise.
+        parse: Option<String>,
     },
     /// One or more hashes didn't match current content.
     HashMismatch(String),
@@ -67,6 +70,7 @@ fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
         return Ok(EditResult::Applied {
             diff: String::new(),
             context: String::new(),
+            parse: None,
         });
     }
 
@@ -264,7 +268,15 @@ fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
     let diff = format_diffs(&diffs);
     let context = contexts.join("\n---\n");
 
-    Ok(EditResult::Applied { diff, context })
+    let parse = crate::edit_parse_check::check(path, &content, &output)
+        .as_ref()
+        .map(crate::edit_parse_check::format_report);
+
+    Ok(EditResult::Applied {
+        diff,
+        context,
+        parse,
+    })
 }
 
 /// Format per-edit diffs as compact `-`/`+` blocks with hashline anchors.
@@ -471,7 +483,11 @@ fn render_applied(
     show_diff: bool,
 ) -> Result<String, String> {
     match apply_edits(path, edits).map_err(|e| e.to_string())? {
-        EditResult::Applied { diff, context } => {
+        EditResult::Applied {
+            diff,
+            context,
+            parse,
+        } => {
             let mut output = String::new();
             if show_diff && !diff.is_empty() {
                 output.push_str(&diff);
@@ -481,6 +497,12 @@ fn render_applied(
             }
             if !context.is_empty() {
                 output.push_str(&context);
+            }
+            if let Some(parse) = parse {
+                if !output.is_empty() {
+                    output.push_str("\n\n");
+                }
+                output.push_str(&parse);
             }
             let abs_path = fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf());
             let scope = crate::lang::package_root(&abs_path).map_or_else(
@@ -529,7 +551,7 @@ mod tests {
 
         let result = apply_edits(&path, &edits).unwrap();
         match result {
-            EditResult::Applied { diff, context } => {
+            EditResult::Applied { diff, context, .. } => {
                 assert!(
                     diff.contains("- 2:"),
                     "diff should have removed line: {diff}"
@@ -693,7 +715,7 @@ mod tests {
 
         let result = apply_edits(&path, &[]).unwrap();
         match result {
-            EditResult::Applied { diff, context } => {
+            EditResult::Applied { diff, context, .. } => {
                 assert!(diff.is_empty(), "diff should be empty for no edits");
                 assert!(context.is_empty(), "context should be empty for no edits");
             }
@@ -1171,5 +1193,62 @@ mod tests {
         assert!(err.contains("duplicate file path"), "unexpected: {err}");
         // File must be untouched — no worker ran.
         assert_eq!(std::fs::read_to_string(&a).unwrap(), "x\n");
+    }
+
+    // ------------------------------------------------- parse check
+
+    #[test]
+    fn apply_batch_surfaces_parse_block_on_introduced_error() {
+        // Edit drops the closing brace on a Rust line → new ERROR node →
+        // the rendered batch output must carry the `── parse ──` block.
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("m.rs");
+        let content = "fn a() { 1 }\nfn b() { 2 }\n";
+        std::fs::write(&f, content).unwrap();
+        let h = hash_at(content, 1);
+
+        let tasks = vec![ready_task(
+            f.clone(),
+            vec![Edit {
+                start_line: 1,
+                start_hash: h,
+                end_line: 1,
+                end_hash: h,
+                content: "fn a() { 1".into(), // dropped closing brace
+            }],
+        )];
+
+        let out = apply_batch(tasks, &fresh_bloom(), false).expect("edit applies");
+        assert!(
+            out.contains("\u{2500}\u{2500} parse \u{2500}\u{2500}"),
+            "introduced error should surface a parse block: {out}"
+        );
+    }
+
+    #[test]
+    fn apply_batch_no_parse_block_on_clean_edit() {
+        // Valid code edited into still-valid code → no `── parse ──` block.
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("m.rs");
+        let content = "fn a() { 1 }\nfn b() { 2 }\n";
+        std::fs::write(&f, content).unwrap();
+        let h = hash_at(content, 1);
+
+        let tasks = vec![ready_task(
+            f.clone(),
+            vec![Edit {
+                start_line: 1,
+                start_hash: h,
+                end_line: 1,
+                end_hash: h,
+                content: "fn a() { 10 }".into(),
+            }],
+        )];
+
+        let out = apply_batch(tasks, &fresh_bloom(), false).expect("edit applies");
+        assert!(
+            !out.contains("\u{2500}\u{2500} parse \u{2500}\u{2500}"),
+            "clean edit must not surface a parse block: {out}"
+        );
     }
 }

--- a/src/edit_parse_check.rs
+++ b/src/edit_parse_check.rs
@@ -1,0 +1,473 @@
+//! Post-edit tree-sitter parse check.
+//!
+//! After `tilth_edit` writes a file, parse the pre- and post-edit content with
+//! the language's tree-sitter grammar and surface any *new* `ERROR` / `MISSING`
+//! nodes the edit introduced. Pre-existing errors stay silent.
+//!
+//! Multiset diff by `(ErrorKind, detail)` where `ErrorKind` is the local
+//! `Error`/`Missing` enum (not the tree-sitter node kind) and `detail` is the
+//! trimmed/truncated node text. Deliberately non-positional — robust to edits
+//! that shift line numbers (a positional key would false-flag pre-existing
+//! errors below the edit site).
+
+use std::collections::HashMap;
+use std::path::Path;
+
+use crate::lang::detect_file_type;
+use crate::lang::outline::outline_language;
+use crate::types::FileType;
+
+/// Maximum number of new errors listed before truncating to a count summary.
+const MAX_LISTED: usize = 10;
+
+/// Maximum characters of error-node text shown in the `detail` field.
+const DETAIL_MAX_CHARS: usize = 40;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ErrorKind {
+    Error,
+    Missing,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParseError {
+    /// 1-indexed line number, suitable for direct display.
+    pub line: usize,
+    /// 0-indexed column from `tree_sitter::Point::column`. Internal sort key
+    /// only — never rendered, so the indexing offset doesn't appear in output.
+    pub col: usize,
+    pub kind: ErrorKind,
+    /// For `ERROR`: trimmed/truncated node text. For `MISSING`: the node `kind()`
+    /// (i.e. what was expected, e.g. `;`).
+    pub detail: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParseReport {
+    pub new_errors: Vec<ParseError>,
+    /// Total errors in the post-edit parse, used for the truncation summary.
+    pub total_post: usize,
+}
+
+/// Parse `before` and `after`, return a report of errors introduced by the
+/// edit. Returns `None` when:
+/// - the path's language has no tree-sitter grammar, or
+/// - no new errors were introduced.
+pub fn check(path: &Path, before: &str, after: &str) -> Option<ParseReport> {
+    let FileType::Code(lang) = detect_file_type(path) else {
+        return None;
+    };
+    let grammar = outline_language(lang)?;
+
+    let pre = parse_errors(&grammar, before)?;
+    let post = parse_errors(&grammar, after)?;
+
+    let total_post = post.len();
+    let new_errors = multiset_subtract(&pre, post);
+    if new_errors.is_empty() {
+        return None;
+    }
+
+    Some(ParseReport {
+        new_errors,
+        total_post,
+    })
+}
+
+/// Format a report as a `── parse ──` block, caps at `MAX_LISTED` lines.
+pub fn format_report(report: &ParseReport) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::from("\u{2500}\u{2500} parse \u{2500}\u{2500}");
+    for e in report.new_errors.iter().take(MAX_LISTED) {
+        let kind = match e.kind {
+            ErrorKind::Error => "ERROR",
+            ErrorKind::Missing => "MISSING",
+        };
+        if e.detail.is_empty() {
+            let _ = write!(out, "\n:{} {kind}", e.line);
+        } else {
+            let _ = write!(out, "\n:{} {kind} {}", e.line, e.detail);
+        }
+    }
+    let total_new = report.new_errors.len();
+    if total_new > MAX_LISTED {
+        let more = total_new - MAX_LISTED;
+        let total_post = report.total_post;
+        let _ = write!(
+            out,
+            "\n... and {more} more ({total_new} new, {total_post} total)"
+        );
+    }
+    out
+}
+
+fn parse_errors(grammar: &tree_sitter::Language, source: &str) -> Option<Vec<ParseError>> {
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(grammar).ok()?;
+    let tree = parser.parse(source, None)?;
+    let mut errors = Vec::new();
+    collect_errors(tree.root_node(), source.as_bytes(), &mut errors);
+    errors.sort_by_key(|e| (e.line, e.col));
+    Some(errors)
+}
+
+fn collect_errors(node: tree_sitter::Node, source: &[u8], out: &mut Vec<ParseError>) {
+    if node.is_error() || node.is_missing() {
+        let pos = node.start_position();
+        let (kind, detail) = if node.is_missing() {
+            (ErrorKind::Missing, node.kind().to_string())
+        } else {
+            let text = node.utf8_text(source).unwrap_or("").trim();
+            (ErrorKind::Error, truncate_chars(text, DETAIL_MAX_CHARS))
+        };
+        out.push(ParseError {
+            line: pos.row + 1,
+            col: pos.column,
+            kind,
+            detail,
+        });
+    }
+    let mut cursor = node.walk();
+    for child in node.children(&mut cursor) {
+        collect_errors(child, source, out);
+    }
+}
+
+/// Multiset subtraction. For each key `(ErrorKind, detail)` — i.e.
+/// `(Error|Missing, trimmed node text or expected kind)` — count occurrences
+/// in `pre`; walk `post` in order, skipping the first `pre_count` instances
+/// of that key (they match pre-existing errors), and collecting the rest as
+/// new. Positions are deliberately not part of the key.
+fn multiset_subtract(pre: &[ParseError], post: Vec<ParseError>) -> Vec<ParseError> {
+    let mut remaining: HashMap<(ErrorKind, String), usize> = HashMap::new();
+    for e in pre {
+        *remaining.entry((e.kind, e.detail.clone())).or_insert(0) += 1;
+    }
+    let mut new_errors = Vec::new();
+    for e in post {
+        let key = (e.kind, e.detail.clone());
+        if let Some(count) = remaining.get_mut(&key) {
+            if *count > 0 {
+                *count -= 1;
+                continue;
+            }
+        }
+        new_errors.push(e);
+    }
+    new_errors
+}
+
+fn truncate_chars(s: &str, max: usize) -> String {
+    let mut out = String::with_capacity(max);
+    for (i, c) in s.chars().enumerate() {
+        if i >= max {
+            return format!("{out}…");
+        }
+        out.push(c);
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    fn rust(name: &str) -> PathBuf {
+        PathBuf::from(format!("/tmp/{name}.rs"))
+    }
+
+    #[test]
+    fn clean_edit_returns_none() {
+        let before = "fn a() { 1 }\nfn b() { 2 }\n";
+        let after = "fn a() { 10 }\nfn b() { 2 }\n";
+        assert!(check(&rust("clean"), before, after).is_none());
+    }
+
+    #[test]
+    fn introduced_error_reported() {
+        let before = "fn a() { 1 }\n";
+        let after = "fn a() { 1 \n"; // missing closing brace
+        let r = check(&rust("brace"), before, after).expect("should report");
+        assert!(!r.new_errors.is_empty(), "expected new errors");
+        assert!(r
+            .new_errors
+            .iter()
+            .any(|e| matches!(e.kind, ErrorKind::Error | ErrorKind::Missing)),);
+    }
+
+    #[test]
+    fn preexisting_error_silent() {
+        // File starts broken (missing brace at end), edit unrelated line.
+        let before = "fn a() { 1 }\nfn b() { 2 \n";
+        let after = "fn a() { 99 }\nfn b() { 2 \n";
+        assert!(
+            check(&rust("preexisting"), before, after).is_none(),
+            "pre-existing error should not be flagged"
+        );
+    }
+
+    #[test]
+    fn pre_existing_error_shifted_by_edit_is_silent() {
+        // Pre-existing trailing error. The edit deletes a line above it,
+        // shifting the error's line number down. Positional diff would
+        // false-flag; multiset diff stays silent.
+        let before = "fn a() { 1 }\nfn b() { 2 }\nfn c() { 3 \n";
+        let after = "fn b() { 2 }\nfn c() { 3 \n"; // dropped fn a
+        assert!(
+            check(&rust("shifted"), before, after).is_none(),
+            "shifted pre-existing error should not be flagged",
+        );
+    }
+
+    #[test]
+    fn missing_node_reported() {
+        // Java grammar reports MISSING for omitted semicolons.
+        let path = PathBuf::from("/tmp/T.java");
+        let before = "class T { int x = 1; }\n";
+        let after = "class T { int x = 1 }\n";
+        let r = check(&path, before, after).expect("should report");
+        assert!(
+            r.new_errors
+                .iter()
+                .any(|e| matches!(e.kind, ErrorKind::Missing)),
+            "expected MISSING node, got {:?}",
+            r.new_errors
+        );
+    }
+
+    #[test]
+    fn format_caps_at_ten_with_summary() {
+        // tree-sitter coalesces consecutive bad tokens into one ERROR node, so
+        // crafting 15 separate errors from source is grammar-dependent and
+        // fragile. Test format_report directly with a synthetic report — the
+        // cap is the unit under test, not the parser.
+        let new_errors: Vec<ParseError> = (1..=15)
+            .map(|i| ParseError {
+                line: i,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: "}".into(),
+            })
+            .collect();
+        let report = ParseReport {
+            new_errors,
+            total_post: 15,
+        };
+        let formatted = format_report(&report);
+        let listed = formatted.lines().filter(|l| l.starts_with(':')).count();
+        assert_eq!(listed, MAX_LISTED, "expected exactly 10 listed");
+        assert!(
+            formatted.contains("... and 5 more (15 new, 15 total)"),
+            "summary missing: {formatted}",
+        );
+    }
+
+    #[test]
+    fn no_grammar_returns_none() {
+        // .txt files have no grammar (FileType::Other).
+        let path = PathBuf::from("/tmp/notes.txt");
+        let before = "hello\n";
+        let after = "hello there\n";
+        assert!(check(&path, before, after).is_none());
+    }
+
+    #[test]
+    fn dockerfile_returns_none() {
+        let path = PathBuf::from("/tmp/Dockerfile");
+        let before = "FROM scratch\n";
+        let after = "FROM scratch\nCMD echo hi\n";
+        assert!(check(&path, before, after).is_none());
+    }
+
+    #[test]
+    fn error_detail_truncated() {
+        // Construct an error with a long literal that becomes the error text.
+        // Rust grammar treats unbalanced parens as ERROR — wrap in a function
+        // and inject a long broken expression.
+        let long = "x".repeat(200);
+        let before = "fn a() { 1 }\n";
+        let after = format!("fn a() {{ ({long} \n");
+        let r = check(&rust("trunc"), before, &after).expect("should report");
+        for e in &r.new_errors {
+            assert!(
+                e.detail.chars().count() <= DETAIL_MAX_CHARS + 1,
+                "detail too long: {:?}",
+                e.detail
+            );
+        }
+    }
+
+    #[test]
+    fn errors_sorted_by_line_then_col() {
+        // Synthetic input — sort is a property of parse_errors() and the
+        // formatter output. Construct an unsorted list, run it through
+        // multiset_subtract (which preserves order) and verify the post-parse
+        // list is sorted in check(). Easier to assert directly on parse_errors
+        // by re-parsing a known-broken file.
+        let path = rust("sort");
+        let before = "fn a() { 1 }\n";
+        // Two unrelated syntax errors on different lines.
+        let after = "fn a() { ) }\nfn b() { ( }\n";
+        let r = check(&path, before, after).expect("should report new errors");
+        assert!(
+            r.new_errors.len() >= 2,
+            "expected >=2 errors, got {:?}",
+            r.new_errors
+        );
+        let mut last: (usize, usize) = (0, 0);
+        for e in &r.new_errors {
+            assert!(
+                (e.line, e.col) >= last,
+                "errors not sorted: {:?}",
+                r.new_errors
+            );
+            last = (e.line, e.col);
+        }
+    }
+
+    #[test]
+    fn format_omits_block_header_only_on_no_errors() {
+        // format_report is only called when new_errors is non-empty (check returns
+        // None otherwise). This guards the contract — format starts with the header.
+        let report = ParseReport {
+            new_errors: vec![ParseError {
+                line: 5,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: "}".into(),
+            }],
+            total_post: 1,
+        };
+        let s = format_report(&report);
+        assert!(s.starts_with("\u{2500}\u{2500} parse \u{2500}\u{2500}"));
+        assert!(s.contains(":5 ERROR"));
+        assert!(s.contains('}'));
+    }
+
+    #[test]
+    fn multiset_subtract_reports_only_the_surplus() {
+        // Core non-positional contract: with two pre-existing `(Error, "}")` and
+        // three in post, exactly one (the surplus) is new. Pre instances are
+        // absorbed regardless of their post positions/lines.
+        let mk = |line: usize| ParseError {
+            line,
+            col: 0,
+            kind: ErrorKind::Error,
+            detail: "}".into(),
+        };
+        let pre = vec![mk(1), mk(2)];
+        let post = vec![mk(10), mk(20), mk(30)];
+        let new = multiset_subtract(&pre, post);
+        assert_eq!(new.len(), 1, "only the surplus duplicate is new: {new:?}");
+        assert_eq!(new[0].line, 30, "FIFO skip absorbs the first two: {new:?}");
+    }
+
+    #[test]
+    fn multiset_subtract_distinguishes_kind_and_detail_keys() {
+        // A pre-existing `(Error, "}")` must not absorb a new `(Missing, "}")`
+        // or a new `(Error, ")")` — the key is (ErrorKind, detail), not detail alone.
+        let pre = vec![ParseError {
+            line: 1,
+            col: 0,
+            kind: ErrorKind::Error,
+            detail: "}".into(),
+        }];
+        let post = vec![
+            ParseError {
+                line: 1,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: "}".into(),
+            },
+            ParseError {
+                line: 2,
+                col: 0,
+                kind: ErrorKind::Missing,
+                detail: "}".into(),
+            },
+            ParseError {
+                line: 3,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: ")".into(),
+            },
+        ];
+        let new = multiset_subtract(&pre, post);
+        assert_eq!(new.len(), 2, "matching-key absorbed, others new: {new:?}");
+        assert!(
+            new.iter().any(|e| e.kind == ErrorKind::Missing),
+            "Missing/}} not absorbed by Error/}}: {new:?}"
+        );
+        assert!(
+            new.iter().any(|e| e.detail == ")"),
+            "Error/) not absorbed by Error/}}: {new:?}",
+        );
+    }
+
+    #[test]
+    fn summary_distinguishes_new_from_total() {
+        // The truncation summary reports `(new, total)` as two distinct numbers.
+        // A regression printing new_errors.len() for the total field would be
+        // invisible if new == total — pin them apart (12 new, 25 total).
+        let new_errors: Vec<ParseError> = (1..=12)
+            .map(|i| ParseError {
+                line: i,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: "}".into(),
+            })
+            .collect();
+        let report = ParseReport {
+            new_errors,
+            total_post: 25,
+        };
+        let formatted = format_report(&report);
+        assert!(
+            formatted.contains("... and 2 more (12 new, 25 total)"),
+            "summary must report new and total separately: {formatted}"
+        );
+    }
+
+    #[test]
+    fn format_renders_error_with_empty_detail() {
+        // The detail-empty branch renders `:N KIND` with no trailing text.
+        let report = ParseReport {
+            new_errors: vec![ParseError {
+                line: 7,
+                col: 0,
+                kind: ErrorKind::Error,
+                detail: String::new(),
+            }],
+            total_post: 1,
+        };
+        let s = format_report(&report);
+        assert!(
+            s.lines().any(|l| l == ":7 ERROR"),
+            "empty detail should render bare `:7 ERROR` with no trailing space: {s:?}"
+        );
+    }
+
+    #[test]
+    fn check_total_post_counts_preexisting_plus_new() {
+        // total_post (the summary denominator) must count every post-edit error,
+        // not just the new ones. Start with one pre-existing trailing error, then
+        // introduce a second, unrelated error above it. New == 1, total >= 2.
+        let path = rust("total_post");
+        let before = "fn a() { 1 }\nfn b() { 2 \n"; // b already broken (no brace)
+        let after = "fn a() { ) }\nfn b() { 2 \n"; // a now broken too
+        let r = check(&path, before, after).expect("should report the new error");
+        assert_eq!(
+            r.new_errors.len(),
+            1,
+            "only one new error: {:?}",
+            r.new_errors
+        );
+        assert!(
+            r.total_post > r.new_errors.len(),
+            "total_post must include the pre-existing error: total={}, new={}",
+            r.total_post,
+            r.new_errors.len()
+        );
+    }
+}

--- a/src/edit_parse_check.rs
+++ b/src/edit_parse_check.rs
@@ -24,41 +24,45 @@ const MAX_LISTED: usize = 10;
 const DETAIL_MAX_CHARS: usize = 40;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-pub enum ErrorKind {
+pub(crate) enum ErrorKind {
     Error,
     Missing,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ParseError {
+pub(crate) struct ParseError {
     /// 1-indexed line number, suitable for direct display.
-    pub line: usize,
+    pub(crate) line: usize,
     /// 0-indexed column from `tree_sitter::Point::column`. Internal sort key
     /// only — never rendered, so the indexing offset doesn't appear in output.
-    pub col: usize,
-    pub kind: ErrorKind,
+    pub(crate) col: usize,
+    pub(crate) kind: ErrorKind,
     /// For `ERROR`: trimmed/truncated node text. For `MISSING`: the node `kind()`
     /// (i.e. what was expected, e.g. `;`).
-    pub detail: String,
+    pub(crate) detail: String,
 }
 
 #[derive(Debug, Clone)]
-pub struct ParseReport {
-    pub new_errors: Vec<ParseError>,
+pub(crate) struct ParseReport {
+    pub(crate) new_errors: Vec<ParseError>,
     /// Total errors in the post-edit parse, used for the truncation summary.
-    pub total_post: usize,
+    pub(crate) total_post: usize,
 }
 
 /// Parse `before` and `after`, return a report of errors introduced by the
 /// edit. Returns `None` when:
 /// - the path's language has no tree-sitter grammar, or
 /// - no new errors were introduced.
-pub fn check(path: &Path, before: &str, after: &str) -> Option<ParseReport> {
+pub(crate) fn check(path: &Path, before: &str, after: &str) -> Option<ParseReport> {
     let FileType::Code(lang) = detect_file_type(path) else {
         return None;
     };
     let grammar = outline_language(lang)?;
 
+    // A `None` from parse_errors (tree-sitter `parser.parse()` failing
+    // internally) reads as a clean parse via `?`. Intentional advisory
+    // limitation — effectively unreachable here: tree-sitter is error-tolerant,
+    // the language is always set, and no parse timeout is configured.
     let pre = parse_errors(&grammar, before)?;
     let post = parse_errors(&grammar, after)?;
 
@@ -75,7 +79,7 @@ pub fn check(path: &Path, before: &str, after: &str) -> Option<ParseReport> {
 }
 
 /// Format a report as a `── parse ──` block, caps at `MAX_LISTED` lines.
-pub fn format_report(report: &ParseReport) -> String {
+pub(crate) fn format_report(report: &ParseReport) -> String {
     use std::fmt::Write as _;
     let mut out = String::from("\u{2500}\u{2500} parse \u{2500}\u{2500}");
     for e in report.new_errors.iter().take(MAX_LISTED) {
@@ -117,8 +121,17 @@ fn collect_errors(node: tree_sitter::Node, source: &[u8], out: &mut Vec<ParseErr
         let (kind, detail) = if node.is_missing() {
             (ErrorKind::Missing, node.kind().to_string())
         } else {
+            // Cap detail at the first line. An unterminated bracket makes the
+            // ERROR node swallow the lines below it into its text; keying on the
+            // full text would let an unrelated edit *below* the bracket change
+            // the multiset key and false-flag a "new" error. The bracket's own
+            // line is stable across such edits.
             let text = node.utf8_text(source).unwrap_or("").trim();
-            (ErrorKind::Error, truncate_chars(text, DETAIL_MAX_CHARS))
+            let first_line = text.lines().next().unwrap_or("");
+            (
+                ErrorKind::Error,
+                truncate_chars(first_line, DETAIL_MAX_CHARS),
+            )
         };
         out.push(ParseError {
             line: pos.row + 1,
@@ -221,6 +234,23 @@ mod tests {
     }
 
     #[test]
+    fn edit_inside_preexisting_unterminated_region_is_silent() {
+        // A pre-existing unclosed `(` makes tree-sitter's ERROR node swallow the
+        // line below it into its text. Editing only that swallowed line must not
+        // false-flag a "new" error: detail is capped at the bracket's own line,
+        // so the multiset key stays stable across an edit beneath it. Without the
+        // first-line cap, the ERROR text changes ("return (\nx = 1" vs
+        // "return (\nx = 2") and the unrelated edit leaks as new.
+        let path = PathBuf::from("/tmp/unterminated.py");
+        let before = "def g():\n    return (\nx = 1\n";
+        let after = "def g():\n    return (\nx = 2\n"; // edit only the swallowed line
+        assert!(
+            check(&path, before, after).is_none(),
+            "edit inside a pre-existing unterminated region should stay silent"
+        );
+    }
+
+    #[test]
     fn missing_node_reported() {
         // Java grammar reports MISSING for omitted semicolons.
         let path = PathBuf::from("/tmp/T.java");
@@ -290,6 +320,7 @@ mod tests {
         let after = format!("fn a() {{ ({long} \n");
         let r = check(&rust("trunc"), before, &after).expect("should report");
         for e in &r.new_errors {
+            // +1 bounds the appended `…` ellipsis (truncate_chars adds one char).
             assert!(
                 e.detail.chars().count() <= DETAIL_MAX_CHARS + 1,
                 "detail too long: {:?}",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ pub mod cache;
 pub(crate) mod classify;
 pub mod diff;
 pub(crate) mod edit;
+pub(crate) mod edit_parse_check;
 pub mod error;
 pub(crate) mod format;
 pub mod index;


### PR DESCRIPTION
## What

Adds a **post-write parse check** to `tilth_edit`. After an edit writes a file, the pre- and post-edit content are parsed with the language's tree-sitter grammar, and a `── parse ──` block is appended to the tool output listing only the **new** `ERROR` / `MISSING` nodes the edit introduced.

```
── parse ──
:42 MISSING ;
:88 ERROR }
```

## Why

An edit that drops a brace or a semicolon currently writes silently — the agent only finds out on the next read or build. This surfaces edit-introduced syntax breakage immediately, at the point of the edit.

## Design

- **Only new errors.** Pre-existing errors stay silent, even when the edit shifts their line numbers. The diff is a **non-positional multiset** keyed on `(ErrorKind, detail)` — a positional key would false-flag pre-existing errors below the edit site.
- **Advisory only.** The write always succeeds; the parse block is output, never a gate. The edit is never rejected.
- **Grammar-less languages short-circuit** to no block (returns `None`).
- Output caps at 10 listed errors, then `... and N more (X new, Y total)`.

## Scope / provenance

Slice 3 extracted from the fold-in mega-PR #112. Authored on an older base (before the `mcp.rs` module split), so a clean cherry-pick does not apply — **re-applied by hand** onto the current post-split layout:

- `src/edit_parse_check.rs` — new module (ported verbatim, incl. its test suite).
- `src/lib.rs` — module declaration.
- `src/edit.rs` — threads `parse: Option<String>` through `EditResult::Applied` and appends the block in the render path. No `mcp/tools/edit.rs` change needed — `tool_edit` forwards `apply_batch`'s output unchanged.

## Heads-up: races open PR #124

PR #124 (`feat(edit): allow tilth_edit to create new files`) also rewrites `src/edit.rs`. Intent is to **land this slice first**; #124 rebases onto it (its changes are in `apply_edits`' create path, orthogonal to the parse-check wiring in the return/render path).

## Tests

`src/edit_parse_check.rs` carries its own suite (clean edit → no block; introduced error → block; pre-existing error silent; shifted pre-existing error silent; `MISSING` reported; format cap; grammar-less → `None`; multiset surplus/key-distinctness; new-vs-total summary). Plus integration assertions in `src/edit.rs` that the rendered `apply_batch` output carries/omits the block.

Gates: `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
