### PR TITLE
feat(read): budgeted sections, signature/stripped modes + default response cap

### DIFF
--- a/src/budget.rs
+++ b/src/budget.rs
@@ -1,5 +1,10 @@
 use crate::types::estimate_tokens;
 
+/// Default cap applied to MCP tool responses when no explicit `budget` is given.
+/// Sits just under the host's ~25K-token tool-response limit so a broad
+/// `tilth_read full:true`, `regex`, or `diff` can't blow the host budget.
+pub const DEFAULT_BUDGET: u64 = 24_000;
+
 /// Apply token budget to output. Works backwards from the cap:
 /// 1. Reserve 50 tokens for header
 /// 2. Truncate content at section boundaries to avoid broken output

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -26,12 +26,22 @@ pub fn apply(output: &str, budget: u64) -> String {
     let safe_max = body.floor_char_boundary(max_bytes);
     let truncated = &body[..safe_max];
 
-    // Prefer section boundaries (\n\n##) to avoid cutting mid-match in search results
+    // Prefer section boundaries (\n\n##) to avoid cutting mid-match in search results.
+    // Fallback is `safe_max` (= truncated.len()), never `max_bytes`: `max_bytes` may
+    // land mid-UTF-8-codepoint and would panic `&body[..cut_point]` on emoji-heavy
+    // single-line content with no newline in the truncated region.
+    //
+    // Reject `\n\n` cuts at position 0: body always starts with the structural
+    // header/body separator, and for code-rendered output (every line carries
+    // a `<n>:<hash>|` prefix, so blank source lines are still non-empty) that's
+    // the *only* `\n\n` in the body. Without this filter, every truncated code
+    // file would return zero content lines.
     let cut_point = truncated
         .rfind("\n\n##")
-        .or_else(|| truncated.rfind("\n\n"))
+        .filter(|&p| p > 0)
+        .or_else(|| truncated.rfind("\n\n").filter(|&p| p > 0))
         .or_else(|| truncated.rfind('\n'))
-        .unwrap_or(max_bytes);
+        .unwrap_or(safe_max);
 
     let clean_body = &body[..cut_point];
 
@@ -40,4 +50,67 @@ pub fn apply(output: &str, budget: u64) -> String {
     format!(
         "{header}{clean_body}\n\n... truncated ({remaining_tokens} tokens omitted, budget: {budget})"
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_roomy_budget_returns_input_unchanged() {
+        // 20 chars ≈ 5 tokens; budget of 1000 is way over.
+        let input = "# header\nshort body\n";
+        assert_eq!(apply(input, 1000), input);
+    }
+
+    #[test]
+    fn apply_tight_budget_truncates_with_marker() {
+        // Build a multi-line body large enough to force truncation.
+        let mut input = String::from("# header\n");
+        for i in 1..=200 {
+            input.push_str(&format!("line {i}\n"));
+        }
+        let out = apply(&input, 80);
+        assert!(out.contains("... truncated"), "marker line missing: {out}");
+        assert!(out.len() < input.len(), "must shrink: {out}");
+    }
+
+    #[test]
+    fn apply_emoji_no_newline_does_not_panic() {
+        // Single-line UTF-8 with no \n in the truncated region: `max_bytes` may land
+        // mid-codepoint, so the fallback must clamp to a char boundary.
+        let body: String = "🦀".repeat(500); // 2000 bytes, no newlines
+        let input = format!("# header\n{body}");
+        // Pick a budget so max_bytes lands somewhere mid-crab.
+        let out = apply(&input, 100);
+        assert!(out.contains("... truncated"), "expected truncation: {out}");
+    }
+
+    #[test]
+    fn apply_code_format_survives_header_separator() {
+        // Code-rendered output has `<n>:<hash>|<content>\n` on every line, so
+        // the only `\n\n` in the body is the header/body separator at position
+        // 0. Pre-fix, `rfind("\n\n")` returned 0 and `clean_body` was empty —
+        // the response was just `<header>\n\n... truncated` regardless of how
+        // generous the budget was. Verify the cut now lands deep enough that
+        // real content survives.
+        let mut input = String::from("# src/foo.rs (200 lines, ~2k tokens) [full]\n\n");
+        for i in 1..=200 {
+            input.push_str(&format!("{i}:abc|let x_{i} = {i};\n"));
+        }
+        // Tight budget — must truncate, but should leave room for many lines.
+        let out = apply(&input, 400);
+        assert!(out.contains("... truncated"), "must truncate: {out}");
+        assert!(
+            out.contains("1:abc|let x_1 ="),
+            "first code line must survive truncation: {out}"
+        );
+        // Cut must land deep into the body (the position-0 `\n\n` is rejected),
+        // so several content lines survive — not just the header separator.
+        let kept_code_lines = out.lines().filter(|l| l.contains(":abc|let x_")).count();
+        assert!(
+            kept_code_lines > 5,
+            "must keep many content lines, not cut at header separator: {out}"
+        );
+    }
 }

--- a/src/mcp/tools/definitions.rs
+++ b/src/mcp/tools/definitions.rs
@@ -86,7 +86,13 @@ pub(in crate::mcp) fn tool_definitions(edit_mode: bool) -> Vec<Value> {
                     "full": {
                         "type": "boolean",
                         "default": false,
-                        "description": "Force full content output, bypass smart outlining."
+                        "description": "Legacy alias for mode='full'. Force full content output, bypass smart outlining."
+                    },
+                    "mode": {
+                        "type": "string",
+                        "enum": ["auto", "full", "signature", "stripped"],
+                        "default": "auto",
+                        "description": "Read view. auto: smart default. full: full content. signature: hash-prefixed declarations only. stripped: whole-file content with plain comments/debug logs/extra blanks removed."
                     },
                     "budget": {
                         "type": "number",

--- a/src/mcp/tools/files.rs
+++ b/src/mcp/tools/files.rs
@@ -38,7 +38,7 @@ pub(in crate::mcp) fn tool_files(args: &Value) -> Result<String, String> {
     let combined = blocks.join("\n\n");
 
     let mut result = scope_warning.unwrap_or_default();
-    result.push_str(&apply_budget(combined, budget));
+    result.push_str(&apply_budget(&combined, budget));
     Ok(result)
 }
 

--- a/src/mcp/tools/mod.rs
+++ b/src/mcp/tools/mod.rs
@@ -42,10 +42,10 @@ pub(super) fn resolve_scope(args: &Value) -> (PathBuf, Option<String>) {
     (resolved, None)
 }
 
-pub(super) fn apply_budget(output: String, budget: Option<u64>) -> String {
+pub(super) fn apply_budget(output: &str, budget: Option<u64>) -> String {
     match budget {
-        Some(b) => crate::budget::apply(&output, b),
-        None => output,
+        Some(b) => crate::budget::apply(output, b),
+        None => crate::budget::apply(output, crate::budget::DEFAULT_BUDGET),
     }
 }
 
@@ -80,6 +80,27 @@ mod tests {
         assert_eq!(scope, PathBuf::from("."));
         assert!(warning.is_some());
         assert!(warning.unwrap().contains("not a valid directory"));
+    }
+
+    #[test]
+    fn apply_budget_none_caps_at_default() {
+        // An output far larger than DEFAULT_BUDGET must be truncated even with
+        // no explicit budget — otherwise a broad read/regex/diff blows the host
+        // ~25K tool-response limit.
+        let oversized = format!(
+            "# header line\n{}",
+            "filler content that repeats and repeats\n".repeat(20_000)
+        );
+        let capped = apply_budget(&oversized, None);
+        assert!(
+            capped.len() < oversized.len(),
+            "output should be truncated below the default budget"
+        );
+        assert!(
+            capped.contains("truncated"),
+            "truncation notice should be present: {}",
+            &capped[capped.len().saturating_sub(120)..]
+        );
     }
 
     /// Reproduces issue #37: MCP host launches tilth with cwd=/. The --scope

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -84,7 +84,7 @@ pub(in crate::mcp) fn tool_read(
             }
         }
         let combined = results.join("\n\n");
-        return Ok(apply_budget(combined, budget));
+        return Ok(apply_budget(&combined, budget));
     }
 
     // Single file read
@@ -164,7 +164,7 @@ pub(in crate::mcp) fn tool_read(
         }
     }
 
-    Ok(apply_budget(output, budget))
+    Ok(apply_budget(&output, budget))
 }
 
 // `cache` is intentionally unwired on the tree-sitter path: OutlineCache stores

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -29,6 +29,10 @@ pub(in crate::mcp) fn tool_read(
             "unknown read mode: {mode_str}. Use: auto, full, signature, stripped"
         ));
     }
+    // Precedence when full:true is combined with a reshaping mode: signature and
+    // stripped win over full. The dispatch below checks force_signature/force_stripped
+    // before falling back to force_full, so `full:true` + `mode:signature` yields a
+    // signature view, not a full dump. Pinned by tool_read_signature_beats_full_flag.
     let force_full = full_flag || mode_str == "full";
     let force_signature = mode_str == "signature";
     let force_stripped = mode_str == "stripped";
@@ -96,6 +100,15 @@ pub(in crate::mcp) fn tool_read(
         return Err("provide either section (single) or sections (array), not both".into());
     }
 
+    // signature/stripped reshape the whole file; a section selection has no
+    // meaning there. Error rather than silently dropping the mode.
+    if (force_signature || force_stripped) && (section.is_some() || sections_arr.is_some()) {
+        return Err(format!(
+            "mode={mode_str} cannot be combined with section/sections — \
+             {mode_str} reshapes the whole file. Drop section/sections or pick mode=auto/full."
+        ));
+    }
+
     // Multi-section path: bypass smart view + related-file hints (those only
     // apply to whole-file reads).
     if let Some(arr) = sections_arr {
@@ -154,6 +167,10 @@ pub(in crate::mcp) fn tool_read(
     Ok(apply_budget(output, budget))
 }
 
+// `cache` is intentionally unwired on the tree-sitter path: OutlineCache stores
+// formatted outline strings, not Vec<OutlineEntry>, so get_outline_entries below
+// re-parses every call. Wiring a structured cache is a separate change. The param
+// is still used by the non-code fallback (read_file), so it keeps its real name.
 fn read_signature_file(path: &Path, cache: &OutlineCache) -> Result<(String, u32), TilthError> {
     let content = std::fs::read_to_string(path).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => TilthError::NotFound {
@@ -173,13 +190,15 @@ fn read_signature_file(path: &Path, cache: &OutlineCache) -> Result<(String, u32
         source: e,
     })?;
     let line_count = u32::try_from(content.lines().count()).unwrap_or(u32::MAX);
-    let header = crate::format::file_header(path, meta.len(), line_count, ViewMode::Signature);
 
     let FileType::Code(lang) = detect_file_type(path) else {
         let body = crate::read::read_file(path, None, false, cache, false)?;
         return Ok((body, line_count));
     };
 
+    // Build the signature header only on the code path — the non-code fallback
+    // above returns the normal read and never uses it.
+    let header = crate::format::file_header(path, meta.len(), line_count, ViewMode::Signature);
     let entries = get_outline_entries(&content, lang);
     let lines: Vec<&str> = content.lines().collect();
     let mut body = String::new();
@@ -201,6 +220,10 @@ fn render_signature_entries(entries: &[OutlineEntry], lines: &[&str], out: &mut 
     }
 }
 
+// `cache` is intentionally unwired on the tree-sitter path: OutlineCache stores
+// formatted outline strings, not Vec<OutlineEntry>, so strip_noise re-parses every
+// call. Wiring a structured cache is a separate change. The param is still used by
+// the non-code fallback (read_file), so it keeps its real name.
 fn read_stripped_file(path: &Path, cache: &OutlineCache) -> Result<(String, u32, u32), TilthError> {
     let content = std::fs::read_to_string(path).map_err(|e| match e.kind() {
         std::io::ErrorKind::NotFound => TilthError::NotFound {
@@ -438,6 +461,60 @@ mod tests {
         assert_ne!(
             via_auto, via_flag,
             "auto must outline a large file, differing from forced full"
+        );
+    }
+
+    #[test]
+    fn tool_read_signature_beats_full_flag() {
+        // full:true + mode:signature must resolve to a signature view, not a full
+        // dump. If a future change flips the dispatch order this test fails loudly.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("precedence.rs");
+        std::fs::write(
+            &path,
+            "fn precedence_target() {\n    let body_marker = 99;\n}\n",
+        )
+        .unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "signature",
+            "full": true,
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let out = tool_read(&args, &cache, &session, false).expect("signature+full read");
+
+        assert!(
+            out.contains("[signature]"),
+            "signature must win over full:true (header): {out}"
+        );
+        assert!(
+            !out.contains("body_marker"),
+            "signature must win over full:true (body omitted): {out}"
+        );
+    }
+
+    #[test]
+    fn tool_read_signature_mode_rejects_section() {
+        // Combining a reshaping mode with section must error, not silently drop the
+        // mode (which would return a section slice and ignore signature entirely).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("conflict.rs");
+        std::fs::write(&path, "fn a() {}\nfn b() {}\n").unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "signature",
+            "section": "1-1",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let err =
+            tool_read(&args, &cache, &session, false).expect_err("signature + section must error");
+        assert!(
+            err.contains("signature") && err.contains("section"),
+            "error must name the conflict: {err}"
         );
     }
 

--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -1,10 +1,14 @@
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use serde_json::Value;
 
 use crate::cache::OutlineCache;
+use crate::error::TilthError;
+use crate::lang::detect_file_type;
+use crate::lang::outline::get_outline_entries;
 use crate::session::Session;
+use crate::types::{FileType, OutlineEntry, ViewMode};
 
 use super::apply_budget;
 
@@ -15,6 +19,19 @@ pub(in crate::mcp) fn tool_read(
     edit_mode: bool,
 ) -> Result<String, String> {
     let budget = args.get("budget").and_then(serde_json::Value::as_u64);
+    let full_flag = args
+        .get("full")
+        .and_then(serde_json::Value::as_bool)
+        .unwrap_or(false);
+    let mode_str = args.get("mode").and_then(|v| v.as_str()).unwrap_or("auto");
+    if !matches!(mode_str, "auto" | "full" | "signature" | "stripped") {
+        return Err(format!(
+            "unknown read mode: {mode_str}. Use: auto, full, signature, stripped"
+        ));
+    }
+    let force_full = full_flag || mode_str == "full";
+    let force_signature = mode_str == "signature";
+    let force_stripped = mode_str == "stripped";
 
     // Multi-file batch read (capped at 20 to bound I/O)
     if let Some(paths_arr) = args.get("paths").and_then(|v| v.as_array()) {
@@ -50,7 +67,14 @@ pub(in crate::mcp) fn tool_read(
             let path_str = p.as_str().ok_or("paths must be an array of strings")?;
             let path = PathBuf::from(path_str);
             session.record_read(&path);
-            match crate::read::read_file(&path, None, false, cache, edit_mode) {
+            let read = if force_signature {
+                read_signature_file(&path, cache).map(|(body, _)| body)
+            } else if force_stripped {
+                read_stripped_file(&path, cache).map(|(body, _, _)| body)
+            } else {
+                crate::read::read_file(&path, None, force_full, cache, edit_mode)
+            };
+            match read {
                 Ok(output) => results.push(output),
                 Err(e) => results.push(format!("# {} — error: {}", path.display(), e)),
             }
@@ -67,10 +91,6 @@ pub(in crate::mcp) fn tool_read(
     let path = PathBuf::from(path_str);
     let section = args.get("section").and_then(|v| v.as_str());
     let sections_arr = args.get("sections").and_then(|v| v.as_array());
-    let full = args
-        .get("full")
-        .and_then(serde_json::Value::as_bool)
-        .unwrap_or(false);
 
     if section.is_some() && sections_arr.is_some() {
         return Err("provide either section (single) or sections (array), not both".into());
@@ -93,14 +113,29 @@ pub(in crate::mcp) fn tool_read(
             ));
         }
         session.record_read(&path);
-        let output =
-            crate::read::read_ranges(&path, &ranges, edit_mode).map_err(|e| e.to_string())?;
-        return Ok(apply_budget(output, budget));
+        let output = match budget {
+            Some(b) => crate::read::read_ranges_with_budget(&path, &ranges, edit_mode, b)
+                .map_err(|e| e.to_string())?,
+            None => {
+                crate::read::read_ranges(&path, &ranges, edit_mode).map_err(|e| e.to_string())?
+            }
+        };
+        return Ok(output);
     }
 
     session.record_read(&path);
-    let mut output = crate::read::read_file(&path, section, full, cache, edit_mode)
-        .map_err(|e| e.to_string())?;
+    let mut output = if section.is_none() && force_signature {
+        read_signature_file(&path, cache)
+            .map(|(body, _)| body)
+            .map_err(|e| e.to_string())?
+    } else if section.is_none() && force_stripped {
+        read_stripped_file(&path, cache)
+            .map(|(body, _, _)| body)
+            .map_err(|e| e.to_string())?
+    } else {
+        crate::read::read_file(&path, section, force_full, cache, edit_mode)
+            .map_err(|e| e.to_string())?
+    };
 
     // Append related-file hint for outlined code files (not section reads, not batch).
     if section.is_none() && crate::read::would_outline(&path) {
@@ -117,4 +152,310 @@ pub(in crate::mcp) fn tool_read(
     }
 
     Ok(apply_budget(output, budget))
+}
+
+fn read_signature_file(path: &Path, cache: &OutlineCache) -> Result<(String, u32), TilthError> {
+    let content = std::fs::read_to_string(path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => TilthError::NotFound {
+            path: path.to_path_buf(),
+            suggestion: None,
+        },
+        std::io::ErrorKind::PermissionDenied => TilthError::PermissionDenied {
+            path: path.to_path_buf(),
+        },
+        _ => TilthError::IoError {
+            path: path.to_path_buf(),
+            source: e,
+        },
+    })?;
+    let meta = std::fs::metadata(path).map_err(|e| TilthError::IoError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let line_count = u32::try_from(content.lines().count()).unwrap_or(u32::MAX);
+    let header = crate::format::file_header(path, meta.len(), line_count, ViewMode::Signature);
+
+    let FileType::Code(lang) = detect_file_type(path) else {
+        let body = crate::read::read_file(path, None, false, cache, false)?;
+        return Ok((body, line_count));
+    };
+
+    let entries = get_outline_entries(&content, lang);
+    let lines: Vec<&str> = content.lines().collect();
+    let mut body = String::new();
+    render_signature_entries(&entries, &lines, &mut body);
+    if body.is_empty() {
+        body = crate::format::hashlines(&content, 1);
+    }
+    Ok((format!("{header}\n\n{}", body.trim_end()), line_count))
+}
+
+fn render_signature_entries(entries: &[OutlineEntry], lines: &[&str], out: &mut String) {
+    for entry in entries {
+        let idx = entry.start_line.saturating_sub(1) as usize;
+        if let Some(line) = lines.get(idx) {
+            let hash = crate::format::line_hash(line.as_bytes());
+            let _ = writeln!(out, "{}:{hash:03x}|{line}", entry.start_line);
+        }
+        render_signature_entries(&entry.children, lines, out);
+    }
+}
+
+fn read_stripped_file(path: &Path, cache: &OutlineCache) -> Result<(String, u32, u32), TilthError> {
+    let content = std::fs::read_to_string(path).map_err(|e| match e.kind() {
+        std::io::ErrorKind::NotFound => TilthError::NotFound {
+            path: path.to_path_buf(),
+            suggestion: None,
+        },
+        std::io::ErrorKind::PermissionDenied => TilthError::PermissionDenied {
+            path: path.to_path_buf(),
+        },
+        _ => TilthError::IoError {
+            path: path.to_path_buf(),
+            source: e,
+        },
+    })?;
+    let meta = std::fs::metadata(path).map_err(|e| TilthError::IoError {
+        path: path.to_path_buf(),
+        source: e,
+    })?;
+    let total_lines = u32::try_from(content.lines().count()).unwrap_or(u32::MAX);
+
+    if !matches!(detect_file_type(path), FileType::Code(_)) {
+        let body = crate::read::read_file(path, None, false, cache, false)?;
+        return Ok((body, total_lines, 0));
+    }
+
+    let skip_lines = crate::search::strip::strip_noise(&content, path, Some((1, total_lines)));
+    let width = total_lines.max(1).to_string().len();
+    let mut body = String::with_capacity(content.len());
+    let mut kept: u32 = 0;
+    for (i, line) in content.lines().enumerate() {
+        let line_num = u32::try_from(i + 1).unwrap_or(u32::MAX);
+        if skip_lines.contains(&line_num) {
+            continue;
+        }
+        let _ = writeln!(body, "{line_num:>width$}  {line}");
+        kept += 1;
+    }
+
+    let stripped = total_lines.saturating_sub(kept);
+    let header = crate::format::file_header(path, meta.len(), total_lines, ViewMode::Stripped);
+    let note = format!(
+        "// stripped {stripped} of {total_lines} lines (plain comments, debug logs, blank collapse) — non-editable view"
+    );
+    Ok((
+        format!("{header}\n{note}\n\n{}", body.trim_end()),
+        total_lines,
+        stripped,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::tools::tool_definitions;
+
+    #[test]
+    fn tool_read_signature_mode_emits_hash_prefixed_signatures() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("signature.rs");
+        std::fs::write(
+            &path,
+            "fn signature_target() {\n    let body_marker = 42;\n}\n",
+        )
+        .unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "signature",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let out = tool_read(&args, &cache, &session, false).expect("signature read");
+
+        assert!(
+            out.contains("[signature]"),
+            "signature header missing: {out}"
+        );
+        assert!(
+            out.lines()
+                .any(|l| l.starts_with("1:") && l.contains("fn signature_target")),
+            "hash-prefixed signature line missing: {out}"
+        );
+        assert!(
+            !out.contains("body_marker"),
+            "signature mode should omit function body: {out}"
+        );
+    }
+
+    #[test]
+    fn tool_read_stripped_mode_drops_comments_and_keeps_doc_comments() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("stripped.rs");
+        std::fs::write(
+            &path,
+            "/// keep docs\nfn keep() {\n    // drop plain comment\n    dbg!(1);\n    println!(\"keep\");\n}\n",
+        )
+        .unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "stripped",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let out = tool_read(&args, &cache, &session, true).expect("stripped read");
+
+        assert!(out.contains("[stripped]"), "stripped header missing: {out}");
+        assert!(out.contains("/// keep docs"), "doc comment missing: {out}");
+        assert!(out.contains("println!"), "kept code missing: {out}");
+        assert!(
+            !out.contains("drop plain comment"),
+            "plain comment should be stripped: {out}"
+        );
+        assert!(!out.contains("dbg!"), "debug log should be stripped: {out}");
+        assert!(
+            !out.lines().any(|l| l.contains(":") && l.contains("|")),
+            "stripped output must not expose hash anchors: {out}"
+        );
+    }
+
+    #[test]
+    fn tool_read_unknown_mode_errors() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("any.rs");
+        std::fs::write(&path, "fn f() {}\n").unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "outline",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let err = tool_read(&args, &cache, &session, false).expect_err("unknown mode must error");
+        assert!(
+            err.starts_with("unknown read mode: outline"),
+            "error must name the bad mode: {err}"
+        );
+        assert!(
+            err.contains("auto, full, signature, stripped"),
+            "error must list valid modes: {err}"
+        );
+    }
+
+    #[test]
+    fn tool_read_signature_mode_non_code_falls_back_to_normal_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, "alpha line\nbeta line\ngamma line\n").unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "signature",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let out = tool_read(&args, &cache, &session, false).expect("signature read on text");
+
+        // Non-code falls back to the normal read: no signature header, full content.
+        assert!(
+            !out.contains("[signature]"),
+            "non-code must not emit signature header: {out}"
+        );
+        assert!(out.contains("alpha line"), "content must survive: {out}");
+        assert!(out.contains("gamma line"), "content must survive: {out}");
+    }
+
+    #[test]
+    fn tool_read_stripped_mode_non_code_falls_back_to_normal_read() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, "alpha line\nbeta line\ngamma line\n").unwrap();
+        let args = serde_json::json!({
+            "path": path.to_str().unwrap(),
+            "mode": "stripped",
+        });
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let out = tool_read(&args, &cache, &session, false).expect("stripped read on text");
+
+        assert!(
+            !out.contains("[stripped]"),
+            "non-code must not emit stripped header: {out}"
+        );
+        assert!(out.contains("alpha line"), "content must survive: {out}");
+        assert!(out.contains("gamma line"), "content must survive: {out}");
+    }
+
+    #[test]
+    fn tool_read_full_flag_is_legacy_alias_for_mode_full() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("aliased.rs");
+        // Body must exceed TOKEN_THRESHOLD (6k tokens ≈ 24KB) so `auto` outlines
+        // rather than dumping full — making the alias equivalence observable, not
+        // a trivial small-file match where auto and full coincide.
+        let mut src = String::from("// header comment\n");
+        for i in 0..1500 {
+            src.push_str(&format!("fn f_{i}() {{\n    let v_{i} = {i};\n}}\n"));
+        }
+        std::fs::write(&path, &src).unwrap();
+        let cache = OutlineCache::new();
+        let session = Session::new();
+
+        let via_flag = tool_read(
+            &serde_json::json!({ "path": path.to_str().unwrap(), "full": true }),
+            &cache,
+            &session,
+            false,
+        )
+        .expect("full:true read");
+        let via_mode = tool_read(
+            &serde_json::json!({ "path": path.to_str().unwrap(), "mode": "full" }),
+            &cache,
+            &session,
+            false,
+        )
+        .expect("mode:full read");
+        let via_auto = tool_read(
+            &serde_json::json!({ "path": path.to_str().unwrap() }),
+            &cache,
+            &session,
+            false,
+        )
+        .expect("auto read");
+
+        assert_eq!(
+            via_flag, via_mode,
+            "full:true must be a byte-identical alias for mode='full'"
+        );
+        assert!(
+            via_flag.contains("[full]"),
+            "alias must force full view: {}",
+            &via_flag[..via_flag.len().min(80)]
+        );
+        assert_ne!(
+            via_auto, via_flag,
+            "auto must outline a large file, differing from forced full"
+        );
+    }
+
+    #[test]
+    fn tilth_read_schema_lists_stripped_mode() {
+        let tools = tool_definitions(false);
+        let read = tools
+            .iter()
+            .find(|tool| tool.get("name").and_then(Value::as_str) == Some("tilth_read"))
+            .expect("tilth_read definition");
+        let modes = read
+            .pointer("/inputSchema/properties/mode/enum")
+            .and_then(Value::as_array)
+            .expect("mode enum");
+
+        assert!(
+            modes.iter().any(|v| v.as_str() == Some("stripped")),
+            "mode enum must advertise stripped: {read}"
+        );
+    }
 }

--- a/src/mcp/tools/search.rs
+++ b/src/mcp/tools/search.rs
@@ -94,6 +94,6 @@ pub(in crate::mcp) fn tool_search(
     .map_err(|e| e.to_string())?;
 
     let mut result = scope_warning.unwrap_or_default();
-    result.push_str(&apply_budget(output, budget));
+    result.push_str(&apply_budget(&output, budget));
     Ok(result)
 }

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -394,6 +394,79 @@ struct Block {
 /// ranges are honored verbatim, not coalesced or sorted. Any invalid
 /// range fails the whole call.
 pub fn read_ranges(path: &Path, ranges: &[&str], edit_mode: bool) -> Result<String, TilthError> {
+    let (blocks, total_bytes, total_lines) = collect_blocks(path, ranges, edit_mode)?;
+    let header = format::file_header(path, total_bytes, total_lines, ViewMode::Section);
+
+    if blocks.len() == 1 {
+        let b = &blocks[0];
+        return Ok(format!("{header}\n\n{}", b.text));
+    }
+
+    let mut out = String::with_capacity(header.len() + total_bytes as usize + blocks.len() * 32);
+    out.push_str(&header);
+    for b in &blocks {
+        let _ = write!(out, "\n\n─── lines {}-{} ───\n", b.start, b.end);
+        out.push_str(&b.text);
+    }
+    Ok(out)
+}
+
+/// Like [`read_ranges`], but with a strict shared token budget across all
+/// sections.
+///
+/// Blocks are emitted in user order. Once the remaining budget cannot hold a
+/// later block, that block is replaced with an omission marker while the marker
+/// itself still fits. If the first block alone exceeds the budget, the standard
+/// truncator cuts that first block and all later blocks are omitted.
+pub fn read_ranges_with_budget(
+    path: &Path,
+    ranges: &[&str],
+    edit_mode: bool,
+    budget: u64,
+) -> Result<String, TilthError> {
+    let (blocks, total_bytes, total_lines) = collect_blocks(path, ranges, edit_mode)?;
+    let header = format::file_header(path, total_bytes, total_lines, ViewMode::Section);
+
+    if blocks.len() == 1 {
+        let single = format!("{header}\n\n{}", blocks[0].text);
+        return Ok(crate::budget::apply(&single, budget));
+    }
+
+    let mut out = String::with_capacity(header.len() + total_bytes as usize + blocks.len() * 32);
+    out.push_str(&header);
+    let mut remaining = budget.saturating_sub(estimate_tokens(header.len() as u64));
+
+    for (i, b) in blocks.iter().enumerate() {
+        let chunk = format!("\n\n─── lines {}-{} ───\n{}", b.start, b.end, b.text);
+        let tokens = estimate_tokens(chunk.len() as u64);
+        if tokens <= remaining {
+            out.push_str(&chunk);
+            remaining -= tokens;
+            continue;
+        }
+        if i == 0 {
+            let single = format!("{header}{chunk}");
+            return Ok(crate::budget::apply(&single, budget));
+        }
+        let marker = format!(
+            "\n\n─── lines {}-{} ───\n... section omitted (budget exhausted) ...",
+            b.start, b.end
+        );
+        let marker_tokens = estimate_tokens(marker.len() as u64);
+        if marker_tokens > remaining {
+            break;
+        }
+        out.push_str(&marker);
+        remaining -= marker_tokens;
+    }
+    Ok(out)
+}
+
+fn collect_blocks(
+    path: &Path,
+    ranges: &[&str],
+    edit_mode: bool,
+) -> Result<(Vec<Block>, u64, u32), TilthError> {
     if ranges.is_empty() {
         return Err(TilthError::InvalidQuery {
             query: String::new(),
@@ -411,7 +484,6 @@ pub fn read_ranges(path: &Path, ranges: &[&str], edit_mode: bool) -> Result<Stri
     })?;
     let buf = &mmap[..];
 
-    // Find line offsets once — shared across all ranges.
     let mut line_offsets: Vec<usize> = vec![0];
     for pos in memchr::memchr_iter(b'\n', buf) {
         line_offsets.push(pos + 1);
@@ -453,20 +525,7 @@ pub fn read_ranges(path: &Path, ranges: &[&str], edit_mode: bool) -> Result<Stri
         });
     }
 
-    let header = format::file_header(path, total_bytes, total_lines, ViewMode::Section);
-
-    if blocks.len() == 1 {
-        let b = &blocks[0];
-        return Ok(format!("{header}\n\n{}", b.text));
-    }
-
-    let mut out = String::with_capacity(header.len() + total_bytes as usize + blocks.len() * 32);
-    out.push_str(&header);
-    for b in &blocks {
-        let _ = write!(out, "\n\n─── lines {}-{} ───\n", b.start, b.end);
-        out.push_str(&b.text);
-    }
-    Ok(out)
+    Ok((blocks, total_bytes, total_lines))
 }
 
 /// Parse "45-89" into (45, 89). 1-indexed.
@@ -918,6 +977,107 @@ mod tests {
             .any(|l| l.starts_with("6:") && l.contains("|zeta"));
         assert!(line_one_match, "expected hashline for line 1: {out}");
         assert!(line_six_match, "expected hashline for line 6: {out}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn budgeted_passes_through_when_budget_ample() {
+        let path = write_temp(
+            "tilth_test_budgeted_passthrough.txt",
+            "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n",
+        );
+        let plain = read_ranges(&path, &["1-2", "5-6"], false).unwrap();
+        let budgeted = read_ranges_with_budget(&path, &["1-2", "5-6"], false, 100_000).unwrap();
+        assert_eq!(plain, budgeted);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn budgeted_omits_later_sections_when_exhausted() {
+        let big_line = "x".repeat(200);
+        let body: String = (0..30).map(|_| format!("{big_line}\n")).collect();
+        let path = write_temp("tilth_test_budgeted_omit.txt", &body);
+        let budget = 240u64;
+        let out =
+            read_ranges_with_budget(&path, &["1-3", "10-12", "20-22"], false, budget).unwrap();
+
+        assert!(out.contains("─── lines 1-3 ───"), "first marker: {out}");
+        assert!(
+            out.contains("─── lines 10-12 ───\n... section omitted (budget exhausted) ..."),
+            "second omitted: {out}"
+        );
+        assert!(
+            out.contains("─── lines 20-22 ───\n... section omitted (budget exhausted) ..."),
+            "third omitted: {out}"
+        );
+        assert!(
+            estimate_tokens(out.len() as u64) <= budget,
+            "output {} tokens > budget {budget}: {out}",
+            estimate_tokens(out.len() as u64)
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn budgeted_truncates_first_section_when_too_large() {
+        let body: String = (0..200)
+            .map(|i| format!("line-{i}-padding-padding-padding\n"))
+            .collect();
+        let path = write_temp("tilth_test_budgeted_first_too_large.txt", &body);
+        let budget = 100u64;
+        let out = read_ranges_with_budget(&path, &["1-150"], false, budget).unwrap();
+        assert!(
+            out.contains("... truncated"),
+            "expected truncation sentinel: {out}"
+        );
+        assert!(
+            estimate_tokens(out.len() as u64) <= budget,
+            "output {} tokens > budget {budget}: {out}",
+            estimate_tokens(out.len() as u64)
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn budgeted_preserves_user_order_until_exhaustion() {
+        let big_line = "y".repeat(200);
+        let body: String = (0..30).map(|_| format!("{big_line}\n")).collect();
+        let path = write_temp("tilth_test_budgeted_order.txt", &body);
+        let budget = 240u64;
+        let out =
+            read_ranges_with_budget(&path, &["20-22", "1-3", "10-12"], false, budget).unwrap();
+        let pos_first = out.find("─── lines 20-22 ───").expect("first marker");
+        let pos_second = out.find("─── lines 1-3 ───").expect("second marker");
+        let pos_third = out.find("─── lines 10-12 ───").expect("third marker");
+        assert!(
+            pos_first < pos_second && pos_second < pos_third,
+            "order: {out}"
+        );
+        assert!(
+            out.contains("─── lines 10-12 ───\n... section omitted (budget exhausted) ..."),
+            "third must be omitted: {out}"
+        );
+        assert!(
+            estimate_tokens(out.len() as u64) <= budget,
+            "output {} tokens > budget {budget}: {out}",
+            estimate_tokens(out.len() as u64)
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn budgeted_never_exceeds_budget_even_when_markers_do_not_fit() {
+        let big_line = "z".repeat(50);
+        let body: String = (0..30).map(|_| format!("{big_line}\n")).collect();
+        let path = write_temp("tilth_test_budgeted_strict_cap.txt", &body);
+        let budget = 80u64;
+        let out =
+            read_ranges_with_budget(&path, &["1-3", "10-12", "20-22"], false, budget).unwrap();
+        assert!(
+            estimate_tokens(out.len() as u64) <= budget,
+            "output {} tokens > budget {budget}: {out}",
+            estimate_tokens(out.len() as u64)
+        );
         let _ = std::fs::remove_file(&path);
     }
 }

--- a/src/search/strip.rs
+++ b/src/search/strip.rs
@@ -144,6 +144,11 @@ const KEEP_MARKERS: &[&str] = &["TODO", "FIXME", "NOTE", "HACK", "SAFETY", "WARN
 
 /// Returns `true` if the line is a plain comment that should be stripped.
 /// Preserves: doc comments, comments containing keep-markers.
+///
+/// Scope: line-comment stripping only. `/* */` block comments are NOT removed
+/// in any language — matching is per-line on the trimmed prefix, so a block
+/// comment's interior lines have no comment prefix and survive. Stripping them
+/// needs multi-line state tracking across lines, which this pass does not do.
 fn is_strippable_comment(trimmed: &str, lang: StripLang) -> bool {
     let is_comment = match lang {
         StripLang::Rust => {

--- a/src/types.rs
+++ b/src/types.rs
@@ -58,6 +58,7 @@ pub enum FileType {
 pub enum ViewMode {
     Full,
     Outline,
+    Signature,
     Keys,
     #[allow(dead_code)]
     HeadTail,
@@ -69,6 +70,7 @@ pub enum ViewMode {
     #[allow(dead_code)]
     Error,
     Section,
+    Stripped,
 }
 
 impl std::fmt::Display for ViewMode {
@@ -76,6 +78,7 @@ impl std::fmt::Display for ViewMode {
         match self {
             Self::Full => write!(f, "full"),
             Self::Outline => write!(f, "outline"),
+            Self::Signature => write!(f, "signature"),
             Self::Keys => write!(f, "keys"),
             Self::HeadTail => write!(f, "head+tail"),
             Self::Empty => write!(f, "empty"),
@@ -84,6 +87,7 @@ impl std::fmt::Display for ViewMode {
             Self::Binary => write!(f, "skipped"),
             Self::Error => write!(f, "error"),
             Self::Section => write!(f, "section"),
+            Self::Stripped => write!(f, "stripped"),
         }
     }
 }


### PR DESCRIPTION
Slice 4 of the fork fold-in (jahala/tilth#112), extracted as a standalone PR and ported onto the post-`mcp/`-split layout. Orthogonal to the open edit (#124) and grok (#125) work — touches only read/budget/types.

## What this adds

- **`tilth_read` `mode` parameter**: `auto` (default) | `full` | `signature` | `stripped`. The existing `full: true` flag becomes a legacy alias for `mode="full"`.
- **`signature` mode** — hash-prefixed declaration lines only, no bodies, for code files (non-code falls back to the normal read).
- **`stripped` mode** — whole-file content with plain comments, debug logs, and collapsible blank runs removed; plain right-aligned line numbers, no hash anchors (an explicitly non-editable view).
- **Budgeted multi-section reads** (`read_ranges_with_budget`) — when `budget` is set on a `sections` call, blocks are emitted in user order, a later over-budget section is replaced by an omission marker (while the marker fits), an over-budget first block is truncated, and the output never exceeds the budget.
- **`budget::apply` truncation bugfix** — reject a `\n\n` cut at byte 0 (code-format output's only `\n\n` is the header/body separator, so the old code truncated to an empty body) and clamp the no-boundary fallback to a UTF-8 char boundary instead of raw `max_bytes` (which could panic on emoji-dense single-line content).

## Porting notes

- Re-homed the original `src/mcp.rs` `tool_read` hunks into `src/mcp/tools/read.rs` (helpers + dispatch) and the schema change into `src/mcp/tools/definitions.rs`, since `mcp.rs` was split after this slice's base commit.
- The fork's unused `apply_with_info` / `TruncationInfo` scaffolding is intentionally omitted (YAGNI — nothing in this slice consumes the metadata); the truncation fix is folded directly into `apply`.
- No prompt changes, so `AGENTS.md` regen is a no-op and the byte-lock tests are unaffected.

## Verification

`cargo build --release`, `cargo clippy -- -D warnings`, `cargo fmt --check`, and `cargo test` all clean (416 tests pass, including 12 ported + 4 hardening tests covering the budget bugfix, budgeted multi-section invariants, mode dispatch, unknown-mode error, non-code fallbacks, and the `full`/`mode="full"` equivalence).

🤖 Generated with [Claude Code](https://claude.com/claude-code)