### PR TITLE
fix(bench): replace hardcoded user path with Path.home()

### DIFF
--- a/benchmark/config.py
+++ b/benchmark/config.py
@@ -21,7 +21,7 @@ RUNNERS = {
 
 # MCP config arguments for codex (tilth server)
 TILTH_MCP_CODEX_ARGS = [
-    "-c", 'mcp_servers.tilth.command="/Users/flysikring/.cargo/bin/tilth"',
+    "-c", f'mcp_servers.tilth.command="{Path.home()}/.cargo/bin/tilth"',
     "-c", 'mcp_servers.tilth.args=["--mcp", "--edit"]',
 ]
 

--- a/benchmark/run.py
+++ b/benchmark/run.py
@@ -40,7 +40,7 @@ def _tilth_version() -> Optional[str]:
     """Get installed tilth version via `tilth --version`."""
     try:
         result = subprocess.run(
-            ["/Users/flysikring/.cargo/bin/tilth", "--version"],
+            [str(Path.home() / ".cargo" / "bin" / "tilth"), "--version"],
             capture_output=True, text=True, timeout=5,
         )
         # Output: "tilth 0.2.1"


### PR DESCRIPTION
Two `/Users/flysikring/.cargo/bin/tilth` references have lived in the benchmark harness since v0.4.1 (`736e5ba`), in code paths the Claude benchmarks never exercise — so nothing ever failed loudly:

- **`config.py`** — `TILTH_MCP_CODEX_ARGS`, only appended on the codex runner (`gpt5`/`o3`)
- **`run.py`** — `_tilth_version()`, which catches `FileNotFoundError` and returns `None`

The version helper failing soft is the only one with a visible symptom: every result file recorded `tilth_version: null`. Confirmed against history — prior haiku runs show `null`, a fresh run after this fix records `0.8.4`.

The Claude MCP config (`fixtures/tilth_mcp.json`) already had the correct path, which is why every run still worked.

Both now resolve via `Path.home()` so the harness works for any user.

🤖 Generated with [Claude Code](https://claude.com/claude-code)