### PR TITLE
fix(install): line-anchor TOML section header matching on upsert

### DIFF
--- a/src/install.rs
+++ b/src/install.rs
@@ -150,27 +150,45 @@ fn write_toml_config(host_info: &HostInfo, edit: bool) -> Result<(), String> {
         String::new()
     };
 
-    // Remove existing [mcp_servers.tilth] section if present
-    let output = if let Some(start) = existing.find("[mcp_servers.tilth]") {
-        // Find end of section: next [header] or EOF
-        let rest = &existing[start..];
-        let end = rest[1..] // skip the opening '['
-            .find("\n[")
-            .map_or(existing.len(), |i| start + 1 + i + 1);
-        format!("{}{}{}", &existing[..start], section, &existing[end..])
-    } else {
-        // Append with a blank line separator
+    let output = upsert_toml_section(&existing, "[mcp_servers.tilth]", &section);
+
+    fs::write(&host_info.path, &output)
+        .map_err(|e| format!("failed to write {}: {e}", host_info.path.display()))?;
+    Ok(())
+}
+
+/// Finds a TOML table header anchored to a line start (or the file start),
+/// returning the byte offset of its opening `[`.
+///
+/// A bare substring search matches the header text inside a comment or string,
+/// then splices from that offset and corrupts a hand-edited config. Anchoring to
+/// `\n<header>` (or start-of-file) only matches a real table header.
+fn find_section_start(text: &str, header: &str) -> Option<usize> {
+    if text.starts_with(header) {
+        return Some(0);
+    }
+    let needle = format!("\n{header}");
+    text.find(&needle).map(|newline_at| newline_at + 1)
+}
+
+/// Replaces an existing `header` table with `section`, or appends `section`
+/// (blank-line separated) when the table is absent. The match is line-anchored
+/// via [`find_section_start`], and the section end is the next table header.
+fn upsert_toml_section(existing: &str, header: &str, section: &str) -> String {
+    let Some(start) = find_section_start(existing, header) else {
         let sep = if existing.is_empty() || existing.ends_with('\n') {
             ""
         } else {
             "\n"
         };
-        format!("{existing}{sep}\n{section}")
+        return format!("{existing}{sep}\n{section}");
     };
 
-    fs::write(&host_info.path, &output)
-        .map_err(|e| format!("failed to write {}: {e}", host_info.path.display()))?;
-    Ok(())
+    let rest = &existing[start..];
+    let end = rest[1..] // skip the opening '['
+        .find("\n[")
+        .map_or(existing.len(), |i| start + 1 + i + 1);
+    format!("{}{}{}", &existing[..start], section, &existing[end..])
 }
 
 /// Returns (command, args) for the tilth MCP server entry.
@@ -503,6 +521,75 @@ fn claude_desktop_path() -> Result<PathBuf, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    const TILTH_HEADER: &str = "[mcp_servers.tilth]";
+
+    #[test]
+    fn toml_section_appended_when_absent() {
+        let out = upsert_toml_section(
+            "[other]\nk = 1\n",
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"x\"\n",
+        );
+        assert!(out.contains("[other]"));
+        assert!(out.contains("[mcp_servers.tilth]\ncommand = \"x\""));
+    }
+
+    #[test]
+    fn toml_header_in_comment_is_not_spliced() {
+        let existing = "# legacy note about [mcp_servers.tilth] kept for humans\n[other]\nk = 1\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"x\"\n",
+        );
+        assert!(
+            out.contains("# legacy note about [mcp_servers.tilth] kept for humans"),
+            "comment corrupted by a substring splice: {out:?}"
+        );
+        assert!(out.contains("[other]"));
+        assert!(out.contains("command = \"x\""));
+    }
+
+    #[test]
+    fn toml_section_replaced_at_line_start() {
+        let existing = "[mcp_servers.tilth]\ncommand = \"old\"\nargs = []\n[other]\nk = 1\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"new\"\n",
+        );
+        assert!(out.contains("command = \"new\""));
+        assert!(!out.contains("\"old\""), "old section not removed: {out:?}");
+        assert!(out.contains("[other]"));
+    }
+
+    #[test]
+    fn toml_section_replaced_at_start_of_file() {
+        let existing = "[mcp_servers.tilth]\ncommand = \"old\"\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"new\"\n",
+        );
+        assert!(out.contains("\"new\""));
+        assert!(!out.contains("\"old\""));
+    }
+
+    #[test]
+    fn toml_section_replacement_handles_multiline_arrays_before_next_table() {
+        let existing = "[mcp_servers.tilth]\ncommand = \"old\"\nargs = [\n  \"old-a\",\n  \"old-b\",\n]\n[other]\nk = 1\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"new\"\nargs = [\"new\"]\n",
+        );
+
+        assert_eq!(
+            out,
+            "[mcp_servers.tilth]\ncommand = \"new\"\nargs = [\"new\"]\n[other]\nk = 1\n"
+        );
+    }
 
     #[test]
     fn amp_resolve_host() {


### PR DESCRIPTION
## What

`tilth install <host>` upserts an MCP-server section into each host's TOML config. The header match was substring-based, so a header string appearing inside a comment or another value could be mistaken for a real section boundary — corrupting config on re-run.

This anchors the header match to the start of a line.

## Why

Re-running `tilth install` against an existing config should be idempotent and never splice into the wrong place. The added tests cover:

- header appearing inside a comment is not spliced
- section appended when absent
- section replaced at line start / start of file
- replacement handling multiline arrays before the next table

## Notes

Carved out of the fork (`paulnsorensen/tilth`) as a tight, net-new, zero-conflict correctness fix. Touches only `src/install.rs`. Builds clean on `origin/main`; all 35 install tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)