### PR TITLE
ci: dual-publish npm wrapper as @plotplot/tilth

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,12 +139,12 @@ jobs:
       - run: npm publish ./npm
       # Anchor the @plotplot org: dual-publish the SAME artifact as `@plotplot/tilth`.
       # Requires a trusted publisher for @plotplot/tilth configured on npmjs.com (one-time).
-      # Recovery: if this scoped publish fails AFTER the unscoped publish (above) has
-      # succeeded, re-running the job re-fails at `npm publish ./npm` (npm 403 — version
-      # already published) and never reaches this step. Recover by publishing the scope
-      # once manually — `cd npm && npm pkg set name=@plotplot/tilth && npm publish --access public`
-      # — or by cutting a new patch version.
+      # Best-effort: the unscoped `tilth` publish above is the canonical release, so a
+      # failure here (e.g. the @plotplot trusted publisher isn't configured yet) must not
+      # fail the release. continue-on-error keeps the job green; if it fails, publish the
+      # scope manually when ready — `cd npm && npm pkg set name=@plotplot/tilth && npm publish --access public`.
       - name: Dual-publish under the @plotplot scope
+        continue-on-error: true
         working-directory: ./npm
         run: |
           npm pkg set name=@plotplot/tilth

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,6 +139,11 @@ jobs:
       - run: npm publish ./npm
       # Anchor the @plotplot org: dual-publish the SAME artifact as `@plotplot/tilth`.
       # Requires a trusted publisher for @plotplot/tilth configured on npmjs.com (one-time).
+      # Recovery: if this scoped publish fails AFTER the unscoped publish (above) has
+      # succeeded, re-running the job re-fails at `npm publish ./npm` (npm 403 — version
+      # already published) and never reaches this step. Recover by publishing the scope
+      # once manually — `cd npm && npm pkg set name=@plotplot/tilth && npm publish --access public`
+      # — or by cutting a new patch version.
       - name: Dual-publish under the @plotplot scope
         working-directory: ./npm
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -135,4 +135,12 @@ jobs:
           registry-url: https://registry.npmjs.org
       # Trusted publishing needs npm >= 11.5.1 (node 20 ships npm 10.x).
       - run: npm install -g npm@latest
+      # Primary package: unscoped `tilth`
       - run: npm publish ./npm
+      # Anchor the @plotplot org: dual-publish the SAME artifact as `@plotplot/tilth`.
+      # Requires a trusted publisher for @plotplot/tilth configured on npmjs.com (one-time).
+      - name: Dual-publish under the @plotplot scope
+        working-directory: ./npm
+        run: |
+          npm pkg set name=@plotplot/tilth
+          npm publish --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,8 @@ CI runs `fmt --check`, `clippy -D warnings`, `cargo test` on every push/PR.
 
 Update version in **both** `Cargo.toml` and `npm/package.json`. Tag with `v<version>` on main.
 
+Releases publish **two npm names** from the same `npm/` wrapper: the canonical unscoped `tilth` and the org anchor `@plotplot/tilth` (the `publish-npm` job renames the artifact and republishes with `--access public`). Both names have an OIDC trusted publisher on npmjs.com (`jahala/tilth` + `release.yml`), so releases need no token. `@plotplot/tilth` was bootstrapped with a one-time manual publish — npm cannot configure trusted publishing for a package that does not exist yet.
+
 ## Benchmarks
 
 26 code navigation tasks across 4 repos (Express/JS, FastAPI/Python, Gin/Go, ripgrep/Rust). Each task runs headless `claude -p` with a question, checks answer against ground-truth strings.


### PR DESCRIPTION
## What
Dual-publish the npm wrapper under the new `@plotplot` org scope alongside the canonical `tilth` package, so every release anchors the org with real code.

## Why
Owning the `plotplot` org already blocks external squatting; dual-publishing **reserves the canonical `@plotplot/tilth` name**, anchors the org with live code, and keeps a migration path open.

## How
- `publish-npm` job: after publishing `tilth`, rename the same `./npm` artifact to `@plotplot/tilth` and `npm publish --access public`.
- Both names use **OIDC trusted publishing** (no token). `@plotplot/tilth` has its own trusted publisher (`jahala/tilth` + `release.yml`) on npmjs.com.
- `@plotplot/tilth@0.9.0` was **bootstrapped** with a one-time manual publish — npm can't configure trusted publishing for a package that doesn't exist yet.

## Safety
- `version-check` unaffected — committed `package.json` stays `name: tilth`; the scope rename is ephemeral in CI.
- Unscoped `tilth` publishes **first**, so a scoped-step failure can't block the primary release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)