### PR TITLE
feat(read): never-worse outline gate

### DIFF
--- a/src/mcp/tools/read.rs
+++ b/src/mcp/tools/read.rs
@@ -416,12 +416,22 @@ mod tests {
     fn tool_read_full_flag_is_legacy_alias_for_mode_full() {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("aliased.rs");
-        // Body must exceed TOKEN_THRESHOLD (6k tokens ≈ 24KB) so `auto` outlines
-        // rather than dumping full — making the alias equivalence observable, not
-        // a trivial small-file match where auto and full coincide.
+        // Body must exceed TOKEN_THRESHOLD (6k tokens ≈ 24KB) AND compress well
+        // so `auto` returns an outline rather than full content — making the
+        // alias equivalence observable, not a trivial small-file match where
+        // auto and full coincide. Functions have large bodies so the outline
+        // (signatures only) is a small fraction of the full-file token cost,
+        // ensuring OGATE does not fire and auto != full.
         let mut src = String::from("// header comment\n");
-        for i in 0..1500 {
-            src.push_str(&format!("fn f_{i}() {{\n    let v_{i} = {i};\n}}\n"));
+        for i in 0..80 {
+            src.push_str(&format!("fn f_{i}() {{\n"));
+            // Large body: many statements so the outline compresses well
+            for j in 0..30 {
+                src.push_str(&format!(
+                    "    let local_var_{j}_in_fn_{i}: u64 = {j} + {i};\n"
+                ));
+            }
+            src.push_str("}\n");
         }
         std::fs::write(&path, &src).unwrap();
         let cache = OutlineCache::new();

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -1105,33 +1105,41 @@ mod tests {
     #[test]
     fn ogate_flat_file_returns_full_when_outline_barely_compresses() {
         use std::fmt::Write as _;
-        // Build a Rust file with many short one-liner declarations.
-        // Each line is a complete `pub const`/`pub fn` so tree-sitter
-        // will generate an outline entry — but the body is empty, so
-        // the outline is nearly as long as the full file. We add a
-        // distinctive body string that only appears in the raw file,
-        // not in any outline entry, so we can prove we got the full file.
+        // A file of empty-body one-liner fns. The signature IS essentially the
+        // whole source line (only ` {}` is dropped), so any signature-bearing
+        // outline is ≥80% of the full-file tokens and OGATE must fire. This holds
+        // regardless of the outline's per-entry formatting overhead, so the test
+        // does not silently break if that format is ever tightened. Enough lines
+        // to clear TOKEN_THRESHOLD (6k) — otherwise the small-file gate returns
+        // full before OGATE is even consulted, passing for the wrong reason.
         let mut src = String::new();
-        for i in 0..800 {
-            // fn with a distinct body comment that outline will strip
-            writeln!(src, "pub fn flat_{i}() {{ /* BODY_MARKER_{i} */ }}").unwrap();
+        for i in 0..2000 {
+            writeln!(src, "pub fn flat_{i}() {{}}").unwrap();
         }
-        // Total bytes ≈ 800 * ~40 = ~32 000 bytes → ~8 000 tokens (> TOKEN_THRESHOLD)
+        // ~2000 * ~21 bytes ≈ 43 KB ≈ 10.7k tokens (> TOKEN_THRESHOLD = 6k).
+        // Assert it so the test provably exercises OGATE rather than the
+        // small-file gate (which would also return `[full]`).
+        assert!(
+            estimate_tokens(src.len() as u64) > TOKEN_THRESHOLD,
+            "fixture must exceed TOKEN_THRESHOLD so OGATE, not the small-file gate, returns full"
+        );
         let path = write_temp("tilth_ogate_flat.rs", &src);
 
         let cache = OutlineCache::new();
         let result = read_file(&path, None, false, &cache, false).unwrap();
 
-        // Gate must have fired: the output contains actual body content
-        // that an outline would never include.
+        // Gate fired → full view. The header tag records the decision directly
+        // (an outline would read `[outline]`), and the trailing fn's body braces
+        // `() {}` only appear in verbatim full content — an outline renders the
+        // signature without the body.
         assert!(
-            result.contains("BODY_MARKER_0"),
-            "expected full content (BODY_MARKER_0 present), got outline: {}",
-            &result[..result.len().min(400)]
+            result.contains("[full]"),
+            "OGATE must return the full view; header was: {}",
+            result.lines().next().unwrap_or("")
         );
         assert!(
-            result.contains("BODY_MARKER_799"),
-            "expected full content (BODY_MARKER_799 present)"
+            result.contains("flat_1999() {}"),
+            "expected verbatim full content (last fn body present)"
         );
 
         let _ = std::fs::remove_file(&path);

--- a/src/read/mod.rs
+++ b/src/read/mod.rs
@@ -15,6 +15,11 @@ use crate::lang::outline::{heading_level, heading_text, parse_markdown};
 use crate::types::{estimate_tokens, FileType, ViewMode};
 
 pub(crate) const TOKEN_THRESHOLD: u64 = 6_000;
+/// Minimum compression ratio required to prefer the outline over full content.
+/// If `outline_tokens >= full_tokens * OUTLINE_MIN_COMPRESSION / 100`, the
+/// outline saves too few tokens to be worth the information loss, so the full
+/// file is returned instead. Integer arithmetic: 80 means 80%.
+const OUTLINE_MIN_COMPRESSION: u64 = 80;
 const FILE_SIZE_CAP: u64 = 500_000; // 500KB
 
 /// Max file size for `full=true` reads. Files above this threshold get a
@@ -145,14 +150,20 @@ pub fn read_file(
         ));
     }
 
-    // Full mode or small file → return full content (skip smart view)
-    if full || tokens <= TOKEN_THRESHOLD {
+    // Canonical full-content view — shared by the small-file gate and OGATE below.
+    let full_view = || {
         let header = format::file_header(path, byte_len, line_count, ViewMode::Full);
         if edit_mode {
             let numbered = format::hashlines(&content, 1);
-            return Ok(format!("{header}\n\n{numbered}"));
+            format!("{header}\n\n{numbered}")
+        } else {
+            format!("{header}\n\n{content}")
         }
-        return Ok(format!("{header}\n\n{content}"));
+    };
+
+    // Full mode or small file → return full content (skip smart view)
+    if full || tokens <= TOKEN_THRESHOLD {
+        return Ok(full_view());
     }
 
     // Large file → smart view by file type
@@ -164,6 +175,14 @@ pub fn read_file(
     let outline = cache.get_or_compute(path, mtime, || {
         outline::generate(path, file_type, &content, buf, capped)
     });
+
+    // OGATE: if the outline is not meaningfully smaller than the full file,
+    // return the full file — same token cost with less information is strictly
+    // worse and forces the caller to do a second read.
+    let outline_tokens = estimate_tokens(outline.len() as u64);
+    if outline_tokens >= tokens * OUTLINE_MIN_COMPRESSION / 100 {
+        return Ok(full_view());
+    }
 
     let mode = match file_type {
         FileType::StructuredData => ViewMode::Keys,
@@ -1078,6 +1097,86 @@ mod tests {
             "output {} tokens > budget {budget}: {out}",
             estimate_tokens(out.len() as u64)
         );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    // OGATE: "never-worse outline gate" — if the outline barely compresses
+    // (outline_tokens >= 80% of full-file tokens), return full content instead.
+    #[test]
+    fn ogate_flat_file_returns_full_when_outline_barely_compresses() {
+        use std::fmt::Write as _;
+        // Build a Rust file with many short one-liner declarations.
+        // Each line is a complete `pub const`/`pub fn` so tree-sitter
+        // will generate an outline entry — but the body is empty, so
+        // the outline is nearly as long as the full file. We add a
+        // distinctive body string that only appears in the raw file,
+        // not in any outline entry, so we can prove we got the full file.
+        let mut src = String::new();
+        for i in 0..800 {
+            // fn with a distinct body comment that outline will strip
+            writeln!(src, "pub fn flat_{i}() {{ /* BODY_MARKER_{i} */ }}").unwrap();
+        }
+        // Total bytes ≈ 800 * ~40 = ~32 000 bytes → ~8 000 tokens (> TOKEN_THRESHOLD)
+        let path = write_temp("tilth_ogate_flat.rs", &src);
+
+        let cache = OutlineCache::new();
+        let result = read_file(&path, None, false, &cache, false).unwrap();
+
+        // Gate must have fired: the output contains actual body content
+        // that an outline would never include.
+        assert!(
+            result.contains("BODY_MARKER_0"),
+            "expected full content (BODY_MARKER_0 present), got outline: {}",
+            &result[..result.len().min(400)]
+        );
+        assert!(
+            result.contains("BODY_MARKER_799"),
+            "expected full content (BODY_MARKER_799 present)"
+        );
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    /// Contrasting test: a large file with big function bodies compresses well
+    /// and must still return the OUTLINE (gate must NOT fire).
+    #[test]
+    fn ogate_large_compressible_file_returns_outline() {
+        use std::fmt::Write as _;
+        // Each function has a large body (many comment lines) so the outline
+        // (which only shows the `fn` signature) is a tiny fraction of the
+        // full-file token count.
+        let mut src = String::new();
+        for i in 0..40 {
+            writeln!(src, "pub fn heavy_{i}() {{").unwrap();
+            // 200 lines of body per function → ~200 * 30 = 6 000 bytes each
+            for j in 0..200 {
+                writeln!(
+                    src,
+                    "    let _x_{j}: u64 = {j}_{i}_padding_value_that_fills_space;"
+                )
+                .unwrap();
+            }
+            writeln!(src, "}}").unwrap();
+        }
+        // Total ≈ 40 * 202 lines * ~50 bytes = ~400 KB → well over TOKEN_THRESHOLD
+        let path = write_temp("tilth_ogate_heavy.rs", &src);
+
+        let cache = OutlineCache::new();
+        let result = read_file(&path, None, false, &cache, false).unwrap();
+
+        // Gate must NOT have fired: the output should be an outline, not full content.
+        // An outline shows signatures but omits the body.
+        assert!(
+            result.contains("heavy_0"),
+            "expected outline to mention function name heavy_0: {}",
+            &result[..result.len().min(400)]
+        );
+        // Body variable lines are only in the full file, not in an outline
+        assert!(
+            !result.contains("_x_0: u64"),
+            "outline must not contain body variables; got full content instead"
+        );
+
         let _ = std::fs::remove_file(&path);
     }
 }


### PR DESCRIPTION
## What
A "never-worse outline gate" in `read_file`: if the generated outline's token cost is ≥80% of the full file's, return full content instead of the outline.

## Why
For poorly-compressing files (flat config/data, dense small modules), tilth could return an outline costing nearly the same tokens as the full file while stripping the actual content — strictly worse, and it forces a second full read. The read path computed the outline but never compared its size.

## How
- After the outline is built, measure it with the same `estimate_tokens` helper; gate on `OUTLINE_MIN_COMPRESSION` (80%).
- OGATE's full-return is byte-identical to the canonical full-return — extracted both into a shared `full_view` closure (single source of truth).
- Untouched: small files (already short-circuit), no-outline files, `section`/`full` reads.

## Tests
- `ogate_flat_file_returns_full_when_outline_barely_compresses` — low-compressibility file returns full content (asserts body markers an outline omits; fails-before / passes-after).
- `ogate_large_compressible_file_returns_outline` — contrast: well-compressing file still returns the outline (gate is selective, not "always full").
- Adjusted one pre-existing alias test whose fixture happened to be low-compressibility; its real invariant (`full:true == mode:full`, `auto != full`) is preserved.

471 tests pass · `clippy -D warnings` clean · `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)