### PR TITLE
feat(search): query-aware truncation

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -505,6 +505,19 @@ fn format_line_list(lines: &[u32]) -> String {
     parts.join(",")
 }
 
+/// The symbol to feed query-aware truncation when expanding a match's body.
+///
+/// For `impl`/`implements` matches the user searched for the trait or interface,
+/// which is held in `impl_target` — `def_name` is the rendered label
+/// (`"impl Trait for Type"` / `"Type implements Trait"`) and never appears
+/// verbatim in the body, so boosting on it is a no-op. For plain definitions
+/// `impl_target` is `None` and the searched token is the symbol name in
+/// `def_name`. Preferring `impl_target` routes the real query into the boost for
+/// both shapes.
+fn boost_query(m: &Match) -> Option<&str> {
+    m.impl_target.as_deref().or(m.def_name.as_deref())
+}
+
 /// Format a single match entry (unchanged from original behavior).
 fn format_single_match(
     m: &Match,
@@ -646,7 +659,7 @@ fn format_single_match(
                                 &content,
                                 def_start,
                                 def_end,
-                                m.def_name.as_deref(),
+                                boost_query(m),
                             ) {
                                 let keep_set: HashSet<u32> = keep.into_iter().collect();
                                 for ln in def_start..=def_end {
@@ -1927,6 +1940,46 @@ mod tests {
             out.contains("[usage in function Foo.bar]"),
             "expected scope suffix in output, got: {out}"
         );
+    }
+
+    #[test]
+    fn boost_query_routes_impl_target_into_truncation() {
+        use crate::types::Match;
+
+        let base = Match {
+            path: PathBuf::from("x.rs"),
+            line: 1,
+            text: String::new(),
+            is_definition: true,
+            exact: true,
+            file_lines: 200,
+            mtime: SystemTime::now(),
+            def_range: Some((1, 200)),
+            def_name: None,
+            def_weight: 0,
+            impl_target: None,
+        };
+
+        // Plain definition: the searched token is the symbol name in def_name.
+        let plain = Match {
+            def_name: Some("handle_request".to_string()),
+            ..base.clone()
+        };
+        assert_eq!(boost_query(&plain), Some("handle_request"));
+
+        // impl match: def_name is the rendered label ("impl Iterator for Counter")
+        // which never appears in the body — the searched trait lives in
+        // impl_target. Regression guard for the dead-boost bug where def_name was
+        // passed and the boost matched nothing.
+        let impl_match = Match {
+            def_name: Some("impl Iterator for Counter".to_string()),
+            impl_target: Some("Iterator".to_string()),
+            ..base.clone()
+        };
+        assert_eq!(boost_query(&impl_match), Some("Iterator"));
+
+        // No names: no boost.
+        assert_eq!(boost_query(&base), None);
     }
 
     #[test]

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -641,10 +641,13 @@ fn format_single_match(
                     let mut skip_lines = strip::strip_noise(&content, &m.path, m.def_range);
 
                     if let Some((def_start, def_end)) = m.def_range {
-                        if let crate::types::FileType::Code(lang) = file_type {
-                            if let Some(keep) =
-                                truncate::select_diverse_lines(&content, def_start, def_end, lang)
-                            {
+                        if let crate::types::FileType::Code(_) = file_type {
+                            if let Some(keep) = truncate::select_diverse_lines(
+                                &content,
+                                def_start,
+                                def_end,
+                                m.def_name.as_deref(),
+                            ) {
                                 let keep_set: HashSet<u32> = keep.into_iter().collect();
                                 for ln in def_start..=def_end {
                                     if !keep_set.contains(&ln) {

--- a/src/search/truncate.rs
+++ b/src/search/truncate.rs
@@ -4,7 +4,11 @@
 //!
 //! All detection is line-by-line text matching; no tree-sitter needed.
 
-use crate::types::Lang;
+/// Score boost applied to lines that contain the searched symbol.
+const QUERY_MATCH_BOOST: u32 = 50;
+
+/// Score boost applied to lines immediately adjacent (±1) to a matching line.
+const QUERY_PROXIMITY_BOOST: u32 = 5;
 
 /// Minimum function size (in lines) before smart truncation kicks in.
 const SMART_TRUNCATE_MIN_LINES: u32 = 80;
@@ -17,11 +21,16 @@ const SMART_TRUNCATE_MAX_LINES: usize = 40;
 /// Returns `None` if the range is smaller than [`SMART_TRUNCATE_MIN_LINES`]
 /// (no truncation needed). Otherwise returns `Some(vec)` of 1-based line
 /// numbers to KEEP, sorted ascending.
+///
+/// When `query` is `Some(symbol)`, lines containing the symbol (case-sensitive
+/// substring) receive a [`QUERY_MATCH_BOOST`] on top of their structural score,
+/// and their immediate neighbours (±1) receive a [`QUERY_PROXIMITY_BOOST`].
+/// When `query` is `None`, behaviour is byte-identical to the previous version.
 pub(crate) fn select_diverse_lines(
     content: &str,
     start: u32,
     end: u32,
-    _lang: Lang,
+    query: Option<&str>,
 ) -> Option<Vec<u32>> {
     if end.saturating_sub(start) < SMART_TRUNCATE_MIN_LINES {
         return None;
@@ -30,6 +39,7 @@ pub(crate) fn select_diverse_lines(
     let lines: Vec<&str> = content.lines().collect();
     let mut scored: Vec<(u32, u32)> = Vec::new(); // (line_number, score)
 
+    // Pass 1: structural scoring
     for line_num in start..=end {
         let idx = (line_num - 1) as usize;
         let line = match lines.get(idx) {
@@ -39,6 +49,37 @@ pub(crate) fn select_diverse_lines(
         let trimmed = line.trim();
         let score = score_line(trimmed, line_num, start, end);
         scored.push((line_num, score));
+    }
+
+    // Pass 2: query-aware boost — if a query symbol is provided, boost lines
+    // that contain it (case-sensitive substring) and their immediate neighbours.
+    if let Some(q) = query {
+        if !q.is_empty() {
+            // Collect indices (within `scored`) of lines that match the query.
+            let match_indices: Vec<usize> = scored
+                .iter()
+                .enumerate()
+                .filter_map(|(i, &(line_num, _))| {
+                    let idx = (line_num - 1) as usize;
+                    if lines.get(idx).is_some_and(|l| l.contains(q)) {
+                        Some(i)
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+
+            // Apply match boost to direct matches and proximity boost to neighbours.
+            for mi in match_indices {
+                scored[mi].1 = scored[mi].1.saturating_add(QUERY_MATCH_BOOST);
+                if mi > 0 {
+                    scored[mi - 1].1 = scored[mi - 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
+                }
+                if mi + 1 < scored.len() {
+                    scored[mi + 1].1 = scored[mi + 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
+                }
+            }
+        }
     }
 
     // Sort by (score DESC, line ASC) to pick highest-value lines first
@@ -156,13 +197,15 @@ fn is_var_decl(trimmed: &str) -> bool {
 mod tests {
     use super::*;
 
+    // ── Existing tests — all pass `None` for the new `query` parameter ──────
+
     #[test]
     fn short_function_returns_none() {
         let content = (1..=50)
             .map(|i| format!("line {i}"))
             .collect::<Vec<_>>()
             .join("\n");
-        let result = select_diverse_lines(&content, 1, 50, Lang::Rust);
+        let result = select_diverse_lines(&content, 1, 50, None);
         assert!(
             result.is_none(),
             "functions <80 lines should not be truncated"
@@ -179,7 +222,7 @@ mod tests {
         lines.push("}".to_owned());
         let content = lines.join("\n");
 
-        let result = select_diverse_lines(&content, 1, 100, Lang::Rust);
+        let result = select_diverse_lines(&content, 1, 100, None);
         assert!(result.is_some(), "functions >=80 lines should be truncated");
 
         let kept = result.unwrap();
@@ -207,7 +250,7 @@ mod tests {
         lines.push("}".to_owned()); // line 91
 
         let content = lines.join("\n");
-        let result = select_diverse_lines(&content, 1, 91, Lang::Rust).unwrap();
+        let result = select_diverse_lines(&content, 1, 91, None).unwrap();
 
         assert!(result.contains(&11), "if-line should be kept");
         assert!(result.contains(&21), "match-line should be kept");
@@ -228,7 +271,7 @@ mod tests {
         lines.push("}".to_owned());
 
         let content = lines.join("\n");
-        let result = select_diverse_lines(&content, 1, 91, Lang::Rust).unwrap();
+        let result = select_diverse_lines(&content, 1, 91, None).unwrap();
 
         assert!(result.contains(&16), "?; line should be kept");
         assert!(result.contains(&26), ".unwrap() line should be kept");
@@ -252,7 +295,7 @@ mod tests {
         lines.push("}".to_owned());
         let content = lines.join("\n");
 
-        let result = select_diverse_lines(&content, 1, 100, Lang::Rust).unwrap();
+        let result = select_diverse_lines(&content, 1, 100, None).unwrap();
 
         // Function call lines (score 10) should dominate over blanks/comments (score 0)
         let has_fn_calls = result.iter().any(|&ln| {
@@ -270,7 +313,7 @@ mod tests {
         let lines: Vec<String> = (1..=81).map(|i| format!("line {i}")).collect();
         let content = lines.join("\n");
         // end - start = 81 - 1 = 80 => equals threshold => triggers
-        let result = select_diverse_lines(&content, 1, 81, Lang::Rust);
+        let result = select_diverse_lines(&content, 1, 81, None);
         assert!(
             result.is_some(),
             "exactly 80-line gap should trigger truncation"
@@ -282,10 +325,114 @@ mod tests {
         let lines: Vec<String> = (1..=80).map(|i| format!("line {i}")).collect();
         let content = lines.join("\n");
         // end - start = 80 - 1 = 79 => below threshold
-        let result = select_diverse_lines(&content, 1, 80, Lang::Rust);
+        let result = select_diverse_lines(&content, 1, 80, None);
         assert!(
             result.is_none(),
             "79-line gap should not trigger truncation"
+        );
+    }
+
+    // ── QTRUNC tests — query-aware boost ────────────────────────────────────
+
+    /// Core differential test: a plain assignment line carrying a unique token
+    /// (`needle_marker`) would normally be dropped (score 1, outcompeted by
+    /// higher-score lines). With `query = Some("needle_marker")` it must survive;
+    /// with `query = None` it must not.
+    #[test]
+    fn query_boost_rescues_needle_line() {
+        // Build a body of 100 lines (triggers truncation).
+        // Lines 2..=99 are plain assignments; line 100 is closing `}`.
+        // We plant `needle_marker` on line 50 (a low-score assignment line).
+        // The other 97 interior lines are plain assignments too (also score 1),
+        // so with 40 slots and 2 locked (start/end), only 38 interior lines
+        // can be kept — the needle is not guaranteed to be among them without
+        // the boost.
+        let mut lines: Vec<String> = Vec::new();
+        lines.push("fn example() {".to_owned()); // line 1
+        for i in 2usize..=99 {
+            if i == 50 {
+                lines.push("    let needle_marker = 50;".to_owned()); // line 50
+            } else {
+                lines.push(format!("    let x{i} = {i};"));
+            }
+        }
+        lines.push("}".to_owned()); // line 100
+        let content = lines.join("\n");
+
+        // With query=None the needle competes equally with 97 other score-1 lines.
+        // With only 38 interior slots available and 97 candidates, most are dropped.
+        // Verify None drops it (stable sort puts it anywhere — we assert it CAN be
+        // absent) by checking with the boosted version first, which MUST include it.
+        let with_query = select_diverse_lines(&content, 1, 100, Some("needle_marker")).unwrap();
+        assert!(
+            with_query.contains(&50),
+            "query=Some: needle_marker line must be kept"
+        );
+
+        // Without query: all interior lines have identical structural score (1),
+        // so the sort is stable by line number and the first 38 (lines 2..=39)
+        // are kept. Line 50 falls outside that window.
+        let without_query = select_diverse_lines(&content, 1, 100, None).unwrap();
+        assert!(
+            !without_query.contains(&50),
+            "query=None: needle_marker line must NOT be kept (score too low)"
+        );
+    }
+
+    /// Proximity test: the line immediately after the needle also survives with
+    /// the query boost (QUERY_PROXIMITY_BOOST lifts it above competitors).
+    #[test]
+    fn query_boost_preserves_neighbour() {
+        // Same setup as above but we also check line 51 (needle + 1).
+        // With query=None, line 51 is just another score-1 line that falls
+        // outside the first-38-lines window alongside line 50.
+        let mut lines: Vec<String> = Vec::new();
+        lines.push("fn example() {".to_owned()); // line 1
+        for i in 2usize..=99 {
+            if i == 50 {
+                lines.push("    let needle_marker = 50;".to_owned()); // line 50
+            } else {
+                lines.push(format!("    let x{i} = {i};"));
+            }
+        }
+        lines.push("}".to_owned()); // line 100
+        let content = lines.join("\n");
+
+        let with_query = select_diverse_lines(&content, 1, 100, Some("needle_marker")).unwrap();
+        // Line 51 gets QUERY_PROXIMITY_BOOST (5) on top of its structural score (1)
+        // => total 6, vs bare score 1 for lines 40+. It must survive.
+        assert!(
+            with_query.contains(&51),
+            "query=Some: neighbour of needle (line 51) must be kept"
+        );
+
+        let without_query = select_diverse_lines(&content, 1, 100, None).unwrap();
+        assert!(
+            !without_query.contains(&51),
+            "query=None: line 51 must NOT be kept without boost"
+        );
+    }
+
+    /// Sanity: passing `query = Some("")` (empty string) behaves identically to `None`.
+    #[test]
+    fn empty_query_behaves_like_none() {
+        let mut lines: Vec<String> = Vec::new();
+        lines.push("fn example() {".to_owned());
+        for i in 2usize..=99 {
+            if i == 50 {
+                lines.push("    let needle_marker = 50;".to_owned());
+            } else {
+                lines.push(format!("    let x{i} = {i};"));
+            }
+        }
+        lines.push("}".to_owned());
+        let content = lines.join("\n");
+
+        let empty_q = select_diverse_lines(&content, 1, 100, Some("")).unwrap();
+        let none_q = select_diverse_lines(&content, 1, 100, None).unwrap();
+        assert_eq!(
+            empty_q, none_q,
+            "empty query must produce identical output to None"
         );
     }
 }

--- a/src/search/truncate.rs
+++ b/src/search/truncate.rs
@@ -37,9 +37,14 @@ pub(crate) fn select_diverse_lines(
     }
 
     let lines: Vec<&str> = content.lines().collect();
-    let mut scored: Vec<(u32, u32)> = Vec::new(); // (line_number, score)
+    // Treat an empty query as no query, so the boost pass below is skipped and
+    // behaviour stays byte-identical to the `None` path.
+    let query = query.filter(|q| !q.is_empty());
+    let mut scored: Vec<(u32, u32, bool)> = Vec::new(); // (line_number, score, matches_query)
 
-    // Pass 1: structural scoring
+    // Pass 1: structural scoring + query-match detection in a single walk. Each
+    // line is read once here; the match flag is recorded so Pass 2 never has to
+    // re-read `lines`.
     for line_num in start..=end {
         let idx = (line_num - 1) as usize;
         let line = match lines.get(idx) {
@@ -48,35 +53,22 @@ pub(crate) fn select_diverse_lines(
         };
         let trimmed = line.trim();
         let score = score_line(trimmed, line_num, start, end);
-        scored.push((line_num, score));
+        let matches_query = query.is_some_and(|q| line.contains(q));
+        scored.push((line_num, score, matches_query));
     }
 
-    // Pass 2: query-aware boost — if a query symbol is provided, boost lines
-    // that contain it (case-sensitive substring) and their immediate neighbours.
-    if let Some(q) = query {
-        if !q.is_empty() {
-            // Collect indices (within `scored`) of lines that match the query.
-            let match_indices: Vec<usize> = scored
-                .iter()
-                .enumerate()
-                .filter_map(|(i, &(line_num, _))| {
-                    let idx = (line_num - 1) as usize;
-                    if lines.get(idx).is_some_and(|l| l.contains(q)) {
-                        Some(i)
-                    } else {
-                        None
-                    }
-                })
-                .collect();
-
-            // Apply match boost to direct matches and proximity boost to neighbours.
-            for mi in match_indices {
-                scored[mi].1 = scored[mi].1.saturating_add(QUERY_MATCH_BOOST);
-                if mi > 0 {
-                    scored[mi - 1].1 = scored[mi - 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
+    // Pass 2: query-aware boost — lift lines that contain the searched symbol
+    // and their immediate neighbours (±1). Skipped entirely when there is no
+    // query, keeping the `None` path byte-identical.
+    if query.is_some() {
+        for i in 0..scored.len() {
+            if scored[i].2 {
+                scored[i].1 = scored[i].1.saturating_add(QUERY_MATCH_BOOST);
+                if i > 0 {
+                    scored[i - 1].1 = scored[i - 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
                 }
-                if mi + 1 < scored.len() {
-                    scored[mi + 1].1 = scored[mi + 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
+                if i + 1 < scored.len() {
+                    scored[i + 1].1 = scored[i + 1].1.saturating_add(QUERY_PROXIMITY_BOOST);
                 }
             }
         }
@@ -89,9 +81,9 @@ pub(crate) fn select_diverse_lines(
     scored.truncate(SMART_TRUNCATE_MAX_LINES);
 
     // Re-sort by line number for reading order
-    scored.sort_by_key(|&(line, _)| line);
+    scored.sort_by_key(|&(line, _, _)| line);
 
-    Some(scored.into_iter().map(|(line, _)| line).collect())
+    Some(scored.into_iter().map(|(line, _, _)| line).collect())
 }
 
 /// Score a single line based on its content. Higher scores indicate more
@@ -359,10 +351,10 @@ mod tests {
         lines.push("}".to_owned()); // line 100
         let content = lines.join("\n");
 
-        // With query=None the needle competes equally with 97 other score-1 lines.
-        // With only 38 interior slots available and 97 candidates, most are dropped.
-        // Verify None drops it (stable sort puts it anywhere — we assert it CAN be
-        // absent) by checking with the boosted version first, which MUST include it.
+        // Both selections are deterministic (stable sort, tie-broken by ascending
+        // line number). With the boost, line 50 jumps above the score-1 crowd and
+        // is kept; without it, the 38 interior slots fill with the lowest line
+        // numbers (2..=39), so line 50 is dropped. Check the boosted case first.
         let with_query = select_diverse_lines(&content, 1, 100, Some("needle_marker")).unwrap();
         assert!(
             with_query.contains(&50),


### PR DESCRIPTION
## What
Makes `select_diverse_lines` (the smart-truncation line selector) query-aware: lines containing the searched symbol get a score boost (and their ±1 neighbours a smaller one), so they survive truncation.

## Why
The selector kept generically "important" lines (signatures, control flow, calls) but was blind to what the agent searched for — so the very lines mentioning the target symbol could be truncated away, forcing another search. There's a single production call site, and the matched symbol (`m.def_name`) was already in scope there.

## How
- Replace the dead `_lang` param with `query: Option<&str>` (the slot the design always intended) — also removes end-to-end dead plumbing, since the call site no longer extracts `lang` just to ignore it.
- Pass 2 (only when `query` is `Some` and non-empty): `QUERY_MATCH_BOOST` (50) on lines containing the symbol, `QUERY_PROXIMITY_BOOST` (5) on ±1 neighbours, atop the structural score. Integer, deterministic, `saturating_add`.
- `None`/empty query → pass 2 skipped → byte-identical to before.
- Symbol-name only; threading the raw multi-word query string is a deliberate follow-up.

## Tests
- `query_boost_rescues_needle_line` — differential: a low-score line carrying the symbol is dropped with `None` but kept with `Some` (it sits past the 40-line keep-window; score 1→51).
- `query_boost_preserves_neighbour` — the ±1 neighbour survives via the proximity boost.
- `empty_query_behaves_like_none` — `Some("")` ≡ `None`.

472 tests pass · `clippy -D warnings` clean · `fmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)