### PR TITLE
feat(search): value-based budget allocation (rate-distortion)

### DIFF
--- a/src/search/alloc.rs
+++ b/src/search/alloc.rs
@@ -23,8 +23,12 @@ use crate::types::estimate_tokens;
 /// When the total cost is within budget every block is kept, so the caller's
 /// render is byte-identical to the un-budgeted output.
 pub(crate) fn select_within_budget(items: &[(i64, u64)], budget: u64) -> Vec<bool> {
-    // Fast path: everything fits → keep all (byte-identical render).
-    let total: u64 = items.iter().map(|&(_, tokens)| tokens).sum();
+    // Fast path: everything fits → keep all (byte-identical render). Saturating
+    // so a future caller passing pathological token counts can't overflow-panic
+    // in debug (within `fit_to_budget` the sum is bounded by the body length).
+    let total: u64 = items
+        .iter()
+        .fold(0u64, |acc, &(_, tokens)| acc.saturating_add(tokens));
     if total <= budget {
         return vec![true; items.len()];
     }
@@ -62,6 +66,27 @@ pub(crate) fn fit_to_budget(
     blocks: &[(i64, usize, usize)],
     budget_tokens: u64,
 ) -> String {
+    // Invariant the slicing below relies on: blocks are ascending, non-overlapping,
+    // within `body`, and on char boundaries. They come from `String::len()`
+    // snapshots taken during assembly; assert it in debug so a future regression in
+    // the segment recorder trips here rather than panicking on a bad slice in
+    // release.
+    #[cfg(debug_assertions)]
+    {
+        let mut prev_end = 0usize;
+        for &(_, start, end) in blocks {
+            debug_assert!(start >= prev_end, "blocks overlap or are out of order");
+            debug_assert!(end >= start, "block end precedes start");
+            debug_assert!(end <= body.len(), "block end exceeds body length");
+            debug_assert!(
+                body.is_char_boundary(start),
+                "block start off char boundary"
+            );
+            debug_assert!(body.is_char_boundary(end), "block end off char boundary");
+            prev_end = end;
+        }
+    }
+
     if estimate_tokens(body.len() as u64) <= budget_tokens {
         return body.to_string();
     }
@@ -70,6 +95,15 @@ pub(crate) fn fit_to_budget(
     // selection only spends the budget left after reserving them.
     let block_bytes: usize = blocks.iter().map(|&(_, s, e)| e.saturating_sub(s)).sum();
     let structural_tokens = estimate_tokens(body.len().saturating_sub(block_bytes) as u64);
+
+    // If structural bytes alone already meet or exceed the budget, value selection
+    // can't help: every block would be dropped, leaving a still-over-budget string
+    // plus a misleading "lower-value omitted" note. Hand the whole body back and
+    // let `budget::apply`'s position cut handle it.
+    if structural_tokens >= budget_tokens {
+        return body.to_string();
+    }
+
     let block_budget = budget_tokens.saturating_sub(structural_tokens);
 
     let items: Vec<(i64, u64)> = blocks
@@ -193,6 +227,28 @@ mod tests {
         assert!(
             out.contains("omitted to fit budget"),
             "omitted marker expected: {out}"
+        );
+    }
+
+    #[test]
+    fn fit_to_budget_passes_through_when_structural_exceeds_budget() {
+        // A long structural header dwarfs a tiny block. Even dropping the block
+        // can't get under the budget, so value selection is useless: return the
+        // body unchanged (no misleading "omitted" note) and let the caller's
+        // position cut handle it.
+        let header = "H".repeat(400); // ~100 tokens of structural bytes
+        let body = format!("{header}## x\nbody-x");
+        let blk_start = body.find("body-x").unwrap();
+        let blocks = [(1i64, blk_start, body.len())];
+        // Budget 10 tokens « structural ~100 tokens.
+        let out = fit_to_budget(&body, &blocks, 10);
+        assert_eq!(
+            out, body,
+            "structural-over-budget must pass the body through unchanged"
+        );
+        assert!(
+            !out.contains("omitted"),
+            "no misleading omitted note when nothing was value-dropped: {out}"
         );
     }
 }

--- a/src/search/alloc.rs
+++ b/src/search/alloc.rs
@@ -1,0 +1,198 @@
+//! Value-based budget allocation for search output.
+//!
+//! When assembled search output exceeds the token budget, `budget::apply`'s
+//! position-based tail-cut drops whatever sorts last — but faceted output can
+//! place a high-value match in the final facet. This keeps blocks by information
+//! value instead, so the most relevant matches survive regardless of where they
+//! land in the rendered order.
+
+use std::fmt::Write;
+
+use crate::types::estimate_tokens;
+
+/// Choose which blocks to keep within `budget` tokens, preferring higher value.
+///
+/// `items` is `(value, tokens)` per block in rendered order; higher `value`
+/// means more worth keeping. Returns a keep-mask in the SAME order as `items`.
+///
+/// Strategy: first-fit by value — consider blocks in descending value order and
+/// keep each that still fits in the remaining budget (a smaller, lower-value
+/// block can be kept after a larger higher-value one was skipped, so leftover
+/// budget is not wasted). Deterministic: ties broken by original index.
+///
+/// When the total cost is within budget every block is kept, so the caller's
+/// render is byte-identical to the un-budgeted output.
+pub(crate) fn select_within_budget(items: &[(i64, u64)], budget: u64) -> Vec<bool> {
+    // Fast path: everything fits → keep all (byte-identical render).
+    let total: u64 = items.iter().map(|&(_, tokens)| tokens).sum();
+    if total <= budget {
+        return vec![true; items.len()];
+    }
+
+    let mut keep = vec![false; items.len()];
+    // Consider blocks by descending value, stable on original index.
+    let mut order: Vec<usize> = (0..items.len()).collect();
+    order.sort_by(|&a, &b| items[b].0.cmp(&items[a].0).then(a.cmp(&b)));
+
+    let mut remaining = budget;
+    for i in order {
+        let (_, tokens) = items[i];
+        if tokens <= remaining {
+            keep[i] = true;
+            remaining -= tokens;
+        }
+        // else: skip — a smaller lower-value block may still fit.
+    }
+    keep
+}
+
+/// Fit assembled search output to `budget_tokens`, keeping the highest-value
+/// match blocks. `blocks` are `(value, byte_start, byte_end)` for each match
+/// block within `body`, in ascending `byte_start` order with no overlap; every
+/// other byte is structural (headers, facet labels, hidden-tails) and always
+/// kept.
+///
+/// When `body` is already within budget it is returned UNCHANGED (byte-identical
+/// to the streamed output). Over budget, the lowest-value blocks are dropped
+/// (not the trailing ones), so the most relevant matches survive whichever facet
+/// they landed in. Byte ranges come from `String::len()` snapshots taken during
+/// assembly, so every slice lands on a char boundary.
+pub(crate) fn fit_to_budget(
+    body: &str,
+    blocks: &[(i64, usize, usize)],
+    budget_tokens: u64,
+) -> String {
+    if estimate_tokens(body.len() as u64) <= budget_tokens {
+        return body.to_string();
+    }
+
+    // Structural bytes (everything outside a block) are always kept; the value
+    // selection only spends the budget left after reserving them.
+    let block_bytes: usize = blocks.iter().map(|&(_, s, e)| e.saturating_sub(s)).sum();
+    let structural_tokens = estimate_tokens(body.len().saturating_sub(block_bytes) as u64);
+    let block_budget = budget_tokens.saturating_sub(structural_tokens);
+
+    let items: Vec<(i64, u64)> = blocks
+        .iter()
+        .map(|&(v, s, e)| (v, estimate_tokens(e.saturating_sub(s) as u64)))
+        .collect();
+    let keep = select_within_budget(&items, block_budget);
+
+    let mut out = String::with_capacity(body.len());
+    let mut cursor = 0usize;
+    let mut dropped = 0usize;
+    for (i, &(_, start, end)) in blocks.iter().enumerate() {
+        out.push_str(&body[cursor..start]); // structural gap before this block
+        if keep[i] {
+            out.push_str(&body[start..end]);
+        } else {
+            dropped += 1;
+        }
+        cursor = end;
+    }
+    out.push_str(&body[cursor..]); // trailing structural bytes
+
+    if dropped > 0 {
+        let _ = write!(
+            out,
+            "\n\n... {dropped} lower-value match(es) omitted to fit budget"
+        );
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn keeps_all_when_under_budget() {
+        let items = [(10, 30), (5, 30), (1, 30)];
+        assert_eq!(select_within_budget(&items, 1000), vec![true, true, true]);
+    }
+
+    #[test]
+    fn drops_lower_value_when_over_budget() {
+        // Each block costs 100; budget fits exactly one → the highest-value one.
+        let items = [(1, 100), (10, 100), (5, 100)];
+        assert_eq!(select_within_budget(&items, 100), vec![false, true, false]);
+    }
+
+    #[test]
+    fn first_fit_uses_leftover_for_smaller_lower_value_block() {
+        // Value order: (10,60) kept (rem 40); (5,50) skipped (50 > 40);
+        // (1,30) kept (30 <= 40) — leftover budget is not wasted.
+        let items = [(10, 60), (5, 50), (1, 30)];
+        assert_eq!(select_within_budget(&items, 100), vec![true, false, true]);
+    }
+
+    #[test]
+    fn ties_break_by_original_index() {
+        // Two equal-value blocks, budget fits one → the earlier index wins.
+        let items = [(7, 100), (7, 100)];
+        assert_eq!(select_within_budget(&items, 100), vec![true, false]);
+    }
+
+    #[test]
+    fn zero_budget_keeps_nothing_costly() {
+        let items = [(10, 1), (5, 1)];
+        assert_eq!(select_within_budget(&items, 0), vec![false, false]);
+    }
+
+    #[test]
+    fn zero_cost_block_always_kept() {
+        // A zero-token block fits any budget, even 0.
+        let items = [(1, 0), (10, 50)];
+        assert_eq!(select_within_budget(&items, 0), vec![true, false]);
+    }
+
+    #[test]
+    fn empty_input_is_empty() {
+        assert_eq!(select_within_budget(&[], 100), Vec::<bool>::new());
+    }
+
+    #[test]
+    fn negative_values_are_ordered_correctly() {
+        // Penalised (negative-value) blocks are dropped before positive ones.
+        let items = [(-5, 100), (3, 100)];
+        assert_eq!(select_within_budget(&items, 100), vec![false, true]);
+    }
+
+    #[test]
+    fn fit_to_budget_under_budget_is_byte_identical() {
+        let body = "HEADER\n## a\nbody-a\n## b\nbody-b".to_string();
+        let blocks = [(1i64, 7, 20), (2i64, 20, body.len())];
+        assert_eq!(fit_to_budget(&body, &blocks, 100_000), body);
+    }
+
+    #[test]
+    fn fit_to_budget_drops_low_value_keeps_high_and_structural() {
+        // HEADER (structural) + two ~200-byte blocks. Budget fits structural +
+        // one block only → the high-value one survives, the low-value one drops.
+        let high = "AAAA".repeat(50);
+        let low = "BBBB".repeat(50);
+        let body = format!("HEADER\n{high}\n{low}");
+        let a_start = body.find(&high).unwrap();
+        let a_end = a_start + high.len();
+        let b_start = body.find(&low).unwrap();
+        let b_end = b_start + low.len();
+        let blocks = [(10i64, a_start, a_end), (1i64, b_start, b_end)];
+
+        // body ~408 bytes (~102 tokens); structural ~8 bytes (~2 tokens); each
+        // block ~50 tokens. Budget 55 → fits structural + one block.
+        let out = fit_to_budget(&body, &blocks, 55);
+        assert!(
+            out.starts_with("HEADER"),
+            "structural header must survive: {out}"
+        );
+        assert!(out.contains(&high), "high-value block must survive: {out}");
+        assert!(
+            !out.contains("BBBB"),
+            "low-value block must be dropped: {out}"
+        );
+        assert!(
+            out.contains("omitted to fit budget"),
+            "omitted marker expected: {out}"
+        );
+    }
+}

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1,3 +1,4 @@
+mod alloc;
 pub mod blast;
 pub mod callees;
 pub mod callers;
@@ -205,6 +206,7 @@ pub fn search_multi_symbol_expanded(
             result.definitions,
             result.usages,
         );
+        let mut segments: Vec<(i64, usize, usize)> = Vec::new();
         format_matches(
             &result.matches,
             &result.scope,
@@ -214,6 +216,7 @@ pub fn search_multi_symbol_expanded(
             &mut expand_remaining,
             &mut expanded_files,
             &mut out,
+            &mut segments,
         );
         if result.total_found > result.matches.len() {
             let omitted = result.total_found - result.matches.len();
@@ -222,6 +225,7 @@ pub fn search_multi_symbol_expanded(
                 "\n\n... and {omitted} more matches. Narrow with scope."
             );
         }
+        out = crate::search::alloc::fit_to_budget(&out, &segments, crate::budget::DEFAULT_BUDGET);
         sections.push(out);
     }
 
@@ -359,6 +363,7 @@ fn format_matches(
     expand_remaining: &mut usize,
     expanded_files: &mut HashSet<PathBuf>,
     out: &mut String,
+    segments: &mut Vec<(i64, usize, usize)>,
 ) {
     // Multi-file: one expand per unique file. Single-file: sequential per-match.
     // expanded_files may contain entries from prior queries (cross-query dedup).
@@ -373,6 +378,7 @@ fn format_matches(
     for group in &groups {
         if group.len() == 1 {
             // Single match — format as before
+            let start = out.len();
             format_single_match(
                 group[0],
                 scope,
@@ -384,9 +390,17 @@ fn format_matches(
                 multi_file,
                 out,
             );
+            segments.push((i64::from(group[0].def_weight), start, out.len()));
         } else {
             // Multiple usages collapsed into one entry
+            let start = out.len();
             format_grouped_usages(group, scope, cache, out);
+            let value = group
+                .iter()
+                .map(|m| i64::from(m.def_weight))
+                .max()
+                .unwrap_or(0);
+            segments.push((value, start, out.len()));
         }
     }
 }
@@ -933,6 +947,7 @@ fn format_search_result(
     let mut out = header;
     let mut expand_remaining = expand;
     let mut expanded_files = HashSet::new();
+    let mut segments: Vec<(i64, usize, usize)> = Vec::new();
 
     // File-level retrieval: when a file basename matches the query exactly,
     // prepend a compact outline so the agent gets file-level context first.
@@ -967,6 +982,7 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+                &mut segments,
             );
             write_hidden_tail(
                 &mut out,
@@ -991,6 +1007,7 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+                &mut segments,
             );
             write_hidden_tail(
                 &mut out,
@@ -1034,6 +1051,7 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+                &mut segments,
             );
             write_hidden_tail(
                 &mut out,
@@ -1058,6 +1076,7 @@ fn format_search_result(
                 &mut expand_remaining,
                 &mut expanded_files,
                 &mut out,
+                &mut segments,
             );
             write_hidden_tail(
                 &mut out,
@@ -1077,6 +1096,7 @@ fn format_search_result(
             &mut expand_remaining,
             &mut expanded_files,
             &mut out,
+            &mut segments,
         );
 
         // Global hidden-tail only on the linear path. The faceted path emits
@@ -1090,6 +1110,10 @@ fn format_search_result(
             );
         }
     }
+
+    // Apply value-based budget allocation before appending the token footer.
+    // Under-budget: byte-identical. Over-budget: drops lowest-value match blocks.
+    out = crate::search::alloc::fit_to_budget(&out, &segments, crate::budget::DEFAULT_BUDGET);
 
     let tokens = estimate_tokens(out.len() as u64);
     let token_str = if tokens >= 1000 {
@@ -2206,5 +2230,70 @@ mod tests {
             !out.starts_with("\n\n## "),
             "grouped-usage heading must not be H2, got: {out:?}"
         );
+    }
+
+    // Verify that format_matches records segment byte ranges correctly.
+    // Each push must cover non-empty, non-overlapping ranges that index into `out`.
+    #[test]
+    fn format_matches_segments_record_correct_byte_ranges() {
+        use crate::index::bloom::BloomFilterCache;
+        use crate::types::Match;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("a.rs");
+        std::fs::write(&p, "fn alpha() {}\nfn beta() {}\nfn gamma() {}\n").unwrap();
+
+        let mk = |line: u32, weight: u16, name: &str| Match {
+            path: p.clone(),
+            line,
+            text: format!("fn {name}()"),
+            is_definition: true,
+            exact: true,
+            file_lines: 3,
+            mtime: SystemTime::now(),
+            def_range: Some((line, line)),
+            def_name: Some(name.to_string()),
+            def_weight: weight,
+            impl_target: None,
+        };
+
+        let matches = vec![mk(1, 30, "alpha"), mk(2, 10, "beta"), mk(3, 50, "gamma")];
+        let cache = OutlineCache::new();
+        let bloom = BloomFilterCache::new();
+        let mut out = String::from("HEADER");
+        let mut segments: Vec<(i64, usize, usize)> = Vec::new();
+        let mut expand_remaining = 0usize;
+        let mut expanded_files = HashSet::new();
+
+        format_matches(
+            &matches,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            &mut out,
+            &mut segments,
+        );
+
+        // One segment per match (all singletons — definitions are never grouped).
+        assert_eq!(segments.len(), 3, "expected one segment per match");
+
+        // Values must match def_weight casts.
+        assert_eq!(segments[0].0, 30i64);
+        assert_eq!(segments[1].0, 10i64);
+        assert_eq!(segments[2].0, 50i64);
+
+        // Ranges must be valid, non-empty, and non-overlapping.
+        let mut cursor = "HEADER".len();
+        for (i, &(_, start, end)) in segments.iter().enumerate() {
+            assert!(start >= cursor, "segment {i} start < cursor");
+            assert!(end > start, "segment {i} is empty");
+            assert!(end <= out.len(), "segment {i} end out of bounds");
+            // Slice must not panic (validates char-boundary alignment).
+            let _ = &out[start..end];
+            cursor = end;
+        }
     }
 }


### PR DESCRIPTION
## What
Replaces the position-based tail-cut for **over-budget** search output with a **value-based keep-set**: when assembled output exceeds the budget, drop the *lowest-value* match blocks rather than whatever sorts last.

## Why
`budget::apply` cut the trailing `\n\n##` section. But search output is faceted (Definitions → Implementations → Tests → Usages), so a high-value match in a later facet could be deleted while a verbose, low-value match in an earlier facet kept its full body. This is the keystone the roadmap names.

## How
- **`src/search/alloc.rs`** (new, pure, 10 tests):
  - `select_within_budget(items: &[(value, tokens)], budget) → keep-mask` — first-fit by value desc, deterministic (ties by index).
  - `fit_to_budget(body, blocks, budget) → String` — `blocks` are `(value, byte_start, byte_end)`; structural bytes always kept; **returns `body` unchanged when within budget**; over budget drops lowest-value blocks + appends an "N omitted" marker. Byte ranges come from `len()` snapshots → char-boundary-safe.
- **`format_matches`** records each rendered block's `(def_weight, byte-range)` — pure instrumentation, zero output change.
- **`format_search_result`** fits to `DEFAULT_BUDGET` before the token footer; the lib-layer `apply` stays as a final clamp.

## Safety
- **Under-budget output is byte-identical** — the streaming assembly is only *instrumented*, not restructured. Every pre-existing search test passes **unchanged** (480 lib + 4 bin green).
- Deterministic (no float/RNG/clock).

## Tests
- `alloc.rs`: first-fit, ties, zero/negative budget, zero-cost, empty; `fit_to_budget` byte-identical-under-budget and drop-low-value-over-budget.
- `mod.rs`: `format_matches` segment recording — correct values + non-overlapping, in-bounds, char-safe ranges.

## Deferred
The full cost-per-correct **benchmark** (#351) is deferred as a recommended-but-optional validation: it spends real `claude -p` budget and barely exercises this change (most searches are under budget). Correctness is fully test-verified; determinism/byte-identical/composition audited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)