### PR TITLE
feat(lang): add Bash tree-sitter support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,8 +64,8 @@ AGENTS.md              User-facing copy of the MCP instructions. Generated from 
 
 ## Languages supported
 
-Rust, TypeScript, TSX, JavaScript, Python, Go, Java, C, C++, Ruby, PHP, C#, Swift.
-Kotlin, Dockerfile, Make detected but have no tree-sitter grammar (outline returns None).
+Rust, TypeScript, TSX, JavaScript, Python, Go, Java, Scala, C, C++, Ruby, PHP, C#, Swift, Kotlin, Elixir, Bash.
+Dockerfile, Make detected but have no tree-sitter grammar (outline returns None).
 
 ## Build, test, install
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -864,6 +864,7 @@ dependencies = [
  "thiserror",
  "toml",
  "tree-sitter",
+ "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
  "tree-sitter-cpp",
@@ -932,6 +933,16 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
+ "tree-sitter-language",
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
+dependencies = [
+ "cc",
  "tree-sitter-language",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tree-sitter-c-sharp = "0.23"
 tree-sitter-swift = "0.7"
 tree-sitter-kotlin-ng = "1.1"
 tree-sitter-elixir = "0.3"
+tree-sitter-bash = "0.25.1"
 tree-sitter-md = "0.5"
 
 # Search (ripgrep internals)

--- a/fuzz/fuzz_targets/outline.rs
+++ b/fuzz/fuzz_targets/outline.rs
@@ -1,7 +1,7 @@
 #![no_main]
 //! Fuzz `outline` rendering across every supported language.
 //!
-//! Iterates each input through all 18 `Lang` variants. The render path
+//! Iterates each input through all 19 `Lang` variants. The render path
 //! exercises tree-sitter parsing, AST traversal, signature extraction,
 //! and the formatter — i.e. tilth's primary input surface ("any file on
 //! disk in any language").
@@ -30,6 +30,7 @@ const LANGS: &[Lang] = &[
     Lang::Kotlin,
     Lang::CSharp,
     Lang::Elixir,
+    Lang::Bash,
     Lang::Dockerfile,
     Lang::Make,
 ];

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -25,6 +25,7 @@ pub fn detect_file_type(path: &Path) -> FileType {
         Some("kt" | "kts") => FileType::Code(Lang::Kotlin),
         Some("cs") => FileType::Code(Lang::CSharp),
         Some("ex" | "exs") => FileType::Code(Lang::Elixir),
+        Some("sh" | "bash" | "bats") => FileType::Code(Lang::Bash),
 
         Some("md" | "mdx" | "rst") => FileType::Markdown,
         Some("json" | "yaml" | "yml" | "toml" | "xml" | "ini") => FileType::StructuredData,
@@ -42,6 +43,9 @@ fn file_type_from_name(path: &Path) -> FileType {
         Some("Makefile" | "GNUmakefile") => FileType::Code(Lang::Make),
         Some("Vagrantfile" | "Rakefile") => FileType::Code(Lang::Ruby),
         Some(n) if n.starts_with(".env") => FileType::StructuredData,
+        Some(".bashrc" | ".bash_profile" | ".bash_aliases" | ".profile") => {
+            FileType::Code(Lang::Bash)
+        }
         _ => FileType::Other,
     }
 }

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -284,9 +284,9 @@ fn node_to_entry(
             return elixir_attr_to_entry(node, lines);
         }
 
-        // Bash: top-level variable assignments (`MY_VAR=value`)
+        // Bash: top-level variable assignments (`MY_VAR=value`, `ARR[0]=value`)
         "variable_assignment" if lang == Lang::Bash => {
-            let name = find_child_text(node, "name", lines).unwrap_or_else(|| "<var>".into());
+            let name = assignment_name(node, lines).unwrap_or_else(|| "<var>".into());
             (OutlineKind::Variable, name, None)
         }
 
@@ -300,7 +300,7 @@ fn node_to_entry(
             let name = node
                 .children(&mut cursor)
                 .find_map(|child| match child.kind() {
-                    "variable_assignment" => find_child_text(child, "name", lines),
+                    "variable_assignment" => assignment_name(child, lines),
                     "variable_name" => Some(node_text(child, lines)),
                     _ => None,
                 })?;
@@ -411,6 +411,23 @@ fn extract_signature(node: tree_sitter::Node, lines: &[&str]) -> String {
 /// Find a named child and return its text.
 fn find_child_text(node: tree_sitter::Node, field: &str, lines: &[&str]) -> Option<String> {
     node.child_by_field_name(field).map(|n| node_text(n, lines))
+}
+
+/// Resolve the variable name from an assignment `name` field, unwrapping a
+/// `subscript` (`ARR[0]=x`) to its base `variable_name` so the symbol
+/// surfaces as `ARR`, not `ARR[0]`.
+fn assignment_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    let name = node.child_by_field_name("name")?;
+    if name.kind() == "subscript" {
+        let mut cursor = name.walk();
+        let base = name
+            .children(&mut cursor)
+            .find(|c| c.kind() == "variable_name")
+            .unwrap_or(name);
+        Some(node_text(base, lines))
+    } else {
+        Some(node_text(name, lines))
+    }
 }
 
 /// Get the text of a node, truncated to the first line.
@@ -813,12 +830,13 @@ fn elixir_extract_doc_string(node: tree_sitter::Node, lines: &[&str]) -> Option<
 pub(crate) fn extract_import_source(text: &str, lang: Option<crate::types::Lang>) -> String {
     let trimmed = text.trim().trim_end_matches(';');
 
-    // Bash: `source ./lib.sh` or `. ./lib.sh`
+    // Bash: `source ./lib.sh`, `. ./lib.sh`, or tab-separated variants
     if lang == Some(crate::types::Lang::Bash) {
         let after = trimmed
-            .strip_prefix("source ")
-            .or_else(|| trimmed.strip_prefix(". "))
-            .unwrap_or(trimmed);
+            .strip_prefix("source")
+            .or_else(|| trimmed.strip_prefix('.'))
+            .filter(|rest| rest.starts_with(char::is_whitespace))
+            .map_or(trimmed, str::trim_start);
         // Skip variable-expanded paths (contain `$`)
         if after.contains('$') {
             return String::new();
@@ -1140,5 +1158,33 @@ main() {
             result.is_empty(),
             "variable-expanded source should return empty, got: {result:?}"
         );
+    }
+
+    #[test]
+    fn bash_subscript_assignment_surfaces_base_name() {
+        // `ARR[0]=hello` should appear as `ARR` (Variable), not `ARR[0]`.
+        let entries = get_outline_entries("ARR[0]=hello\n", Lang::Bash);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+        assert!(
+            names.contains(&"ARR"),
+            "expected ARR in outline, got: {names:?}"
+        );
+        assert!(
+            !names.contains(&"ARR[0]"),
+            "ARR[0] must not appear verbatim in outline, got: {names:?}"
+        );
+        let entry = entries.iter().find(|e| e.name == "ARR").unwrap();
+        assert_eq!(
+            entry.kind,
+            OutlineKind::Variable,
+            "ARR should be OutlineKind::Variable"
+        );
+    }
+
+    #[test]
+    fn bash_extract_import_source_tab_separated() {
+        // `source\t./lib.sh` (tab separator) must be parsed correctly.
+        let result = extract_import_source("source\t./lib/utils.sh", Some(Lang::Bash));
+        assert_eq!(result, "./lib/utils.sh");
     }
 }

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -21,6 +21,7 @@ pub fn outline_language(lang: Lang) -> Option<tree_sitter::Language> {
         Lang::Swift => tree_sitter_swift::LANGUAGE,
         Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE,
         Lang::Elixir => tree_sitter_elixir::LANGUAGE,
+        Lang::Bash => tree_sitter_bash::LANGUAGE,
         Lang::Dockerfile | Lang::Make => {
             return None;
         }
@@ -281,6 +282,29 @@ fn node_to_entry(
         // Elixir: @type, @typep, @opaque are unary_operator nodes
         "unary_operator" if lang == Lang::Elixir => {
             return elixir_attr_to_entry(node, lines);
+        }
+
+        // Bash: top-level variable assignments (`MY_VAR=value`)
+        "variable_assignment" if lang == Lang::Bash => {
+            let name = find_child_text(node, "name", lines).unwrap_or_else(|| "<var>".into());
+            (OutlineKind::Variable, name, None)
+        }
+
+        // Bash: top-level `export` / `declare` / `readonly` declarations. The name
+        // is the `name` of the inner variable_assignment (`export FOO=bar`) or a
+        // bare variable_name child (`export FOO`). Function-local `local`
+        // declarations are nested in function bodies, so walk_top_level never
+        // reaches them here. Multi-variable declarations surface their first name.
+        "declaration_command" if lang == Lang::Bash => {
+            let mut cursor = node.walk();
+            let name = node
+                .children(&mut cursor)
+                .find_map(|child| match child.kind() {
+                    "variable_assignment" => find_child_text(child, "name", lines),
+                    "variable_name" => Some(node_text(child, lines)),
+                    _ => None,
+                })?;
+            (OutlineKind::Variable, name, None)
         }
 
         _ => return None,
@@ -789,6 +813,19 @@ fn elixir_extract_doc_string(node: tree_sitter::Node, lines: &[&str]) -> Option<
 pub(crate) fn extract_import_source(text: &str, lang: Option<crate::types::Lang>) -> String {
     let trimmed = text.trim().trim_end_matches(';');
 
+    // Bash: `source ./lib.sh` or `. ./lib.sh`
+    if lang == Some(crate::types::Lang::Bash) {
+        let after = trimmed
+            .strip_prefix("source ")
+            .or_else(|| trimmed.strip_prefix(". "))
+            .unwrap_or(trimmed);
+        // Skip variable-expanded paths (contain `$`)
+        if after.contains('$') {
+            return String::new();
+        }
+        return after.trim_matches(|c| c == '"' || c == '\'').to_string();
+    }
+
     // Elixir: `use GenServer`, `import Kernel`, `alias Foo.Bar`, `require Logger`
     // Must be checked before the Rust `use` and JS `import` branches.
     if lang == Some(crate::types::Lang::Elixir) {
@@ -941,5 +978,167 @@ mod markdown_helper_tests {
         let lines: Vec<&str> = src.lines().collect();
         let headings = collect_headings(&tree);
         assert_eq!(heading_text(headings[0], &lines), "Foo");
+    }
+}
+
+#[cfg(test)]
+mod bash_outline_tests {
+    use super::{extract_import_source, get_outline_entries};
+    use crate::search::callees::extract_callee_names;
+    use crate::types::{Lang, OutlineKind};
+
+    // Fixture covering both function syntaxes, top-level vars, and a nested local.
+    const BASH_FIXTURE: &str = r#"MY_CONST=hello
+DEBUG_MODE=0
+
+greet() { echo "hi $1"; }
+
+function cleanup {
+    rm -f /tmp/x
+}
+
+main() {
+    greet world
+    cleanup
+    local y=1
+}
+"#;
+
+    #[test]
+    fn bash_outline_functions_and_vars() {
+        let entries = get_outline_entries(BASH_FIXTURE, Lang::Bash);
+
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+
+        // All three functions must appear
+        assert!(
+            names.contains(&"greet"),
+            "expected greet in outline, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"cleanup"),
+            "expected cleanup in outline, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"main"),
+            "expected main in outline, got: {names:?}"
+        );
+
+        // Top-level variables must appear
+        assert!(
+            names.contains(&"MY_CONST"),
+            "expected MY_CONST in outline, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"DEBUG_MODE"),
+            "expected DEBUG_MODE in outline, got: {names:?}"
+        );
+
+        // Functions must have Function kind
+        for fname in &["greet", "cleanup", "main"] {
+            let entry = entries.iter().find(|e| e.name == *fname).unwrap();
+            assert_eq!(
+                entry.kind,
+                OutlineKind::Function,
+                "{fname} should be OutlineKind::Function"
+            );
+        }
+
+        // Variables must have Variable kind
+        for vname in &["MY_CONST", "DEBUG_MODE"] {
+            let entry = entries.iter().find(|e| e.name == *vname).unwrap();
+            assert_eq!(
+                entry.kind,
+                OutlineKind::Variable,
+                "{vname} should be OutlineKind::Variable"
+            );
+        }
+
+        // Nested `local y=1` must NOT appear at the top level
+        assert!(
+            !names.contains(&"y"),
+            "nested local 'y' must not appear in top-level outline, got: {names:?}"
+        );
+    }
+
+    #[test]
+    fn bash_callee_names_for_main() {
+        // Derive main's range from the outline so the test can't silently drift
+        // if the fixture is edited.
+        let main = get_outline_entries(BASH_FIXTURE, Lang::Bash)
+            .into_iter()
+            .find(|e| e.name == "main")
+            .expect("main must be in the outline");
+        let names = extract_callee_names(
+            BASH_FIXTURE,
+            Lang::Bash,
+            Some((main.start_line, main.end_line)),
+        );
+
+        assert!(
+            names.contains(&"greet".to_string()),
+            "expected greet as callee, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"cleanup".to_string()),
+            "expected cleanup as callee, got: {names:?}"
+        );
+        // echo is called inside greet, outside main's range, so it is absent here.
+    }
+
+    #[test]
+    fn bash_outline_surfaces_declarations_and_hyphenated_names() {
+        // export/declare/readonly declarations must surface (the common config
+        // pattern), and hyphenated function names must be captured whole.
+        let src = "export E_VAR=1\n\
+                   declare -r D_VAR=2\n\
+                   readonly R_VAR=3\n\
+                   deploy-app() { :; }\n";
+        let entries = get_outline_entries(src, Lang::Bash);
+        let names: Vec<&str> = entries.iter().map(|e| e.name.as_str()).collect();
+
+        for v in ["E_VAR", "D_VAR", "R_VAR"] {
+            let e = entries
+                .iter()
+                .find(|e| e.name == v)
+                .unwrap_or_else(|| panic!("{v} should be outlined, got: {names:?}"));
+            assert_eq!(e.kind, OutlineKind::Variable, "{v} should be a Variable");
+        }
+        let dep = entries
+            .iter()
+            .find(|e| e.name == "deploy-app")
+            .unwrap_or_else(|| panic!("deploy-app should be outlined whole, got: {names:?}"));
+        assert_eq!(dep.kind, OutlineKind::Function);
+    }
+
+    #[test]
+    fn bash_extract_import_source_source_keyword() {
+        let line = "source ./lib/utils.sh";
+        let result = extract_import_source(line, Some(Lang::Bash));
+        assert_eq!(result, "./lib/utils.sh");
+    }
+
+    #[test]
+    fn bash_extract_import_source_dot_keyword() {
+        let line = ". ./config.sh";
+        let result = extract_import_source(line, Some(Lang::Bash));
+        assert_eq!(result, "./config.sh");
+    }
+
+    #[test]
+    fn bash_extract_import_source_quoted() {
+        let line = r#"source "./lib/helpers.sh""#;
+        let result = extract_import_source(line, Some(Lang::Bash));
+        assert_eq!(result, "./lib/helpers.sh");
+    }
+
+    #[test]
+    fn bash_extract_import_source_variable_expanded_returns_empty() {
+        let line = r#"source "$DIR/lib.sh""#;
+        let result = extract_import_source(line, Some(Lang::Bash));
+        assert!(
+            result.is_empty(),
+            "variable-expanded source should return empty, got: {result:?}"
+        );
     }
 }

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -24,6 +24,7 @@ pub(crate) const DEFINITION_KINDS: &[&str] = &[
     // Variables, constants & properties (Kotlin, C#, Swift)
     "lexical_declaration",
     "variable_declaration",
+    "variable_assignment", // Bash top-level assignments
     "const_item",
     "const_declaration",
     "static_item",
@@ -309,6 +310,7 @@ pub(crate) fn definition_weight(kind: &str) -> u16 {
         "const_item" | "const_declaration" | "static_item" => 80,
         "mod_item" | "namespace_definition" | "property_declaration" => 70,
         "lexical_declaration" | "variable_declaration" => 40,
+        "variable_assignment" => 60,
         "export_statement" => 30,
         _ => 50,
     }

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -24,7 +24,7 @@ pub(crate) const DEFINITION_KINDS: &[&str] = &[
     // Variables, constants & properties (Kotlin, C#, Swift)
     "lexical_declaration",
     "variable_declaration",
-    "variable_assignment", // Bash top-level assignments
+    "variable_assignment", // Bash top-level assignments (bash-only today; a future grammar reusing this node kind would inherit definition_weight 60)
     "const_item",
     "const_declaration",
     "static_item",

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -253,6 +253,7 @@ fn lang_display_name(lang: Lang) -> &'static str {
         Lang::Kotlin => "Kotlin",
         Lang::CSharp => "C#",
         Lang::Elixir => "Elixir",
+        Lang::Bash => "Bash",
         Lang::Dockerfile => "Docker",
         Lang::Make => "Make",
     }

--- a/src/read/imports.rs
+++ b/src/read/imports.rs
@@ -65,7 +65,10 @@ pub(crate) fn is_import_line(line: &str, lang: Lang) -> bool {
                 || trimmed.starts_with("use ")
                 || trimmed.starts_with("require ")
         }
-        Lang::Bash => trimmed.starts_with("source ") || trimmed.starts_with(". "),
+        Lang::Bash => trimmed
+            .strip_prefix("source")
+            .or_else(|| trimmed.strip_prefix('.'))
+            .is_some_and(|rest| rest.starts_with(char::is_whitespace)),
         _ => false,
     }
 }
@@ -320,6 +323,31 @@ mod tests {
         assert_eq!(
             from_sibling, from_cousin,
             "different spellings should normalize to the same PathBuf"
+        );
+    }
+
+    #[test]
+    fn bash_is_import_line_tab_separated() {
+        // Tab between `source` and path is valid bash and must be detected.
+        assert!(
+            is_import_line("source\t./lib.sh", Lang::Bash),
+            "source<TAB>./lib.sh should be detected as an import line"
+        );
+        // False positives: `sourcefile=1` looks like it starts with `source` but
+        // has no whitespace separator.
+        assert!(
+            !is_import_line("sourcefile=1", Lang::Bash),
+            "sourcefile=1 must not be detected as an import line"
+        );
+        // `./script.sh` is a script execution, not a source directive.
+        assert!(
+            !is_import_line("./script.sh", Lang::Bash),
+            "./script.sh must not be detected as an import line"
+        );
+        // `.bashrc` — dot followed by non-whitespace, not a source directive.
+        assert!(
+            !is_import_line(".bashrc", Lang::Bash),
+            ".bashrc must not be detected as an import line"
         );
     }
 }

--- a/src/read/imports.rs
+++ b/src/read/imports.rs
@@ -65,6 +65,7 @@ pub(crate) fn is_import_line(line: &str, lang: Lang) -> bool {
                 || trimmed.starts_with("use ")
                 || trimmed.starts_with("require ")
         }
+        Lang::Bash => trimmed.starts_with("source ") || trimmed.starts_with(". "),
         _ => false,
     }
 }
@@ -79,7 +80,8 @@ pub(crate) fn is_external(source: &str, lang: Lang) -> bool {
         Lang::TypeScript | Lang::Tsx | Lang::JavaScript => {
             !(source.starts_with('.') || source.starts_with("@/") || source.starts_with("~/"))
         }
-        Lang::Python => !source.starts_with('.'),
+        // Bash: dot-relative paths are local; anything else (bare name, /abs/path) is external.
+        Lang::Python | Lang::Bash => !source.starts_with('.'),
         Lang::C | Lang::Cpp => !source.starts_with('"'),
         // Elixir, Go, Java, Scala, Kotlin — can't resolve without build system knowledge.
         _ => true,
@@ -92,6 +94,7 @@ fn resolve(dir: &Path, source: &str, lang: Lang) -> Option<PathBuf> {
         Lang::TypeScript | Lang::Tsx | Lang::JavaScript => resolve_js(dir, source),
         Lang::Python => resolve_python(dir, source),
         Lang::C | Lang::Cpp => resolve_c_include(dir, source),
+        Lang::Bash => resolve_bash(dir, source),
         // Elixir, Go, Java, etc. — module-to-file mapping requires build system conventions.
         _ => None,
     };
@@ -241,6 +244,18 @@ fn resolve_c_include(dir: &Path, source: &str) -> Option<PathBuf> {
     } else {
         None
     }
+}
+
+// --- Bash ---
+
+fn resolve_bash(dir: &Path, source: &str) -> Option<PathBuf> {
+    // Only resolve literal relative paths — no extension inference. A single
+    // metadata() stat avoids the exists()+is_file() two-call TOCTOU; resolution
+    // is best-effort, so a stale result only ever costs a related-file hint.
+    let candidate = dir.join(source);
+    std::fs::metadata(&candidate)
+        .is_ok_and(|m| m.is_file())
+        .then_some(candidate)
 }
 
 #[cfg(test)]

--- a/src/search/callee_query.rs
+++ b/src/search/callee_query.rs
@@ -70,6 +70,7 @@ pub(super) fn callee_query_str(lang: Lang) -> Option<&'static str> {
             "(call target: (identifier) @callee)\n",
             "(call target: (dot right: (identifier) @callee))\n",
         )),
+        Lang::Bash => Some("(command name: (command_name) @callee)\n"),
         _ => None,
     }
 }
@@ -139,6 +140,7 @@ mod tests {
             ("swift", tree_sitter_swift::LANGUAGE.into()),
             ("kotlin", tree_sitter_kotlin_ng::LANGUAGE.into()),
             ("elixir", tree_sitter_elixir::LANGUAGE.into()),
+            ("bash", tree_sitter_bash::LANGUAGE.into()),
         ];
         let mut seen = std::collections::HashMap::new();
         for (name, lang) in &grammars {
@@ -161,5 +163,12 @@ mod tests {
         let lang: tree_sitter::Language = tree_sitter_elixir::LANGUAGE.into();
         let query_str = callee_query_str(Lang::Elixir).unwrap();
         tree_sitter::Query::new(&lang, query_str).expect("elixir callee query should compile");
+    }
+
+    #[test]
+    fn bash_callee_query_compiles() {
+        let lang: tree_sitter::Language = tree_sitter_bash::LANGUAGE.into();
+        let query_str = callee_query_str(Lang::Bash).unwrap();
+        tree_sitter::Query::new(&lang, query_str).expect("bash callee query should compile");
     }
 }

--- a/src/search/strip.rs
+++ b/src/search/strip.rs
@@ -15,6 +15,7 @@ enum StripLang {
     JsTs,
     JavaKotlinCSharp,
     CppC,
+    Bash,
 }
 
 /// Detect stripping language from file extension.
@@ -26,6 +27,7 @@ fn detect_lang(path: &Path) -> Option<StripLang> {
         "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => Some(StripLang::JsTs),
         "java" | "kt" | "kts" | "cs" | "scala" | "sc" => Some(StripLang::JavaKotlinCSharp),
         "c" | "h" | "cpp" | "hpp" | "cc" | "cxx" => Some(StripLang::CppC),
+        "sh" | "bash" | "bats" => Some(StripLang::Bash),
         _ => None,
     }
 }
@@ -136,6 +138,10 @@ fn is_debug_log(trimmed: &str, lang: StripLang) -> bool {
                 || trimmed.starts_with("cout ")
                 || trimmed.starts_with("cout<<")
         }
+        // Only strip echo lines explicitly labelled DEBUG — plain echo is functional output.
+        StripLang::Bash => {
+            trimmed.starts_with("echo \"DEBUG") || trimmed.starts_with("echo 'DEBUG")
+        }
     }
 }
 
@@ -193,6 +199,13 @@ fn is_strippable_comment(trimmed: &str, lang: StripLang) -> bool {
                 return false;
             }
             trimmed.starts_with("//")
+        }
+        StripLang::Bash => {
+            // Keep shebangs (`#!`) and any line-comment starting with `#!`.
+            if trimmed.starts_with("#!") {
+                return false;
+            }
+            trimmed.starts_with('#')
         }
     };
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -38,6 +38,7 @@ pub enum Lang {
     Kotlin,
     CSharp,
     Elixir,
+    Bash,
     Dockerfile,
     Make,
 }
@@ -66,6 +67,7 @@ impl Lang {
             | Lang::Kotlin
             | Lang::CSharp
             | Lang::Elixir
+            | Lang::Bash
             | Lang::Dockerfile
             | Lang::Make => false,
         }


### PR DESCRIPTION
## Summary

Adds full Bash language support via `tree-sitter-bash` (0.25, ABI-compatible with tilth's 0.26 core) — a common scripting language that had no prior coverage.

**Detection:** `.sh` / `.bash` / `.bats` extensions, plus `.bashrc` / `.bash_profile` / `.bash_aliases` / `.profile` init files.

**Outline:**
- Functions in both syntaxes — `foo() { … }` and `function foo { … }` (reuses the existing `function_definition` path)
- Top-level variables — bare `VAR=…` plus `export` / `declare` / `readonly` declarations
- Function-local `local` and nested definitions are correctly excluded (top-level only)

**Search / grok:** callee extraction from command invocations (calls inside `$(…)` and pipelines resolve correctly); `source` / `.` import resolution; noise-stripping that keeps shebangs and strips only `DEBUG`-labelled `echo`.

Also refreshes the stale "Languages supported" list in CLAUDE.md (Scala/Kotlin/Elixir were already shipped but unlisted).

## Testing

- New in-source tests covering both function syntaxes, declarations, hyphenated names, callees, and import-source parsing.
- `cargo clippy -- -D warnings`, `cargo fmt --check`, `cargo test` (477 lib + 4 bin) all green on stable 1.96.
- Verified end-to-end on real scripts (outline, callers, grok) and stress-tested for panic-safety on adversarial input (unicode identifiers, malformed/unclosed syntax, deeply-nested subshells, associative arrays).
- Added Bash to the outline fuzz target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)