### PR TITLE
fix(budget): guard rfind('\n') fallback to prevent empty truncation body

### DIFF
--- a/src/budget.rs
+++ b/src/budget.rs
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    fn apply_with_info_single_long_line_body_does_not_collapse() {
+    fn single_long_line_body_does_not_collapse() {
         // Regression: a body that is one very long line with no interior \n has no
         // `\n\n` to land on, so rfind('\n') finds only the leading separator at
         // offset 0. Without the `filter(|&p| p > 0)` guard on that arm, cut_point
@@ -100,20 +100,15 @@ mod tests {
         // `header\n\n... truncated` with zero content.
         let long_line = "x".repeat(10_000);
         let input = format!("# header\n{long_line}");
-        let (out, info) = apply_with_info(&input, 400);
-        let info = info.expect("must truncate: body is 10k+ chars");
-        // Must have cut somewhere, but NOT at position 0.
-        assert!(
-            info.at_line >= 2,
-            "cut landed at line {}, expected >= 2 (body should not be empty)",
-            info.at_line
-        );
+        let out = apply(&input, 400);
+        // The truncation marker must appear (body is 10k+ chars).
+        assert!(out.contains("truncated"), "marker line missing: {out:.80?}");
         // The body content must survive — the output must contain some 'x' chars.
+        // If cut_point landed at 0, clean_body would be empty and no 'x' survives.
         assert!(
             out.contains('x'),
             "body content collapsed to empty — single-long-line truncation bug: {out:.80?}"
         );
-        assert!(out.contains("truncated"), "marker line missing: {out:.80?}");
     }
 
     #[test]

--- a/src/budget.rs
+++ b/src/budget.rs
@@ -45,7 +45,7 @@ pub fn apply(output: &str, budget: u64) -> String {
         .rfind("\n\n##")
         .filter(|&p| p > 0)
         .or_else(|| truncated.rfind("\n\n").filter(|&p| p > 0))
-        .or_else(|| truncated.rfind('\n'))
+        .or_else(|| truncated.rfind('\n').filter(|&p| p > 0))
         .unwrap_or(safe_max);
 
     let clean_body = &body[..cut_point];
@@ -89,6 +89,31 @@ mod tests {
         // Pick a budget so max_bytes lands somewhere mid-crab.
         let out = apply(&input, 100);
         assert!(out.contains("... truncated"), "expected truncation: {out}");
+    }
+
+    #[test]
+    fn apply_with_info_single_long_line_body_does_not_collapse() {
+        // Regression: a body that is one very long line with no interior \n has no
+        // `\n\n` to land on, so rfind('\n') finds only the leading separator at
+        // offset 0. Without the `filter(|&p| p > 0)` guard on that arm, cut_point
+        // becomes 0, clean_body is empty, and the response collapses to
+        // `header\n\n... truncated` with zero content.
+        let long_line = "x".repeat(10_000);
+        let input = format!("# header\n{long_line}");
+        let (out, info) = apply_with_info(&input, 400);
+        let info = info.expect("must truncate: body is 10k+ chars");
+        // Must have cut somewhere, but NOT at position 0.
+        assert!(
+            info.at_line >= 2,
+            "cut landed at line {}, expected >= 2 (body should not be empty)",
+            info.at_line
+        );
+        // The body content must survive — the output must contain some 'x' chars.
+        assert!(
+            out.contains('x'),
+            "body content collapsed to empty — single-long-line truncation bug: {out:.80?}"
+        );
+        assert!(out.contains("truncated"), "marker line missing: {out:.80?}");
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,8 @@
     clippy::cast_possible_wrap,        // u32→i32 for tree-sitter APIs
     clippy::module_name_repetitions,   // Rust naming conventions
     clippy::similar_names,             // common in parser/search code
-    clippy::too_many_lines,            // one complex function (find_definitions)
+    clippy::too_many_lines,            // crate-wide to cover find_definitions in src/search/symbol.rs;
+                                       // narrow to a per-function allow once a refactor shrinks that file
     clippy::too_many_arguments,        // internal recursive AST walker
     clippy::unnecessary_wraps,         // Result return for API consistency
     clippy::struct_excessive_bools,    // CLI struct derives clap

--- a/src/map.rs
+++ b/src/map.rs
@@ -68,6 +68,8 @@ pub fn generate(scope: &Path, depth: usize, budget: Option<u64>, cache: &Outline
                     .unwrap_or(std::time::SystemTime::UNIX_EPOCH);
 
                 let outline_str = cache.get_or_compute(path, mtime, || {
+                    // Best-effort: an unreadable file contributes no outline symbols rather than
+                    // aborting the map. Errors are intentionally swallowed here.
                     let content = std::fs::read_to_string(path).unwrap_or_default();
                     let buf = content.as_bytes();
                     outline::generate(path, file_type, &content, buf, true)

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -579,6 +579,9 @@ fn parse_pyproject_toml(root: &Path) -> Option<ManifestInfo> {
 // ---------------------------------------------------------------------------
 
 /// Run a git command with a 200ms timeout. Returns None if it fails or times out.
+/// Best-effort: every git failure (spawn error, non-zero exit, timeout, I/O error)
+/// is intentionally swallowed into None — git context is a cosmetic fingerprint
+/// and must never break the primary read/search path.
 fn git_output(root: &Path, args: &[&str]) -> Option<String> {
     let mut child = Command::new("git")
         .args(args)

--- a/src/types.rs
+++ b/src/types.rs
@@ -90,13 +90,16 @@ pub enum ViewMode {
     Outline,
     Signature,
     Keys,
+    // Reserved/roadmap: planned head+tail view mode, not yet wired.
     #[allow(dead_code)]
     HeadTail,
     Empty,
     Generated,
     Minified,
+    // Reserved/roadmap: binary file view variant, not yet wired.
     #[allow(dead_code)]
     Binary,
+    // Reserved/roadmap: error view variant, not yet wired.
     #[allow(dead_code)]
     Error,
     Section,
@@ -196,11 +199,13 @@ pub enum OutlineKind {
     Variable,
     ImmutableVariable,
     Export,
-    #[allow(dead_code)]
+    // Property is constructed in lang/outline.rs (property_declaration nodes).
     Property,
     Module,
+    // Reserved/roadmap: no tree-sitter grammar currently emits TestSuite nodes.
     #[allow(dead_code)]
     TestSuite,
+    // Reserved/roadmap: no tree-sitter grammar currently emits TestCase nodes.
     #[allow(dead_code)]
     TestCase,
 }


### PR DESCRIPTION
`budget::truncate` could collapse a body with no interior newline to empty output. When the body is a single long line, the `rfind('\n')` fallback finds only the leading separator at offset 0; cutting there yields an empty body — a header plus a "... truncated" marker with zero content.

This guards that fallback arm with `.filter(|&p| p > 0)` so it falls through to `safe_max` and preserves content. The other two cut arms (`rfind("\n\n##")`, `rfind("\n\n")`) already carried this guard; this closes the one remaining hole. Adds a regression test asserting the truncated single-long-line body is non-empty.

Also adds doc comments to reserved `ViewMode`/`OutlineKind` variants and drops a now-stale `#[allow(dead_code)]` on `OutlineKind::Property` (constructed at `lang/outline.rs:222`).

Ported from paulnsorensen/tilth (fork PR #67).

🤖 Generated with [Claude Code](https://claude.com/claude-code)