### PR TITLE
fix(cache,edit,install): bounded cache eviction + atomic file writes

### DIFF
--- a/src/cache.rs
+++ b/src/cache.rs
@@ -2,13 +2,14 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::SystemTime;
 
-use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 
 use crate::types::Lang;
 
-/// Cached outline entry.
+/// Cached outline entry keyed by path. `mtime` is stored in the value so a
+/// stale entry is detected and evicted in O(1) (one map lookup, no `retain`).
 struct CacheEntry {
+    mtime: SystemTime,
     outline: Arc<str>,
 }
 
@@ -21,15 +22,22 @@ pub struct ParsedFile {
     pub lang: Lang,
 }
 
-/// Outline cache keyed by (canonical path, mtime). If the file changes,
-/// mtime changes and the old entry is never hit again.
+/// Cached parsed entry keyed by path.
+struct ParsedEntry {
+    mtime: SystemTime,
+    file: Arc<ParsedFile>,
+}
+
+/// Outline cache keyed by canonical path. Eviction is O(1): on every access
+/// the stored `mtime` is compared to the caller-supplied value; a mismatch
+/// replaces the entry without scanning the whole map.
 ///
 /// Stores two derived analyses: rendered outline strings (used by search
 /// formatting) and parsed tree-sitter trees (used by AST scope queries).
 /// Both share the same key + invalidation; nothing else is shared.
 pub struct OutlineCache {
-    entries: DashMap<(PathBuf, SystemTime), CacheEntry>,
-    parsed: DashMap<(PathBuf, SystemTime), Arc<ParsedFile>>,
+    entries: DashMap<PathBuf, CacheEntry>,
+    parsed: DashMap<PathBuf, ParsedEntry>,
 }
 
 impl Default for OutlineCache {
@@ -48,23 +56,29 @@ impl OutlineCache {
     }
 
     /// Get cached outline or compute and cache it. Accepts `&Path` (not `&PathBuf`).
-    /// Uses `entry()` API to avoid TOCTOU race between get and insert.
     pub fn get_or_compute(
         &self,
         path: &Path,
         mtime: SystemTime,
         compute: impl FnOnce() -> String,
     ) -> Arc<str> {
-        match self.entries.entry((path.to_path_buf(), mtime)) {
-            Entry::Occupied(e) => Arc::clone(&e.get().outline),
-            Entry::Vacant(e) => {
-                let outline: Arc<str> = compute().into();
-                e.insert(CacheEntry {
-                    outline: Arc::clone(&outline),
-                });
-                outline
+        let key = path.to_path_buf();
+        // Fast path: entry exists and mtime matches.
+        if let Some(e) = self.entries.get(&key) {
+            if e.mtime == mtime {
+                return Arc::clone(&e.outline);
             }
         }
+        // Stale or absent — compute and insert, replacing any stale entry.
+        let outline: Arc<str> = compute().into();
+        self.entries.insert(
+            key,
+            CacheEntry {
+                mtime,
+                outline: Arc::clone(&outline),
+            },
+        );
+        outline
     }
 
     /// Parse a code file with tree-sitter and cache the result. Returns
@@ -77,25 +91,60 @@ impl OutlineCache {
         if meta.len() > 500_000 {
             return None;
         }
-        match self.parsed.entry((path.to_path_buf(), mtime)) {
-            Entry::Occupied(e) => Some(Arc::clone(e.get())),
-            Entry::Vacant(e) => {
-                let crate::types::FileType::Code(lang) = crate::lang::detect_file_type(path) else {
-                    return None;
-                };
-                let ts_lang = crate::lang::outline::outline_language(lang)?;
-                let content = std::fs::read_to_string(path).ok()?;
-                let mut parser = tree_sitter::Parser::new();
-                parser.set_language(&ts_lang).ok()?;
-                let tree = parser.parse(&content, None)?;
-                let parsed = Arc::new(ParsedFile {
-                    content: Arc::new(content),
-                    tree,
-                    lang,
-                });
-                e.insert(Arc::clone(&parsed));
-                Some(parsed)
+        let key = path.to_path_buf();
+        // Fast path: entry exists and mtime matches.
+        if let Some(e) = self.parsed.get(&key) {
+            if e.mtime == mtime {
+                return Some(Arc::clone(&e.file));
             }
         }
+        // Stale or absent — parse and insert.
+        let crate::types::FileType::Code(lang) = crate::lang::detect_file_type(path) else {
+            return None;
+        };
+        let ts_lang = crate::lang::outline::outline_language(lang)?;
+        let content = std::fs::read_to_string(path).ok()?;
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&ts_lang).ok()?;
+        let tree = parser.parse(&content, None)?;
+        let file = Arc::new(ParsedFile {
+            content: Arc::new(content),
+            tree,
+            lang,
+        });
+        self.parsed.insert(
+            key,
+            ParsedEntry {
+                mtime,
+                file: Arc::clone(&file),
+            },
+        );
+        Some(file)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{Duration, SystemTime};
+
+    #[test]
+    fn evicts_stale_mtime_on_reinsert() {
+        let cache = OutlineCache::new();
+        let path = std::path::Path::new("fake/path.rs");
+        let t0 = SystemTime::UNIX_EPOCH;
+        let t1 = t0 + Duration::from_secs(1);
+
+        // Insert with t0.
+        cache.get_or_compute(path, t0, || "outline v0".to_string());
+        assert_eq!(cache.entries.len(), 1);
+
+        // Re-insert with t1 — stale t0 entry must be evicted.
+        cache.get_or_compute(path, t1, || "outline v1".to_string());
+        assert_eq!(cache.entries.len(), 1, "stale entry was not evicted");
+
+        // Confirm only the new entry survives.
+        let hit = cache.get_or_compute(path, t1, || panic!("should hit cache"));
+        assert_eq!(&*hit, "outline v1");
     }
 }

--- a/src/edit.rs
+++ b/src/edit.rs
@@ -217,7 +217,10 @@ fn apply_edits(path: &Path, edits: &[Edit]) -> Result<EditResult, TilthError> {
         output.push_str(line_sep);
     }
 
-    fs::write(path, &output).map_err(|e| TilthError::IoError {
+    // Write atomically: temp file in the same directory, then rename so a
+    // crash or full-disk mid-write never corrupts the original. Permissions
+    // on the temp are set to match the original before rename.
+    crate::util::atomic_write_bytes(path, output.as_bytes()).map_err(|e| TilthError::IoError {
         path: path.to_path_buf(),
         source: e,
     })?;

--- a/src/install.rs
+++ b/src/install.rs
@@ -202,7 +202,7 @@ fn upsert_toml_section(existing: &str, header: &str, section: &str) -> String {
 /// comments). Returns `rest.len()` when no following header exists.
 fn toml_section_end(rest: &str) -> usize {
     let bytes = rest.as_bytes();
-    let mut depth: i32 = 0;
+    let mut depth: u32 = 0;
     let mut in_str: Option<u8> = None;
     let mut escaped = false;
     let mut at_line_start = true;
@@ -245,7 +245,7 @@ fn toml_section_end(rest: &str) -> usize {
                 at_line_start = false;
             }
             b']' => {
-                depth -= 1;
+                depth = depth.saturating_sub(1);
                 at_line_start = false;
             }
             _ if c.is_ascii_whitespace() => {}
@@ -669,6 +669,28 @@ mod tests {
         assert_eq!(
             out, "[mcp_servers.tilth]\ncommand = \"new\"\n[other]\nk = 1\n",
             "section end was truncated by a value line starting with '[': {out:?}"
+        );
+    }
+
+    #[test]
+    fn toml_section_end_unmatched_bracket_does_not_go_negative() {
+        // An unmatched ']' in a hand-edited config must not drive depth negative
+        // and must not truncate the rewritten section.
+        let existing = "[mcp_servers.tilth]\ncommand = \"old\"\nbad = ]\n[other]\nk = 1\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"new\"\n",
+        );
+        // The [other] table must still be present — section must not be truncated
+        // by a depth that went negative on the unmatched ']'.
+        assert!(
+            out.contains("[other]"),
+            "[other] was lost — unmatched ']' drove depth negative: {out:?}"
+        );
+        assert!(
+            out.contains("command = \"new\""),
+            "new section not written: {out:?}"
         );
     }
 

--- a/src/install.rs
+++ b/src/install.rs
@@ -100,6 +100,13 @@ pub fn run(host: &str, edit: bool) -> Result<(), String> {
     Ok(())
 }
 
+/// Write `content` to `path` atomically: write to a sibling temp file first,
+/// then rename over the target so an interrupted write never truncates `path`.
+fn atomic_write(path: &std::path::Path, content: &str) -> Result<(), String> {
+    crate::util::atomic_write_bytes(path, content.as_bytes())
+        .map_err(|e| format!("failed to write {}: {e}", path.display()))
+}
+
 fn write_json_config(host_info: &HostInfo, edit: bool) -> Result<(), String> {
     let servers_key = match host_info.format {
         ConfigFormat::Json { servers_key } | ConfigFormat::JsonLocal { servers_key } => servers_key,
@@ -123,8 +130,7 @@ fn write_json_config(host_info: &HostInfo, edit: bool) -> Result<(), String> {
 
     let out =
         serde_json::to_string_pretty(&config).expect("serde_json::Value is always serializable");
-    fs::write(&host_info.path, &out)
-        .map_err(|e| format!("failed to write {}: {e}", host_info.path.display()))?;
+    atomic_write(&host_info.path, &out)?;
     Ok(())
 }
 
@@ -152,8 +158,7 @@ fn write_toml_config(host_info: &HostInfo, edit: bool) -> Result<(), String> {
 
     let output = upsert_toml_section(&existing, "[mcp_servers.tilth]", &section);
 
-    fs::write(&host_info.path, &output)
-        .map_err(|e| format!("failed to write {}: {e}", host_info.path.display()))?;
+    atomic_write(&host_info.path, &output)?;
     Ok(())
 }
 
@@ -185,10 +190,70 @@ fn upsert_toml_section(existing: &str, header: &str, section: &str) -> String {
     };
 
     let rest = &existing[start..];
-    let end = rest[1..] // skip the opening '['
-        .find("\n[")
-        .map_or(existing.len(), |i| start + 1 + i + 1);
+    let end = start + toml_section_end(rest);
     format!("{}{}{}", &existing[..start], section, &existing[end..])
+}
+
+/// Byte offset (within `rest`, which starts at the current table header) of the
+/// next top-level table header — a line-start `[` at array-bracket depth 0 and
+/// outside any string. A bare "line starts with `[`" test cannot distinguish a
+/// real header `[other]` from a multi-line array element like `["a", "b"],`, so
+/// we track bracket nesting (skipping bracket characters inside strings and
+/// comments). Returns `rest.len()` when no following header exists.
+fn toml_section_end(rest: &str) -> usize {
+    let bytes = rest.as_bytes();
+    let mut depth: i32 = 0;
+    let mut in_str: Option<u8> = None;
+    let mut escaped = false;
+    let mut at_line_start = true;
+    let mut past_header_line = false;
+    let mut i = 0;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if let Some(quote) = in_str {
+            if escaped {
+                escaped = false;
+            } else if c == b'\\' && quote == b'"' {
+                escaped = true;
+            } else if c == quote {
+                in_str = None;
+            }
+            at_line_start = false;
+            i += 1;
+            continue;
+        }
+        match c {
+            b'\n' => {
+                at_line_start = true;
+                past_header_line = true;
+            }
+            b'#' => {
+                while i < bytes.len() && bytes[i] != b'\n' {
+                    i += 1;
+                }
+                continue;
+            }
+            b'"' | b'\'' => {
+                in_str = Some(c);
+                at_line_start = false;
+            }
+            b'[' => {
+                if at_line_start && depth == 0 && past_header_line {
+                    return i;
+                }
+                depth += 1;
+                at_line_start = false;
+            }
+            b']' => {
+                depth -= 1;
+                at_line_start = false;
+            }
+            _ if c.is_ascii_whitespace() => {}
+            _ => at_line_start = false,
+        }
+        i += 1;
+    }
+    rest.len()
 }
 
 /// Returns (command, args) for the tilth MCP server entry.
@@ -588,6 +653,22 @@ mod tests {
         assert_eq!(
             out,
             "[mcp_servers.tilth]\ncommand = \"new\"\nargs = [\"new\"]\n[other]\nk = 1\n"
+        );
+    }
+
+    #[test]
+    fn toml_section_end_not_truncated_by_value_starting_with_bracket() {
+        // A value line that starts with '[' (array-of-arrays element) must NOT
+        // be treated as a table header when finding the section end.
+        let existing = "[mcp_servers.tilth]\ncommand = \"old\"\nmatrix = [\n[\"a\", \"b\"],\n[\"c\"],\n]\n[other]\nk = 1\n";
+        let out = upsert_toml_section(
+            existing,
+            TILTH_HEADER,
+            "[mcp_servers.tilth]\ncommand = \"new\"\n",
+        );
+        assert_eq!(
+            out, "[mcp_servers.tilth]\ncommand = \"new\"\n[other]\nk = 1\n",
+            "section end was truncated by a value line starting with '[': {out:?}"
         );
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ pub(crate) mod search;
 pub(crate) mod session;
 pub(crate) mod timeout;
 pub(crate) mod types;
+pub(crate) mod util;
 
 /// Re-exports for the fuzz harness. Not stable; do not depend on this.
 /// Items here are only `pub` so `fuzz/fuzz_targets/*.rs` can reach them

--- a/src/util.rs
+++ b/src/util.rs
@@ -12,7 +12,13 @@ use std::sync::atomic::{AtomicU64, Ordering};
 pub(crate) fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    // `Path::new("foo.txt").parent()` returns `Some("")`, not `None`; treat an
+    // empty parent as "no directory" so the temp file anchors to "." rather than
+    // the empty-string path.
+    let dir = path
+        .parent()
+        .filter(|p| !p.as_os_str().is_empty())
+        .unwrap_or_else(|| Path::new("."));
     let tmp = dir.join(format!(".tilth-tmp.{}.{n}", std::process::id()));
     std::fs::write(&tmp, bytes).inspect_err(|_| {
         let _ = std::fs::remove_file(&tmp);

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,0 +1,29 @@
+//! Shared utilities used by both `edit` and `install`.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// Write `bytes` to `path` atomically: write to a temp file in the same
+/// directory, preserve the original file's permissions (if it exists), then
+/// rename into place. A crash mid-write leaves the original intact.
+///
+/// The temp name is qualified with the process ID and a process-wide counter
+/// so concurrent or batched writes in the same directory can't collide.
+pub(crate) fn atomic_write_bytes(path: &Path, bytes: &[u8]) -> std::io::Result<()> {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let tmp = dir.join(format!(".tilth-tmp.{}.{n}", std::process::id()));
+    std::fs::write(&tmp, bytes).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })?;
+    // Preserve original file permissions so the rename doesn't widen or strip
+    // the mode. Ignore errors — target may not exist yet or platform may not
+    // support it; the write already succeeded.
+    if let Ok(meta) = std::fs::metadata(path) {
+        let _ = std::fs::set_permissions(&tmp, meta.permissions());
+    }
+    std::fs::rename(&tmp, path).inspect_err(|_| {
+        let _ = std::fs::remove_file(&tmp);
+    })
+}


### PR DESCRIPTION
Two durability/correctness fixes plus a small TOML-scan fix:

1. **Bounded cache eviction.** `OutlineCache` is rekeyed from `(PathBuf, SystemTime)` to `PathBuf`, with the mtime moved into the value. Inserting a new mtime now replaces the prior entry in place, bounding the cache to one entry per live path — the old keying never evicted stale-mtime entries, so the cache grew unbounded as files changed. The lookup reference is also scoped to its block so no `DashMap` reference is held across the insert (defensive hardening of the guard lifetime).
2. **Atomic file writes.** Writes in `edit` and `install` go through a shared `util::atomic_write_bytes`: write to a collision-free temp file in the same directory, copy the original file's permissions onto the temp, then atomically rename over the target. A crash mid-write can no longer leave a truncated file.
3. **TOML section scan.** `toml_section_end` uses a bracket-depth scan that is correct for multibyte content, comments, array-of-tables headers, and single-quoted strings, replacing a bare `"\n["` search.

Adds tests for stale-mtime eviction and the TOML value-with-bracket case.

Ported from paulnsorensen/tilth (fork PR #70).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
