### PR TITLE
fix(search): Go stdlib classification, fixture penalty, footer dedup

### DIFF
--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -418,15 +418,11 @@ pub fn search_callers_expanded(
                     );
                 }
 
-                let _ = writeln!(output, "\n{} functions affected across 2 hops.", {
-                    // Dedup hop-1 by calling_function for a distinct-function count.
-                    let hop1_fns: std::collections::HashSet<&str> = sorted_callers
-                        .iter()
-                        .filter(|c| c.calling_function != "<top-level>")
-                        .map(|c| c.calling_function.as_str())
-                        .collect();
-                    hop1_fns.len() + unique_total
-                });
+                let _ = writeln!(
+                    output,
+                    "\n{} functions affected across 2 hops.",
+                    all_caller_names.len() + unique_total
+                );
             }
         }
     }
@@ -546,6 +542,60 @@ mod tests {
         assert!(
             msg.contains("test files"),
             "glob-driven hint should appear when glob is Some: {msg}"
+        );
+    }
+    /// Regression test: when there are more than MAX_MATCHES (10) hop-1 call
+    /// sites but still <= IMPACT_FANOUT_THRESHOLD unique callers, the footer
+    /// "N functions affected across 2 hops" must use the pre-truncation unique
+    /// count, not the post-truncation count.
+    ///
+    /// Setup: 8 unique functions, each calling `target_fn` twice = 16 call
+    /// sites. Truncation to MAX_MATCHES=10 only keeps the first ~5 functions,
+    /// dropping functions 6-8. The old code rebuilt the hop-1 set from
+    /// sorted_callers AFTER truncation and undercounted. The fix uses
+    /// all_caller_names (pre-truncation) which always holds 8.
+    #[test]
+    fn footer_count_uses_pre_truncation_caller_set() {
+        let dir = tempfile::tempdir().unwrap();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+
+        // 8 files: each declares one function that calls `target_fn` twice.
+        // Total: 16 call sites from 8 unique caller names.
+        // One hop-2 file calls caller_a_0 so the 2nd-hop block fires.
+        for i in 0..8usize {
+            let content = format!(
+                "fn target_fn() {{}}\
+                \nfn caller_a_{i}() {{ target_fn(); target_fn(); }}\
+                \n"
+            );
+            std::fs::write(dir.path().join(format!("f{i}.rs")), content).unwrap();
+        }
+        std::fs::write(
+            dir.path().join("hop2.rs"),
+            "fn hop2_fn() { caller_a_0(); }\n",
+        )
+        .unwrap();
+
+        let result =
+            search_callers_expanded("target_fn", dir.path(), &bloom, 0, None, None, false).unwrap();
+
+        let footer_line = result
+            .lines()
+            .find(|l| l.contains("functions affected across 2 hops"))
+            .unwrap_or_else(|| panic!("footer line missing from output:\n{result}"));
+
+        let reported: usize = footer_line
+            .split_whitespace()
+            .next()
+            .unwrap()
+            .parse()
+            .unwrap_or_else(|_| panic!("footer count not a number: {footer_line}"));
+
+        // hop-1 = 8 (all_caller_names, pre-truncation); hop-2 = 1 (hop2_fn → caller_a_0).
+        assert_eq!(
+            reported, 9,
+            "footer reported {reported} but expected exactly 9 (8 hop-1 + 1 hop-2); \
+             old post-truncation rebuild would undercount: {footer_line}"
         );
     }
 }

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -418,22 +418,25 @@ pub fn search_callers_expanded(
                     );
                 }
 
-                let _ = writeln!(
-                    output,
-                    "\n{} functions affected across 2 hops.",
-                    sorted_callers.len() + count
-                );
+                let _ = writeln!(output, "\n{} functions affected across 2 hops.", {
+                    // Dedup hop-1 by calling_function for a distinct-function count.
+                    let hop1_fns: std::collections::HashSet<&str> = sorted_callers
+                        .iter()
+                        .filter(|c| c.calling_function != "<top-level>")
+                        .map(|c| c.calling_function.as_str())
+                        .collect();
+                    hop1_fns.len() + unique_total
+                });
             }
         }
     }
 
     let tokens = crate::types::estimate_tokens(output.len() as u64);
-    let token_str = if tokens >= 1000 {
-        format!("~{}.{}k", tokens / 1000, (tokens % 1000) / 100)
-    } else {
-        format!("~{tokens}")
-    };
-    let _ = write!(output, "\n\n({token_str} tokens)");
+    let _ = write!(
+        output,
+        "\n\n({} tokens)",
+        crate::search::format_token_count(tokens)
+    );
     Ok(output)
 }
 

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -364,6 +364,57 @@ fn is_placeholder_name(name: &str) -> bool {
     false
 }
 
+/// Root (first `/`-segment) of each Go stdlib package. A Go import is stdlib
+/// when its first path segment is one of these — covering both single-segment
+/// (`fmt`) and multi-segment (`net/http`, `encoding/json`) forms. Matching the
+/// root (not the whole path) avoids misclassifying a local package like
+/// `mypackage` while still suppressing the noisy multi-segment stdlib paths.
+const GO_STDLIB_ROOTS: &[&str] = &[
+    "archive",
+    "bufio",
+    "bytes",
+    "cmp",
+    "compress",
+    "container",
+    "context",
+    "crypto",
+    "database",
+    "debug",
+    "embed",
+    "encoding",
+    "errors",
+    "flag",
+    "fmt",
+    "go",
+    "hash",
+    "html",
+    "image",
+    "index",
+    "io",
+    "log",
+    "maps",
+    "math",
+    "mime",
+    "net",
+    "os",
+    "path",
+    "plugin",
+    "reflect",
+    "regexp",
+    "runtime",
+    "slices",
+    "sort",
+    "strconv",
+    "strings",
+    "sync",
+    "syscall",
+    "testing",
+    "text",
+    "time",
+    "unicode",
+    "unsafe",
+];
+
 /// Returns true if the import source is a standard library module.
 /// Agents can't navigate into stdlib — showing these is noise.
 fn is_stdlib(source: &str, lang: crate::types::Lang) -> bool {
@@ -402,7 +453,7 @@ fn is_stdlib(source: &str, lang: crate::types::Lang) -> bool {
                     | "asyncio"
             )
         }
-        Lang::Go => source.starts_with("fmt") || !source.contains('.'),
+        Lang::Go => GO_STDLIB_ROOTS.contains(&source.split('/').next().unwrap_or(source)),
         _ => false,
     }
 }
@@ -579,4 +630,74 @@ fn assemble(parts: &[&str]) -> String {
         .copied()
         .collect::<Vec<_>>()
         .join("\n\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn go_stdlib_fmt_is_stdlib() {
+        assert!(is_stdlib("fmt", crate::types::Lang::Go));
+    }
+
+    #[test]
+    fn go_stdlib_fmtlib_is_not_stdlib() {
+        // "fmtlib" is not a Go stdlib package—previously matched via starts_with("fmt")
+        assert!(!is_stdlib("fmtlib", crate::types::Lang::Go));
+    }
+
+    #[test]
+    fn go_stdlib_fmtutil_is_not_stdlib() {
+        assert!(!is_stdlib("fmtutil", crate::types::Lang::Go));
+    }
+
+    #[test]
+    fn go_stdlib_multi_segment_paths_are_stdlib() {
+        // Regression: multi-segment stdlib imports (single-line form
+        // `import "net/http"`) must classify as stdlib via their root segment.
+        // The exact-match allowlist briefly regressed these to "external".
+        for path in [
+            "net/http",
+            "encoding/json",
+            "path/filepath",
+            "crypto/sha256",
+            "text/template",
+            "container/list",
+            "database/sql",
+        ] {
+            assert!(
+                is_stdlib(path, crate::types::Lang::Go),
+                "{path} should be classified as Go stdlib"
+            );
+        }
+    }
+
+    #[test]
+    fn go_local_multi_segment_path_is_not_stdlib() {
+        // A local/third-party multi-segment package whose root isn't stdlib.
+        assert!(!is_stdlib("mypackage/sub", crate::types::Lang::Go));
+    }
+
+    #[test]
+    fn go_local_package_without_dot_is_not_stdlib() {
+        // A local package like "mypackage" has no dot but is NOT stdlib—
+        // the old !source.contains('.') rule wrongly classified it as stdlib.
+        assert!(!is_stdlib("mypackage", crate::types::Lang::Go));
+    }
+
+    #[test]
+    fn go_external_dotted_path_is_not_stdlib() {
+        assert!(!is_stdlib(
+            "github.com/gin-gonic/gin",
+            crate::types::Lang::Go
+        ));
+    }
+
+    #[test]
+    fn go_stdlib_cmp_and_maps_are_stdlib() {
+        // Go 1.21+ added `cmp` and `maps` to the standard library.
+        assert!(is_stdlib("cmp", crate::types::Lang::Go));
+        assert!(is_stdlib("maps", crate::types::Lang::Go));
+    }
 }

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -413,6 +413,9 @@ const GO_STDLIB_ROOTS: &[&str] = &[
     "time",
     "unicode",
     "unsafe",
+    // Go 1.23+ additions
+    "iter",
+    "unique",
 ];
 
 /// Returns true if the import source is a standard library module.

--- a/src/search/facets.rs
+++ b/src/search/facets.rs
@@ -19,7 +19,7 @@ pub fn facet_matches(matches: Vec<Match>, _scope: &Path) -> FacetedResult {
         .iter()
         .find(|m| m.is_definition)
         .and_then(|m| m.path.parent())
-        .and_then(package_root)
+        .and_then(crate::lang::package_root)
         .map(std::path::Path::to_path_buf);
 
     let mut definitions = Vec::new();
@@ -84,11 +84,6 @@ fn is_same_package(path: &Path, primary_pkg: Option<&PathBuf>) -> bool {
     };
 
     path.parent()
-        .and_then(package_root)
+        .and_then(crate::lang::package_root)
         .is_some_and(|p| p == pkg_root.as_path())
-}
-
-/// Re-export from lang module.
-fn package_root(path: &Path) -> Option<&Path> {
-    crate::lang::package_root(path)
 }

--- a/src/search/grok.rs
+++ b/src/search/grok.rs
@@ -727,6 +727,9 @@ fn is_recursive_call_site(
     canonical_target: &Path,
     target: &ResolvedTarget,
 ) -> bool {
+    // Edge case: a legitimately distinct same-named call site nested inside the
+    // target body (e.g. a recursive closure with the same name) would also be
+    // filtered here. Acceptable tradeoff — true self-recursion is the common case.
     m.path == canonical_target
         && m.line >= target.start_line
         && m.line <= target.end_line

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -830,6 +830,15 @@ fn find_basename_candidate(matches: &[Match], query_lower: &str) -> Option<PathB
     candidate.map(Path::to_path_buf)
 }
 
+/// Format a token count into a human-readable string (e.g. "~1.2k" or "~743").
+pub(crate) fn format_token_count(tokens: u64) -> String {
+    if tokens >= 1000 {
+        format!("~{}.{}k", tokens / 1000, (tokens % 1000) / 100)
+    } else {
+        format!("~{tokens}")
+    }
+}
+
 /// Fallback: lightweight directory walk to find a basename-matching file
 /// when it didn't survive ranking/truncation in the match set.
 fn find_basename_fallback(scope: &Path, query_lower: &str) -> Option<PathBuf> {
@@ -1092,11 +1101,7 @@ fn format_search_result(
     }
 
     let tokens = estimate_tokens(out.len() as u64);
-    let token_str = if tokens >= 1000 {
-        format!("~{}.{}k", tokens / 1000, (tokens % 1000) / 100)
-    } else {
-        format!("~{tokens}")
-    };
+    let token_str = format_token_count(tokens);
     let _ = write!(out, "\n\n({token_str} tokens)");
 
     Ok(out)

--- a/src/search/rank.rs
+++ b/src/search/rank.rs
@@ -409,10 +409,15 @@ fn non_code_penalty(path: &Path) -> i32 {
     let is_docs = ext == "md" || ext == "mdx" || ext == "txt" || ext == "rst" || has_docs_component;
 
     let path_str = path.to_string_lossy();
-    let is_config_example = (path_str.contains("example")
-        || path_str.contains("sample")
-        || path_str.contains("template"))
-        && (ext == "md" || ext == "txt" || ext == "rst");
+    let has_example_component = path.components().any(|c| {
+        c.as_os_str().to_str().is_some_and(|s| {
+            matches!(
+                s,
+                "example" | "examples" | "sample" | "samples" | "template" | "templates"
+            )
+        })
+    });
+    let is_config_example = has_example_component && (ext == "md" || ext == "txt" || ext == "rst");
 
     let is_generated = path_str.contains("generated");
 
@@ -850,5 +855,19 @@ mod tests {
             "/repo/build/output.js"
         )));
         assert!(!super::is_vendor_path(&PathBuf::from("/repo/src/auth.rs")));
+    }
+    #[test]
+    fn non_code_penalty_example_substring_not_penalized() {
+        // `examples_parser.rs` contains "example" as a substring but NOT as a
+        // standalone path component — must not be penalized (mirrors fixture_penalty fix).
+        let path = PathBuf::from("/repo/src/examples_parser.rs");
+        assert_eq!(super::non_code_penalty(&path), 0);
+    }
+
+    #[test]
+    fn non_code_penalty_example_component_penalized() {
+        // `examples/guide.md` has "examples" as a path component AND a doc ext.
+        let path = PathBuf::from("/repo/examples/guide.md");
+        assert!(super::non_code_penalty(&path) > 0);
     }
 }

--- a/src/search/rank.rs
+++ b/src/search/rank.rs
@@ -24,7 +24,7 @@ pub fn sort(matches: &mut [Match], query: &str, scope: &Path, context: Option<&P
     // Pre-compute context's package root once (same for entire batch)
     let ctx_parent = context.and_then(|c| c.parent());
     let ctx_pkg_root = context
-        .and_then(package_root)
+        .and_then(crate::lang::package_root)
         .map(std::path::Path::to_path_buf);
 
     // Cache package roots for match paths — avoids repeated stat walks
@@ -183,9 +183,9 @@ fn context_proximity(
             Some(d) => d.to_path_buf(),
             None => return score,
         };
-        let match_root = pkg_cache
-            .entry(match_dir)
-            .or_insert_with_key(|dir| package_root(dir).map(std::path::Path::to_path_buf));
+        let match_root = pkg_cache.entry(match_dir).or_insert_with_key(|dir| {
+            crate::lang::package_root(dir).map(std::path::Path::to_path_buf)
+        });
         if let Some(ref mr) = match_root {
             if mr == cp_root {
                 score += 75;
@@ -277,21 +277,35 @@ fn exported_api_boost(m: &Match) -> i32 {
     }
 }
 
-/// Penalize matches in test fixtures, mocks, stubs, etc. Capped at 200.
+/// Penalize matches in test fixtures, mocks, stubs, etc. Returns 90 for a path
+/// with a fixture component, else 0.
 fn fixture_penalty(m: &Match) -> i32 {
-    let path = m.path.to_string_lossy().to_ascii_lowercase();
-    let text = m.text.to_ascii_lowercase();
+    // Anchor path matching to a PATH COMPONENT to avoid false positives like
+    // `examples_parser.rs` being penalized because "examples" is a substring.
+    let has_fixture_component = m.path.components().any(|c| {
+        c.as_os_str().to_str().is_some_and(|s| {
+            let s = s.to_ascii_lowercase();
+            matches!(
+                s.as_str(),
+                "mock"
+                    | "mocks"
+                    | "fixture"
+                    | "fixtures"
+                    | "stub"
+                    | "stubs"
+                    | "fake"
+                    | "fakes"
+                    | "example"
+                    | "examples"
+            )
+        })
+    });
 
-    let mut score = 0;
-    for needle in ["mock", "fixture", "stub", "fake", "example"] {
-        if path.contains(needle) {
-            score += 90;
-        }
-        if text.contains(needle) {
-            score += 40;
-        }
+    if has_fixture_component {
+        90
+    } else {
+        0
     }
-    score.min(200)
 }
 
 /// Penalize matches that appear only in comments (not code).
@@ -346,7 +360,11 @@ fn multi_word_boost(m: &Match, query: &str) -> i32 {
         return 0;
     }
 
-    let words: Vec<&str> = query.split_whitespace().collect();
+    let words: Vec<String> = query
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| !w.is_empty())
+        .map(str::to_ascii_lowercase)
+        .collect();
     if words.len() < 2 {
         return 0;
     }
@@ -355,9 +373,15 @@ fn multi_word_boost(m: &Match, query: &str) -> i32 {
     let text_lower = m.text.to_ascii_lowercase();
     let haystack = format!("{path_lower} {text_lower}");
 
+    // Whole-word matching: split haystack on non-alphanumeric boundaries so
+    // short words like "in" or "to" don't match unrelated substrings.
+    let haystack_words: Vec<&str> = haystack
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|w| !w.is_empty())
+        .collect();
     let matched = words
         .iter()
-        .filter(|w| haystack.contains(&w.to_ascii_lowercase()))
+        .filter(|w| haystack_words.contains(&w.as_str()))
         .count();
 
     if matched == words.len() {
@@ -417,12 +441,6 @@ fn shared_prefix_depth(a: &Path, b: &Path) -> usize {
         .take_while(|(l, r)| l == r)
         .count()
 }
-
-/// Re-export from lang module to keep rank.rs self-contained.
-fn package_root(path: &Path) -> Option<&Path> {
-    crate::lang::package_root(path)
-}
-
 /// Check if path contains a vendor directory component.
 fn is_vendor_path(path: &Path) -> bool {
     path.components().any(|c| {
@@ -669,8 +687,9 @@ mod tests {
     }
 
     #[test]
-    fn fixture_penalty_capped_at_200() {
-        // A path hitting multiple needles should be capped
+    fn fixture_penalty_flags_fixture_component() {
+        // A path with one or more fixture components returns the flat 90 penalty
+        // (there is no longer a 200 cap — the max contributor is a single 90).
         let m = make_match(
             "/repo/src/fixtures/mock_stub_fake.ts",
             "example fixture mock stub fake",
@@ -678,11 +697,10 @@ mod tests {
             None,
         );
         let penalty = super::fixture_penalty(&m);
-        assert!(
-            penalty <= 200,
-            "fixture_penalty was {penalty}, expected <= 200"
+        assert_eq!(
+            penalty, 90,
+            "a fixture-component path must return the flat 90 penalty, got {penalty}"
         );
-        assert!(penalty > 0);
     }
 
     #[test]
@@ -693,6 +711,21 @@ mod tests {
             true,
             Some("handleAuth"),
         );
+        assert_eq!(super::fixture_penalty(&m), 0);
+    }
+
+    #[test]
+    fn fixture_penalty_examples_component_penalized() {
+        // `examples/` as a path COMPONENT should be penalized.
+        let m = make_match("/repo/examples/demo.rs", "fn main() {}", false, None);
+        assert!(super::fixture_penalty(&m) > 0);
+    }
+
+    #[test]
+    fn fixture_penalty_examples_substring_not_penalized() {
+        // `examples_parser.rs` contains "examples" as a substring but NOT as a
+        // standalone path component — must NOT be penalized.
+        let m = make_match("/repo/src/examples_parser.rs", "fn parse() {}", false, None);
         assert_eq!(super::fixture_penalty(&m), 0);
     }
 


### PR DESCRIPTION
Four search-ranking / classification fixes:

1. Go `is_stdlib` matches the first `/`-segment of an import path against `GO_STDLIB_ROOTS`, so `net/http` and `encoding/json` classify as stdlib; adds `cmp` / `maps` (Go 1.21+) and drops the spurious `http` / `utf8` roots.
2. `fixture_penalty` is anchored to a path *component* rather than a substring, so a file like `examples_parser.rs` is no longer penalized as a fixture.
3. `multi_word_boost` tokenizes the query on the same boundary rule as the haystack, so multi-word queries containing punctuation match symmetrically.
4. The callers hop-2 footer reports the uncapped unique total rather than the capped display count.

Note vs the fork original: the fork's `.tilthignore`-only walker change to `find_basename_fallback` is intentionally omitted — this upstream has no `.tilthignore` feature, so the existing ignore-source walker is kept unchanged.

Ported from paulnsorensen/tilth (fork PR #71).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
