### PR TITLE
feat: add landing page (GitHub Pages)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,7 @@ benchmark/fixtures/repos/
 benchmark/results/*.jsonl
 benchmark/results/*.md
 !benchmark/results/.gitkeep
+
+# Brand (petals) — pulled from the plotplot umbrella, kept local (never committed)
+.petalsrc
+.brand/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,901 @@
+<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>tilth — smart code reading for humans and AI agents</title>
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'><rect width='32' height='32' rx='7' fill='%231C1610'/><g stroke-linecap='round'><line x1='8' y1='9' x2='24' y2='9' stroke='%23403628' stroke-width='1.7'/><line x1='11' y1='15' x2='23' y2='15' stroke='%234E88A6' stroke-width='2.6'/><line x1='11' y1='20' x2='19' y2='20' stroke='%23403628' stroke-width='1.7'/><line x1='8' y1='25' x2='22' y2='25' stroke='%23403628' stroke-width='1.7'/></g><circle cx='8' cy='9' r='1.8' fill='%239A8C72'/><circle cx='11' cy='15' r='2.6' fill='%234E88A6'/></svg>">
+<meta name="description" content="tilth gives ripgrep, tree-sitter, and cat a shared brain: token-aware outlines, definition-first search, callers, blast-radius deps, and structural diff. Structural awareness in one call — and 40% less cost per correct answer across models.">
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400..700;1,9..144,400..600&family=Hanken+Grotesk:wght@400..800&family=JetBrains+Mono:wght@400;500;700&display=swap" rel="stylesheet">
+
+<style>
+/* ─────────────────────────────────────────────────────────────────────────
+   tilth landing page — set in the plotplot brand (v2.0.0). a plotplot garden tool.
+   Every value below resolves to .brand/ (palette, type, layout, surface, motion).
+   tilth's claimed accent is Sky #4E88A6 — "smart code reading for agents".
+   ───────────────────────────────────────────────────────────────────────── */
+:root {
+  /* shared family palette — colors.md */
+  --pp-primary:      #357E2C;
+  --pp-primary-deep: #2C6B2A;
+  --pp-leaf:         #4A9E3F;
+  --pp-forest:       #214A2C;
+  --pp-accent:       #4E88A6;   /* sky — tilth's bloom */
+  --pp-accent-ink:   #4E88A6;   /* sky as a word — labels, ink on paper */
+
+  --pp-text:         #3A2718;
+  --pp-text-soft:    #786148;
+  --pp-bg:           #FAF5E9;
+  --pp-bg-band:      #F2EAD6;
+  --pp-bg-artifact:  #FCFAF2;
+  --pp-surface:      #F5EEDD;
+  --pp-border:       #E2D8C0;
+
+  --pp-healthy: #46913C;
+  --pp-caution: #B0741C;
+  --pp-error:   #BC4126;
+  --pp-info:    #3F7186;
+  --pp-muted:   #9A8C72;
+
+  /* product blooms — for the garden footer only */
+  --pp-tilth:  #4E88A6;
+  --pp-tend:   #D6502F;
+  --pp-petals: #E588A0;
+  --pp-pleach: #97539B;
+  --pp-umbel:  #E89227;
+  --pp-copeca: #1F8A7B;
+
+  /* soil-night terminal — colors.md */
+  --pp-term-bg:      #1C1610;
+  --pp-term-surface: #262019;
+  --pp-term-border:  #403628;
+  --pp-term-green:   #84C56A;
+  --pp-term-sun:     #F2A93B;
+  --pp-term-sky:     #4E88A6;
+  --pp-term-text:    #F3ECD9;
+  --pp-term-soft:    #C9BBA0;
+
+  /* type — typography.md */
+  --font-heading: 'Fraunces', Georgia, serif;
+  --font-body:    'Hanken Grotesk', system-ui, sans-serif;
+  --font-code:    'JetBrains Mono', monospace;
+
+  /* radius — components.md */
+  --radius-xs: 3px; --radius-sm: 6px; --radius-md: 8px; --radius-lg: 10px; --radius-xl: 12px; --radius-full: 999px;
+
+  /* stroke — components.md */
+  --pp-stroke-hairline: 1px; --pp-stroke-emphasis: 1.5px; --pp-stroke-rule: 2px;
+
+  /* shadow — components.md (ink-tinted) */
+  --shadow-rest: 0 1px 0 #E2D8C0, 0 12px 40px -16px rgba(58,39,24,0.35);
+  --shadow-lift: 0 2px 4px rgba(58,39,24,0.05), 0 14px 32px rgba(58,39,24,0.08);
+  --shadow-float: 0 2px 6px rgba(58,39,24,0.07), 0 18px 44px rgba(58,39,24,0.12);
+
+  /* motion — components.md */
+  --ease-petal: cubic-bezier(0.22, 1, 0.36, 1);
+  --dur-unfold: 0.8s;
+  --dur-micro: 0.22s;
+
+  /* layout — layout.md */
+  --container: 1200px;
+  --gutter: 32px;
+}
+
+[data-theme="dark"] {
+  --pp-primary: #84C56A;
+  --pp-primary-deep: #9FD08A;
+  --pp-accent: #4E88A6;
+  --pp-accent-ink: #4E88A6;
+  --pp-leaf: #9FD08A;
+  --pp-text: #F3ECD9;
+  --pp-text-soft: #C9BBA0;
+  --pp-bg: #1C1610;
+  --pp-bg-band: #211A12;
+  --pp-bg-artifact: #211A12;
+  --pp-surface: #262019;
+  --pp-border: #403628;
+  --pp-muted: #C9BBA0;
+}
+
+*, *::before, *::after { box-sizing: border-box; }
+html { font-size: 18px; -webkit-text-size-adjust: 100%; scroll-behavior: smooth; }
+@media (max-width: 880px) { html { font-size: 17px; } }
+@media (max-width: 520px) { html { font-size: 16px; } }
+
+body {
+  margin: 0;
+  font-family: var(--font-body);
+  font-weight: 400;
+  font-size: 1.0625rem;
+  line-height: 1.65;
+  color: var(--pp-text);
+  background: var(--pp-bg);
+  -webkit-font-smoothing: antialiased;
+  transition: background var(--dur-micro) ease, color var(--dur-micro) ease;
+}
+
+h1, h2, h3, h4 { font-family: var(--font-heading); font-optical-sizing: auto; margin: 0; color: var(--pp-text); }
+h1 { font-size: clamp(3.2rem, 5.6vw, 4.4rem); line-height: 1.05; font-weight: 620; letter-spacing: -0.015em; }
+h2 { font-size: 2.4rem; line-height: 1.12; font-weight: 560; letter-spacing: -0.01em; }
+h3 { font-size: 1.6rem; line-height: 1.2; font-weight: 560; }
+h4 { font-size: 1.25rem; line-height: 1.3; font-weight: 560; }
+h1 em, h2 em { font-style: italic; font-weight: inherit; color: var(--pp-accent-ink); }
+p { margin: 0; }
+a { color: var(--pp-primary); text-decoration: none; }
+a:hover { color: var(--pp-primary-deep); }
+code { font-family: var(--font-code); font-size: 0.9em; }
+
+.container { max-width: var(--container); margin: 0 auto; padding: 0 var(--gutter); }
+section { padding: 112px 0; }
+@media (max-width: 880px) { section { padding: 80px 0; } }
+.band { background: var(--pp-bg-band); }
+
+.kicker {
+  font-family: var(--font-code); font-size: 0.8rem; font-weight: 500;
+  letter-spacing: 0.12em; text-transform: uppercase; color: var(--pp-accent-ink);
+  margin-bottom: 20px;
+}
+.lede { font-size: 1.3rem; line-height: 1.5; font-weight: 400; color: var(--pp-text-soft); max-width: 62ch; }
+.section-head { max-width: 66ch; margin-bottom: 56px; }
+.section-head p { margin-top: 16px; }
+
+:where(a, button, .btn, summary):focus-visible {
+  outline: 2px solid var(--pp-primary); outline-offset: 3px; border-radius: var(--radius-xs);
+}
+
+/* ── buttons — components.md conventions ── */
+.btn {
+  display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-body);
+  font-size: 1rem; font-weight: 600; padding: 12px 22px; border-radius: var(--radius-sm);
+  border: 1.5px solid transparent; cursor: pointer; transition: all var(--dur-micro) ease;
+  text-decoration: none; line-height: 1;
+}
+.btn-primary { background: var(--pp-primary); color: var(--pp-bg); }
+.btn-primary:hover { background: var(--pp-primary-deep); color: var(--pp-bg); transform: translateY(-1px); }
+.btn-primary:active { transform: translateY(0); }
+.btn-outline { background: transparent; border-color: var(--pp-primary); color: var(--pp-primary); }
+.btn-outline:hover { background: var(--pp-surface); }
+
+/* ── nav ── */
+header.nav {
+  position: sticky; top: 0; z-index: 50;
+  background: color-mix(in srgb, var(--pp-bg) 88%, transparent);
+  backdrop-filter: blur(8px); border-bottom: 1px solid var(--pp-border);
+}
+.nav-inner { display: flex; align-items: center; justify-content: space-between; height: 64px; }
+.brand { display: inline-flex; align-items: center; gap: 10px; font-weight: 700; font-size: 1.15rem; color: var(--pp-text); }
+.brand:hover { color: var(--pp-text); }
+.nav-links { display: flex; align-items: center; gap: 28px; }
+.nav-links a { color: var(--pp-text-soft); font-size: 0.95rem; font-weight: 500; }
+.nav-links a:hover { color: var(--pp-primary); }
+.nav-right { display: flex; align-items: center; gap: 16px; }
+.theme-toggle {
+  width: 34px; height: 34px; display: inline-grid; place-items: center;
+  border-radius: var(--radius-sm); border: 1px solid var(--pp-border);
+  background: var(--pp-surface); color: var(--pp-text-soft); cursor: pointer;
+}
+.theme-toggle:hover { color: var(--pp-primary); }
+@media (max-width: 880px) { .nav-links { display: none; } }
+
+/* ── hero ── */
+.hero { padding: 80px 0 72px; }
+.hero-grid { display: grid; grid-template-columns: 1.02fr 0.98fr; gap: 56px; align-items: center; }
+@media (max-width: 880px) { .hero-grid { grid-template-columns: 1fr; gap: 44px; } }
+.hero h1 { margin-bottom: 24px; }
+.hero .lede { margin-bottom: 32px; }
+.hero-cta { display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+.hero-note { margin-top: 18px; font-family: var(--font-code); font-size: 0.82rem; color: var(--pp-muted); }
+
+/* ── tilth motif figure ── */
+.tilth-fig { display: grid; gap: 16px; }
+.tilth-svg { width: 100%; height: auto; display: block; }
+
+/* ── terminal pane — components.md ── */
+.term {
+  background: var(--pp-term-bg); border: 1px solid var(--pp-term-border);
+  border-radius: var(--radius-md); box-shadow: var(--shadow-rest);
+  overflow: hidden; font-family: var(--font-code); font-size: 0.84rem; line-height: 1.6;
+}
+.term-bar { display: flex; align-items: center; gap: 7px; padding: 11px 14px; background: var(--pp-term-surface); border-bottom: 1px solid var(--pp-term-border); }
+.term-bar .dot { width: 11px; height: 11px; border-radius: 50%; }
+.term-bar .dot.r { background: var(--pp-error); }
+.term-bar .dot.y { background: var(--pp-caution); }
+.term-bar .dot.g { background: var(--pp-healthy); }
+.term-bar .title { margin-left: 8px; color: var(--pp-term-soft); font-size: 0.76rem; letter-spacing: 0.04em; }
+.term-body { padding: 18px 18px 20px; color: var(--pp-term-text); white-space: pre-wrap; }
+.term-body .pr  { color: var(--pp-term-sun); }
+.term-body .cmd { color: var(--pp-term-text); }
+.term-body .ok  { color: var(--pp-term-green); }
+.term-body .sk  { color: var(--pp-term-sky); }
+.term-body .dim { color: var(--pp-term-soft); }
+.term-body .hl  { color: var(--pp-term-sky); font-weight: 700; }
+.term-body .ar  { color: var(--pp-term-sky); }
+
+/* ── cards / grids ── */
+.grid { display: grid; gap: 24px; }
+.grid-2 { grid-template-columns: repeat(2, 1fr); }
+.grid-3 { grid-template-columns: repeat(3, 1fr); }
+@media (max-width: 880px) { .grid-2, .grid-3 { grid-template-columns: 1fr; } }
+.card {
+  background: var(--pp-surface); border: 1px solid var(--pp-border); border-radius: var(--radius-lg);
+  padding: 28px; transition: transform var(--dur-micro) ease, box-shadow var(--dur-micro) ease;
+}
+.card:hover { transform: translateY(-3px); box-shadow: var(--shadow-lift); }
+.card h4 { margin-bottom: 12px; }
+.card p { color: var(--pp-text-soft); font-size: 0.98rem; }
+.card .num { font-family: var(--font-code); font-size: 0.8rem; color: var(--pp-accent-ink); font-weight: 500; }
+
+/* ── verb cards (the tool surface) ── */
+.verbs { display: grid; grid-template-columns: repeat(3, 1fr); gap: 20px; margin-top: 8px; }
+@media (max-width: 880px) { .verbs { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 520px) { .verbs { grid-template-columns: 1fr; } }
+.verb {
+  background: var(--pp-bg-artifact); border: 1px solid var(--pp-border);
+  border-radius: var(--radius-md); padding: 22px;
+}
+.verb .cmd {
+  font-family: var(--font-code); font-size: 0.86rem; font-weight: 700; color: var(--pp-accent-ink);
+  display: block; margin-bottom: 8px;
+}
+.verb p { color: var(--pp-text-soft); font-size: 0.92rem; margin: 0; line-height: 1.55; }
+
+/* ── beats (how it reads) ── */
+.beats { display: grid; grid-template-columns: repeat(4, 1fr); gap: 24px; margin-top: 16px; }
+@media (max-width: 880px) { .beats { grid-template-columns: repeat(2, 1fr); } }
+@media (max-width: 520px) { .beats { grid-template-columns: 1fr; } }
+.beat { position: relative; border-top: 2px solid var(--pp-border); padding-top: 20px; }
+.beat::before { content: ""; position: absolute; top: -2px; left: 0; width: 36px; height: 2px; background: var(--pp-accent); }
+.beat .step { font-family: var(--font-code); font-size: 0.76rem; letter-spacing: 0.1em; text-transform: uppercase; color: var(--pp-accent-ink); }
+.beat .verbname { font-family: var(--font-code); font-weight: 700; color: var(--pp-primary); font-size: 1.3rem; margin-top: 8px; display: flex; align-items: baseline; gap: 8px; }
+.beat .verbname .seq { color: var(--pp-muted); font-weight: 400; font-size: 1rem; }
+.beat p { color: var(--pp-text-soft); font-size: 0.95rem; margin-top: 12px; }
+
+/* ── benchmark table ── */
+.bench-wrap {
+  background: var(--pp-surface); border: 1px solid var(--pp-border);
+  border-left: 3px solid var(--pp-accent); border-radius: var(--radius-lg);
+  padding: 8px 4px; margin-top: 40px; overflow-x: auto;
+}
+.bench { width: 100%; border-collapse: collapse; font-size: 0.95rem; min-width: 560px; }
+.bench th, .bench td { text-align: right; padding: 16px 20px; }
+.bench th:first-child, .bench td:first-child { text-align: left; }
+.bench thead th {
+  font-family: var(--font-code); font-size: 0.74rem; letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--pp-accent-ink); font-weight: 700; border-bottom: 1px solid var(--pp-border);
+}
+.bench tbody td { border-bottom: 1px solid var(--pp-border); color: var(--pp-text-soft); font-family: var(--font-code); }
+.bench tbody td:first-child { color: var(--pp-text); font-family: var(--font-body); font-weight: 600; }
+.bench tbody tr:last-child td { border-bottom: none; font-weight: 700; color: var(--pp-text); }
+.bench .delta { color: var(--pp-accent-ink); font-weight: 700; }
+.bench-note { margin-top: 16px; font-size: 0.92rem; color: var(--pp-text-soft); }
+
+/* ── what's inside ── */
+.langs { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+.lang {
+  font-family: var(--font-code); font-size: 0.82rem; color: var(--pp-text);
+  background: var(--pp-bg-artifact); border: 1px solid var(--pp-border);
+  border-radius: var(--radius-full); padding: 6px 14px;
+}
+.speed { width: 100%; border-collapse: collapse; font-size: 0.92rem; margin-top: 8px; }
+.speed th, .speed td { text-align: right; padding: 11px 16px; border-bottom: 1px solid var(--pp-border); }
+.speed th:first-child, .speed td:first-child { text-align: left; }
+.speed thead th { font-family: var(--font-code); font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--pp-accent-ink); }
+.speed td { color: var(--pp-text-soft); font-family: var(--font-code); }
+.speed td:first-child { color: var(--pp-text); font-family: var(--font-body); }
+
+/* ── decision table (how it decides) ── */
+.decide { width: 100%; border-collapse: collapse; font-size: 0.95rem; margin-top: 8px; }
+.decide th, .decide td { text-align: left; padding: 12px 16px; border-bottom: 1px solid var(--pp-border); }
+.decide thead th { font-family: var(--font-code); font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--pp-accent-ink); }
+.decide td:first-child { font-family: var(--font-code); color: var(--pp-text); width: 38%; }
+.decide td:last-child { color: var(--pp-text-soft); }
+
+/* ── hosts (MCP install targets) ── */
+.hosts { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 8px; }
+.host {
+  font-family: var(--font-code); font-size: 0.82rem; color: var(--pp-text-soft);
+  background: var(--pp-surface); border: 1px solid var(--pp-border);
+  border-radius: var(--radius-sm); padding: 7px 13px;
+}
+.host b { color: var(--pp-accent-ink); font-weight: 700; }
+
+/* ── two-column "for you" ── */
+.split { display: grid; grid-template-columns: 1fr 1fr; gap: 28px; }
+@media (max-width: 880px) { .split { grid-template-columns: 1fr; } }
+.split ul { list-style: none; margin: 16px 0 0; padding: 0; }
+.split li { padding: 9px 0 9px 28px; position: relative; color: var(--pp-text-soft); border-bottom: 1px solid var(--pp-border); }
+.split li::before { position: absolute; left: 0; top: 9px; font-family: var(--font-code); }
+.split .yes li::before { content: "\2192"; color: var(--pp-primary); }
+.split .no  li::before { content: "\00B7"; color: var(--pp-muted); font-weight: 700; }
+.split h3 .tag { font-family: var(--font-code); font-size: 0.7rem; letter-spacing: 0.06em; text-transform: uppercase; }
+
+/* ── install / status ── */
+.copyrow { display: flex; align-items: stretch; gap: 0; max-width: 520px; }
+.copyrow code {
+  flex: 1; font-family: var(--font-code); font-size: 0.92rem;
+  background: var(--pp-term-bg); color: var(--pp-term-text);
+  padding: 14px 18px; border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+  border: 1px solid var(--pp-term-border);
+}
+.copyrow button {
+  font-family: var(--font-body); font-weight: 600; font-size: 0.9rem; padding: 0 18px;
+  cursor: pointer; background: var(--pp-primary); color: var(--pp-bg);
+  border: none; border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+}
+.copyrow button:hover { background: var(--pp-primary-deep); }
+.copyrow-note { margin-top: 10px; font-family: var(--font-code); font-size: 0.82rem; color: var(--pp-muted); }
+.status-grid {
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: var(--pp-stroke-hairline);
+  background: var(--pp-border); border: 1px solid var(--pp-border);
+  border-radius: var(--radius-lg); overflow: hidden;
+}
+@media (max-width: 520px) { .status-grid { grid-template-columns: 1fr; } }
+.status-cell { background: var(--pp-bg-artifact); padding: 22px 24px; }
+.status-cell .label { font-family: var(--font-code); font-size: 0.72rem; letter-spacing: 0.06em; text-transform: uppercase; color: var(--pp-accent-ink); }
+.status-cell .val { font-family: var(--font-heading); font-size: 1.5rem; font-weight: 560; margin-top: 6px; }
+.status-cell .val small { font-family: var(--font-body); font-size: 0.85rem; color: var(--pp-text-soft); font-weight: 400; }
+
+/* ── code block ── */
+.code {
+  background: var(--pp-term-bg); border: 1px solid var(--pp-term-border); border-radius: var(--radius-md);
+  padding: 20px 22px; font-family: var(--font-code); font-size: 0.84rem; line-height: 1.7;
+  color: var(--pp-term-text); white-space: pre; overflow-x: auto; box-shadow: var(--shadow-rest);
+}
+.code .k  { color: var(--pp-term-sky); }
+.code .s  { color: var(--pp-term-green); }
+.code .c  { color: var(--pp-term-soft); }
+.code .hl { color: var(--pp-term-sun); }
+
+/* ── two-col layout (start section) ── */
+.face-layout { display: grid; grid-template-columns: 0.9fr 1.1fr; gap: 36px; align-items: start; }
+@media (max-width: 880px) { .face-layout { grid-template-columns: 1fr; gap: 24px; } }
+
+/* ── footer / garden ── */
+footer { background: var(--pp-forest); color: #F3ECD9; padding: 80px 0 48px; }
+footer a { color: #9FD08A; }
+footer a:hover { color: #FAF5E9; }
+footer h4 { color: #FAF5E9; font-size: 1.05rem; margin-bottom: 16px; }
+.gf-plot { display: flex; flex-wrap: wrap; align-items: center; gap: 12px 32px; padding-bottom: 28px; margin-bottom: 40px; border-bottom: var(--pp-stroke-hairline) solid rgba(250,245,233,0.12); }
+.gf-plotbrand { display: inline-flex; align-items: center; gap: 8px; }
+.gf-plotword { font-family: var(--font-heading); font-weight: 600; font-size: 1.45rem; letter-spacing: -0.01em; color: #FAF5E9; }
+.gf-plotmark { width: 28px; height: 28px; flex: none; }
+.ppm-stem { fill: none; stroke: #9FD08A; stroke-width: 2; stroke-linecap: round; }
+.ppm-leaf { fill: #9FD08A; }
+.ppm-bloom { fill: var(--pp-accent); }
+.gf-plotline { margin: 0; flex: 1; min-width: 18ch; color: #C9BBA0; font-size: 1rem; }
+.gf-plotlink { font-family: var(--font-code); font-size: 0.85rem; white-space: nowrap; }
+.foot-grid { display: grid; grid-template-columns: 1.3fr 1fr 1fr; gap: 40px; }
+@media (max-width: 880px) { .foot-grid { grid-template-columns: 1fr; gap: 32px; } }
+.garden { display: flex; flex-wrap: wrap; gap: 12px; margin-top: 4px; }
+.garden a {
+  display: inline-flex; align-items: center; gap: 8px; font-family: var(--font-code); font-size: 0.85rem;
+  padding: 8px 12px; border-radius: var(--radius-full); background: rgba(250,245,233,0.06); color: #F3ECD9;
+}
+.garden a:hover { background: rgba(250,245,233,0.12); color: #FAF5E9; }
+.garden a.current { background: rgba(78,136,166,0.24); }
+.garden .dot { width: 8px; height: 8px; border-radius: 50%; }
+.foot-soft { color: #C9BBA0; font-size: 0.92rem; line-height: 1.6; }
+.foot-bottom {
+  margin-top: 56px; padding-top: 24px; border-top: var(--pp-stroke-hairline) solid rgba(250,245,233,0.12);
+  display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap;
+  color: #C9BBA0; font-size: 0.85rem;
+}
+
+/* ── motion: things unfold (ease-petal). reduced-motion disables all. ── */
+.reveal { opacity: 0; transform: translateY(30px); }
+.revealed .reveal, .reveal.revealed { opacity: 1; transform: none; transition: opacity var(--dur-unfold) var(--ease-petal), transform var(--dur-unfold) var(--ease-petal); }
+.stagger > * { opacity: 0; transform: translateY(30px); }
+.stagger.revealed > * { opacity: 1; transform: none; transition: opacity var(--dur-unfold) var(--ease-petal), transform var(--dur-unfold) var(--ease-petal); }
+.stagger.revealed > *:nth-child(2) { transition-delay: 0.1s; }
+.stagger.revealed > *:nth-child(3) { transition-delay: 0.2s; }
+.stagger.revealed > *:nth-child(4) { transition-delay: 0.3s; }
+
+@media (prefers-reduced-motion: reduce) {
+  html { scroll-behavior: auto; }
+  .reveal, .stagger > * { opacity: 1 !important; transform: none !important; transition: none !important; }
+}
+</style>
+</head>
+<body>
+
+<!-- ═══ nav ═══ -->
+<header class="nav">
+  <div class="container nav-inner">
+    <a class="brand" href="#top" aria-label="tilth home">
+      <!--
+        tilth motif in miniature: a code outline reading as tilled soil rows.
+        Four rows of decreasing length (an outline's indentation), one row in sky
+        (the definition you were looking for), a line-range marker at the left gutter.
+      -->
+      <svg width="26" height="26" viewBox="0 0 26 26" aria-hidden="true" fill="none" stroke-linecap="round">
+        <line x1="4"  y1="6"  x2="22" y2="6"  stroke="var(--pp-text-soft)" stroke-width="1.6" opacity="0.5"/>
+        <line x1="7"  y1="11" x2="18" y2="11" stroke="var(--pp-accent)"    stroke-width="2.3"/>
+        <line x1="7"  y1="16" x2="14" y2="16" stroke="var(--pp-text-soft)" stroke-width="1.6" opacity="0.5"/>
+        <line x1="4"  y1="21" x2="20" y2="21" stroke="var(--pp-text-soft)" stroke-width="1.6" opacity="0.5"/>
+        <circle cx="4" cy="6"  r="1.6" fill="var(--pp-muted)" opacity="0.6"/>
+        <circle cx="7" cy="11" r="2.3" fill="var(--pp-accent)"/>
+      </svg>
+      tilth
+    </a>
+    <nav class="nav-links" aria-label="page sections">
+      <a href="#why">the round-trip</a>
+      <a href="#bench">benchmarks</a>
+      <a href="#read">how it reads</a>
+      <a href="#verbs">the verbs</a>
+      <a href="#install">install</a>
+      <a href="https://github.com/jahala/tilth">source</a>
+    </nav>
+    <div class="nav-right">
+      <button class="theme-toggle" id="themeToggle" aria-label="toggle dark mode" title="toggle soil-night">&#9680;</button>
+      <a class="btn btn-primary" href="#install">get tilth</a>
+    </div>
+  </div>
+</header>
+
+<main id="top">
+
+<!-- ═══ hero ═══ -->
+<section class="hero">
+  <div class="container hero-grid">
+
+    <!-- left: copy -->
+    <div class="reveal">
+      <div class="kicker">smart code reading &middot; for humans &amp; agents</div>
+      <h1>give grep, tree-sitter, and cat a <em>shared brain</em>.</h1>
+      <p class="lede">tilth reads code the way an agent needs it: small files whole, large files as a structural outline, and every search resolved to where a symbol is <strong>defined</strong> &mdash; not just where the text appears. structural awareness in one call, not six.</p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="#install">get tilth</a>
+        <a class="btn btn-outline" href="https://github.com/jahala/tilth">view source</a>
+      </div>
+      <p class="hero-note">cargo install tilth &nbsp;&middot;&nbsp; npx tilth &nbsp;&middot;&nbsp; Rust, zero runtime deps &nbsp;&middot;&nbsp; MIT</p>
+    </div>
+
+    <!-- right: motif SVG + terminal -->
+    <div class="tilth-fig reveal">
+      <!--
+        The tilth motif: a flat file resolved into a structural outline.
+        Left, a wall of equal-length lines (undifferentiated text); an arrow; right,
+        an outline — indented rows with line-range ticks, the definition row in sky.
+      -->
+      <svg class="tilth-svg" viewBox="0 0 440 196" role="img" aria-label="A flat wall of text on the left resolves into a structural outline on the right: indented rows with line-range markers, the matched definition highlighted in sky.">
+        <!-- left: undifferentiated file -->
+        <text font-family="'JetBrains Mono', monospace" font-size="9" fill="#9A8C72" x="18" y="26">src/auth.ts</text>
+        <g stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.3">
+          <line x1="18" y1="44" x2="150" y2="44"/>
+          <line x1="18" y1="58" x2="138" y2="58"/>
+          <line x1="18" y1="72" x2="150" y2="72"/>
+          <line x1="18" y1="86" x2="128" y2="86"/>
+          <line x1="18" y1="100" x2="150" y2="100"/>
+          <line x1="18" y1="114" x2="142" y2="114"/>
+          <line x1="18" y1="128" x2="150" y2="128"/>
+          <line x1="18" y1="142" x2="120" y2="142"/>
+          <line x1="18" y1="156" x2="150" y2="156"/>
+          <line x1="18" y1="170" x2="134" y2="170"/>
+        </g>
+        <!-- arrow -->
+        <g stroke="#4E88A6" stroke-width="2" fill="none" stroke-linecap="round" stroke-linejoin="round">
+          <line x1="180" y1="104" x2="214" y2="104"/>
+          <path d="M206 97 L214 104 L206 111"/>
+        </g>
+        <text font-family="'JetBrains Mono', monospace" font-size="8" fill="#4E88A6" x="197" y="92" text-anchor="middle">tilth</text>
+        <!-- right: outline -->
+        <g font-family="'JetBrains Mono', monospace" font-size="9">
+          <text fill="#9A8C72" x="248" y="26">258 lines &middot; 3.4k tok &middot; [outline]</text>
+          <!-- rows: [range] indent bar -->
+          <text fill="#9A8C72" x="248" y="48">[1-12]</text>
+          <line x1="298" y1="44" x2="372" y2="44" stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.45"/>
+          <text fill="#9A8C72" x="248" y="70">[24-42]</text>
+          <line x1="298" y1="66" x2="360" y2="66" stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.45"/>
+          <!-- highlighted definition row (sky) -->
+          <text fill="#4E88A6" x="248" y="92" font-weight="700">[44-89]</text>
+          <line x1="298" y1="88" x2="392" y2="88" stroke="#4E88A6" stroke-width="3.4" stroke-linecap="round"/>
+          <circle cx="294" cy="88" r="2.6" fill="#4E88A6"/>
+          <text fill="#9A8C72" x="248" y="114">[91-258]</text>
+          <line x1="298" y1="110" x2="384" y2="110" stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.45"/>
+          <!-- nested -->
+          <text fill="#9A8C72" x="260" y="136">[99-130]</text>
+          <line x1="318" y1="132" x2="380" y2="132" stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.3"/>
+          <text fill="#9A8C72" x="260" y="158">[132-180]</text>
+          <line x1="318" y1="154" x2="372" y2="154" stroke="#786148" stroke-width="3" stroke-linecap="round" opacity="0.3"/>
+        </g>
+      </svg>
+
+      <div class="term">
+        <div class="term-bar">
+          <span class="dot r"></span><span class="dot y"></span><span class="dot g"></span>
+          <span class="title">tilth &mdash; search</span>
+        </div>
+<div class="term-body"><span class="pr">$</span> <span class="cmd">tilth handleAuth --scope src/</span>
+<span class="dim"># "handleAuth" in src/ &mdash; 6 matches (2 def, 4 usage)</span>
+
+<span class="ok">## src/auth.ts:44-89 </span><span class="sk">[definition]</span>
+<span class="dim">  [24-42]  fn validateToken(token)</span>
+<span class="hl">&rarr; [44-89]  export fn handleAuth(req, res, next)</span>
+<span class="dim">  [91-120] fn refreshSession(req, res)</span>
+
+<span class="sk">  &#9472;&#9472; calls &#9472;&#9472;</span>
+<span class="dim">  validateToken   src/auth.ts:24-42</span>
+<span class="dim">  refreshSession  src/auth.ts:91-120</span></div>
+      </div>
+    </div>
+
+  </div>
+</section>
+
+<!-- ═══ the round-trip ═══ -->
+<section class="band" id="why">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">the round-trip tax</div>
+      <h2>an agent makes six calls to find <em>one</em> function.</h2>
+      <p class="lede">glob &rarr; read &rarr; &ldquo;too big&rdquo; &rarr; grep &rarr; read again &rarr; read another file. each round-trip burns tokens and inference time &mdash; to answer a question the file&rsquo;s own structure already knew.</p>
+    </div>
+    <div class="grid grid-2 stagger">
+      <div class="card">
+        <div class="num">without tilth</div>
+        <h4 style="margin-top:8px">built-in tools answer in fragments</h4>
+        <p>grep finds where a string appears, not where a symbol is defined. cat returns a whole file when you needed eight lines &mdash; or overflows the context window, so the agent re-greps and re-reads. structure is rediscovered on every call.</p>
+      </div>
+      <div class="card">
+        <div class="num">with tilth</div>
+        <h4 style="margin-top:8px">structure, resolved in one call</h4>
+        <p>the outline says <em>what is in the file</em>. search says <em>where things are defined</em>, with each hit shown in its surrounding structure. <code>--section</code> returns exactly the lines you asked for. one call, already structured.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ benchmarks ═══ -->
+<section id="bench">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">measured, not claimed</div>
+      <h2>&minus;40% cost per correct answer.</h2>
+      <p>code-navigation tasks across four real-world repositories &mdash; Express, FastAPI, Gin, ripgrep. baseline is Claude Code&rsquo;s built-in tools; tilth is those same tools plus the tilth MCP server. scored the honest way: dollars spent per correct answer, across 160 runs.</p>
+    </div>
+    <div class="bench-wrap reveal">
+      <table class="bench" aria-label="Cost per correct answer: baseline vs tilth, by model">
+        <thead>
+          <tr>
+            <th>Model</th><th>Runs</th><th>Baseline $/correct</th><th>tilth $/correct</th><th>Change</th><th>Baseline acc</th><th>tilth acc</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr><td>Sonnet 4.6</td><td>86</td><td>$0.26</td><td>$0.15</td><td class="delta">&minus;44%</td><td>84%</td><td>94%</td></tr>
+          <tr><td>Opus 4.6</td><td>25</td><td>$0.22</td><td>$0.14</td><td class="delta">&minus;39%</td><td>91%</td><td>92%</td></tr>
+          <tr><td>Haiku 4.5</td><td>49</td><td>$0.12</td><td>$0.08</td><td class="delta">&minus;38%</td><td>54%</td><td>73%</td></tr>
+          <tr><td>Average</td><td>160</td><td>$0.20</td><td>$0.12</td><td class="delta">&minus;40%</td><td>76%</td><td>86%</td></tr>
+        </tbody>
+      </table>
+    </div>
+    <p class="bench-note reveal">The metric is <strong>cost per correct answer</strong> &mdash; total spend divided by correct answers, the expected cost under retry. It is the same yardstick <a href="https://jahala.github.io/copeca/">copeca</a> applies across the garden: lower means it is cheaper to be right. Every model also finished in fewer turns &mdash; 25% fewer on average. Figures measured on v0.5.0. <a href="https://github.com/jahala/tilth/tree/main/benchmark">Full methodology &rarr;</a></p>
+  </div>
+</section>
+
+<!-- ═══ how it reads ═══ -->
+<section class="band" id="read">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">outline &middot; drill &middot; search &middot; follow</div>
+      <h2>it shows you the shape first.</h2>
+      <p>tree-sitter parses the file into an abstract syntax tree, so tilth knows the difference between a definition and a mention. what it returns is decided by tokens, not lines &mdash; a 1-line minified bundle gets outlined; a 120-line focused module prints whole.</p>
+    </div>
+    <div class="beats stagger reveal">
+      <div class="beat">
+        <div class="step">step 01</div>
+        <div class="verbname">outline<span class="seq">&rarr;</span></div>
+        <p>Read a file. Under ~6k tokens it comes back whole with line numbers; over, you get a structural outline with line ranges for every symbol.</p>
+      </div>
+      <div class="beat">
+        <div class="step">step 02</div>
+        <div class="verbname">drill<span class="seq">&rarr;</span></div>
+        <p><code>--section 44-89</code> returns exactly those lines. <code>--section "## Install"</code> returns exactly that markdown heading. No re-reading the whole file.</p>
+      </div>
+      <div class="beat">
+        <div class="step">step 03</div>
+        <div class="verbname">search<span class="seq">&rarr;</span></div>
+        <p>Definitions first, then usages &mdash; structurally, not by string match. Each hit is shown inside its surrounding file structure, so you know what you found.</p>
+      </div>
+      <div class="beat">
+        <div class="step">step 04</div>
+        <div class="verbname">follow</div>
+        <p>An expanded definition carries a <code>&#9472;&#9472; calls &#9472;&#9472;</code> footer of resolved callees, with file and line. Follow the call chain without a fresh search for each one.</p>
+      </div>
+    </div>
+    <div class="grid grid-2 reveal" style="margin-top:56px">
+      <div class="card">
+        <div class="num">token-aware, by design</div>
+        <h4 style="margin-top:8px">it decides what to show</h4>
+        <table class="decide">
+          <thead><tr><th>input</th><th>behaviour</th></tr></thead>
+          <tbody>
+            <tr><td>empty / binary</td><td><code>[empty]</code> / <code>[skipped]</code> with mime</td></tr>
+            <tr><td>generated (lockfile, .min.js)</td><td><code>[generated]</code></td></tr>
+            <tr><td>&lt; ~6k tokens</td><td>full content, line-numbered</td></tr>
+            <tr><td>&gt; ~6k tokens</td><td>structural outline with ranges</td></tr>
+          </tbody>
+        </table>
+      </div>
+      <div class="card">
+        <div class="num">in MCP mode</div>
+        <h4 style="margin-top:8px">it remembers what the agent saw</h4>
+        <p>Definitions already expanded once come back as <code>[shown earlier]</code> on later searches, instead of repeating the whole body &mdash; so revisiting a symbol costs almost nothing in tokens. <code>expand</code> defaults to 2; no flag to remember.</p>
+        <p style="margin-top:14px">Install with <code>--edit</code> and tilth adds hash-anchored writing: each line carries a hash, and an edit is rejected if the file changed since you read it. No blind overwrite.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ the verbs ═══ -->
+<section id="verbs">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">one binary, the whole loop</div>
+      <h2>read, search, and navigate &mdash; structurally.</h2>
+      <p>The same engine behind the CLI is exposed as MCP tools, so an agent reaches for the right one without a wall of upfront instructions.</p>
+    </div>
+    <div class="verbs stagger reveal">
+      <div class="verb">
+        <span class="cmd">tilth &lt;symbol&gt; --scope</span>
+        <p>Definition-first search. Multi-symbol in one call &mdash; <code>"ServeHTTP, Next"</code> &mdash; each with its own block. <code>--expand</code> inlines source for the top matches.</p>
+      </div>
+      <div class="verb">
+        <span class="cmd">tilth &lt;symbol&gt; --callers</span>
+        <p>Every call site of a symbol, matched structurally with tree-sitter &mdash; not a text grep that trips on comments and strings.</p>
+      </div>
+      <div class="verb">
+        <span class="cmd">tilth &lt;path&gt; --deps</span>
+        <p>Blast radius: what a file imports, and what depends on it &mdash; with the symbols each dependent uses. Read it before you rename an export.</p>
+      </div>
+      <div class="verb">
+        <span class="cmd">tilth grok &lt;symbol&gt;</span>
+        <p>Everything about one symbol in a single call: signature, doc, callers, callees, siblings, tests. The whole neighbourhood at once.</p>
+      </div>
+      <div class="verb">
+        <span class="cmd">tilth diff HEAD~1</span>
+        <p>Function-level structural diff &mdash; which symbols changed, added, or had their signature altered. Replaces <code>git diff</code> for an agent.</p>
+      </div>
+      <div class="verb">
+        <span class="cmd">tilth "/regex/" --scope</span>
+        <p>Content and glob search on ripgrep&rsquo;s own engine, with early termination &mdash; roughly constant time whether the tree is 30 files or 1,000.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ what's inside ═══ -->
+<section class="band" id="inside">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">Rust &middot; ~20,000 lines &middot; no runtime dependencies</div>
+      <h2>fast enough to sit in the loop.</h2>
+      <p>tilth is one binary with nothing to install behind it. Search runs definitions and usages in parallel; reads are memory-mapped; the codebase walk uses SIMD pre-filtering to skip files quickly.</p>
+    </div>
+    <div class="grid grid-3 stagger reveal">
+      <div class="card">
+        <div class="num">16 languages</div>
+        <h4 style="margin-top:8px">AST-aware, via tree-sitter</h4>
+        <p>Definition detection, callee extraction, callers, and outlines &mdash; all structural, across:</p>
+        <div class="langs" style="margin-top:16px">
+          <span class="lang">Rust</span><span class="lang">TypeScript</span><span class="lang">TSX</span><span class="lang">JavaScript</span><span class="lang">Python</span><span class="lang">Go</span><span class="lang">Java</span><span class="lang">Scala</span><span class="lang">C</span><span class="lang">C++</span><span class="lang">Ruby</span><span class="lang">PHP</span><span class="lang">C#</span><span class="lang">Swift</span><span class="lang">Kotlin</span><span class="lang">Elixir</span>
+        </div>
+      </div>
+      <div class="card">
+        <div class="num">constant-time search</div>
+        <h4 style="margin-top:8px">it does not slow down with the repo</h4>
+        <table class="speed">
+          <thead><tr><th>operation</th><th>~30</th><th>~1000</th></tr></thead>
+          <tbody>
+            <tr><td>file read + detect</td><td>~18ms</td><td>~18ms</td></tr>
+            <tr><td>symbol search</td><td>~27ms</td><td>~27ms</td></tr>
+            <tr><td>codebase map</td><td>~21ms</td><td>~240ms</td></tr>
+          </tbody>
+        </table>
+        <p style="margin-top:12px; font-size:0.88rem">Search, content, and glob use early termination. MCP mode pays the ~17ms startup once.</p>
+      </div>
+      <div class="card">
+        <div class="num">built on the good parts</div>
+        <h4 style="margin-top:8px">ripgrep&rsquo;s engine, tree-sitter&rsquo;s parser</h4>
+        <p>Content search runs on ripgrep&rsquo;s own <code>grep-regex</code> and <code>grep-searcher</code>; the directory walk on the <code>ignore</code> crate; reads through <code>memmap2</code>; the outline cache on <code>DashMap</code>, invalidated by mtime. No reinvented wheels.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ install everywhere ═══ -->
+<section id="hosts">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">one server, every agent host</div>
+      <h2>it installs where your agent already lives.</h2>
+      <p>One command wires tilth into a host&rsquo;s MCP config. A host you do not use is simply one you never run.</p>
+    </div>
+    <div class="reveal">
+      <div class="code" style="margin-bottom:28px"><span class="k">tilth</span> install claude-code      <span class="c"># ~/.claude.json</span>
+<span class="k">tilth</span> install claude-code <span class="hl">--edit</span> <span class="c"># + hash-anchored editing</span></div>
+      <div class="hosts">
+        <span class="host"><b>claude-code</b></span><span class="host">cursor</span><span class="host">windsurf</span><span class="host">vscode</span><span class="host">claude-desktop</span><span class="host">codex</span><span class="host">gemini</span><span class="host">opencode</span><span class="host">amp</span><span class="host">droid</span><span class="host">zed</span><span class="host">copilot-cli</span><span class="host">augment</span><span class="host">kiro</span><span class="host">cline</span><span class="host">roo-code</span><span class="host">trae</span><span class="host">qwen-code</span><span class="host">antigravity</span><span class="host">&plus; more</span>
+      </div>
+      <p style="margin-top:20px; color:var(--pp-text-soft); font-size:0.95rem">Smaller models sometimes prefer their built-in tools &mdash; run with <code>--disallowedTools "Bash,Grep,Glob"</code> to make tilth the only way through. Or call the CLI straight from bash; the agent prompt lives in <a href="https://github.com/jahala/tilth/blob/main/AGENTS.md">AGENTS.md</a>.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ is tilth for you ═══ -->
+<section class="band" id="fit">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">the honest answer</div>
+      <h2>is tilth for you?</h2>
+      <p>tilth earns its place when something reads code often and pays for every token &mdash; which is most agents, and plenty of humans. So:</p>
+    </div>
+    <div class="split reveal">
+      <div class="yes">
+        <h3>reach for tilth when <span class="tag" style="color:var(--pp-primary)">&mdash; a fit</span></h3>
+        <ul>
+          <li>an AI agent navigates your code and the token bill shows it</li>
+          <li>the repo is large, unfamiliar, or spans several languages</li>
+          <li>you want definitions and call chains, not string matches</li>
+          <li>you measure a tool by its cost per correct answer</li>
+        </ul>
+      </div>
+      <div class="no">
+        <h3>less to gain when <span class="tag" style="color:var(--pp-muted)">&mdash; maybe not</span></h3>
+        <ul>
+          <li>it&rsquo;s one small script you already hold in your head</li>
+          <li>nothing automated ever reads the code &mdash; only you, occasionally</li>
+          <li>your language isn&rsquo;t among the sixteen tree-sitter grammars</li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ═══ start ═══ -->
+<section id="install">
+  <div class="container">
+    <div class="section-head reveal">
+      <div class="kicker">start</div>
+      <h2>install it, point an agent at it.</h2>
+    </div>
+    <div class="face-layout reveal">
+      <div>
+        <h4 style="margin-bottom:16px">install</h4>
+        <div class="copyrow">
+          <code id="installCmd">cargo install tilth</code>
+          <button id="copyBtn" aria-label="copy install command">copy</button>
+        </div>
+        <p class="copyrow-note">also: <code>npx tilth</code> &nbsp;&middot;&nbsp; prebuilt binaries on the <a href="https://github.com/jahala/tilth/releases">releases page</a></p>
+
+        <h4 style="margin-top:32px; margin-bottom:16px">read, search, navigate</h4>
+        <div class="code"><span class="c"># outline a file (whole, if it's small)</span>
+<span class="k">tilth</span> src/auth.ts
+
+<span class="c"># exactly the lines you need</span>
+<span class="k">tilth</span> src/auth.ts <span class="hl">--section</span> 44-89
+
+<span class="c"># definitions first, with source inlined</span>
+<span class="k">tilth</span> handleAuth <span class="hl">--scope</span> src/ <span class="hl">--expand</span></div>
+      </div>
+      <div>
+        <h4 style="margin-bottom:16px">where tilth is</h4>
+        <div class="status-grid">
+          <div class="status-cell">
+            <div class="label">version</div>
+            <div class="val">0.9.0</div>
+          </div>
+          <div class="status-cell">
+            <div class="label">languages</div>
+            <div class="val">16 <small>tree-sitter</small></div>
+          </div>
+          <div class="status-cell">
+            <div class="label">runtime deps</div>
+            <div class="val">0 <small>one binary</small></div>
+          </div>
+        </div>
+        <p style="margin-top:16px; color:var(--pp-text-soft); font-size:0.92rem">
+          tilth is the state of soil that&rsquo;s ready for planting. Your codebase is the soil; tilth gives it structure, so you can find where to dig.
+          <a href="https://github.com/jahala/tilth">Follow along on GitHub &rarr;</a>
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+</main>
+
+<!-- ═══ footer / the garden ═══ -->
+<footer>
+  <div class="container">
+    <div class="gf-plot reveal">
+      <a class="gf-plotbrand" href="https://plotplot.ai" aria-label="plotplot home">
+        <svg class="gf-plotmark" viewBox="0 0 28 28" aria-hidden="true">
+          <path class="ppm-stem" d="M14 26 V12"/>
+          <path class="ppm-leaf" d="M14 18.5 C9 17.5 6 13.5 6.6 9 C11 9.8 14 13.2 14 18.5 Z"/>
+          <path class="ppm-leaf" d="M14 15.5 C19 14.5 22 10.5 21.4 6 C17 6.8 14 10.2 14 15.5 Z"/>
+          <circle class="ppm-bloom" cx="14" cy="8" r="3"/>
+        </svg>
+        <span class="gf-plotword">plotplot</span>
+      </a>
+      <p class="gf-plotline">a garden of small, sharp tools for building with AI.</p>
+      <a class="gf-plotlink" href="https://plotplot.ai">plotplot.ai &rarr;</a>
+    </div>
+    <div class="foot-grid">
+      <div class="reveal">
+        <h4>tilth</h4>
+        <p class="foot-soft">smart code reading for humans and AI agents. Token-aware outlines, definition-first search, callers, blast-radius deps, and structural diff &mdash; structural awareness in one call.</p>
+        <p class="foot-soft" style="margin-top:16px">
+          <a href="https://github.com/jahala/tilth">github &rarr;</a>
+          &nbsp; MIT licensed &nbsp;&middot;&nbsp;
+          <a href="https://github.com/jahala/tilth/blob/main/CONTRIBUTING.md">contributing</a>
+        </p>
+      </div>
+      <div class="reveal">
+        <h4>the plotplot garden</h4>
+        <nav class="garden" aria-label="plotplot tools">
+          <a href="https://jahala.github.io/tilth/" class="current"><span class="dot" style="background:var(--pp-tilth)"></span>tilth</a>
+          <a href="https://jahala.github.io/tend/"><span class="dot" style="background:var(--pp-tend)"></span>tend</a>
+          <a href="https://jahala.github.io/petals/"><span class="dot" style="background:var(--pp-petals)"></span>petals</a>
+          <a href="https://jahala.github.io/pleach/"><span class="dot" style="background:var(--pp-pleach)"></span>pleach</a>
+          <a href="https://jahala.github.io/umbel/"><span class="dot" style="background:var(--pp-umbel)"></span>umbel</a>
+          <a href="https://jahala.github.io/copeca/"><span class="dot" style="background:var(--pp-copeca)"></span>copeca</a>
+        </nav>
+        <p class="foot-soft" style="margin-top:16px">small, sharp tools for building with agents.</p>
+      </div>
+      <div class="reveal">
+        <h4>nearby</h4>
+        <p class="foot-soft">
+          <a href="https://jahala.github.io/copeca/">copeca</a> &mdash; cost per correct answer. tilth&rsquo;s &minus;40% is a copeca number: same metric, same yardstick.
+        </p>
+        <p class="foot-soft" style="margin-top:16px">
+          <a href="https://buymeacoffee.com/jahala">buy me a coffee &rarr;</a>
+        </p>
+      </div>
+    </div>
+    <div class="foot-bottom">
+      <span>&copy; 2026 &middot; a plotplot garden tool &middot; MIT</span>
+      <span>the state of soil that&rsquo;s ready for planting.</span>
+    </div>
+  </div>
+</footer>
+
+<script>
+(function () {
+  // theme toggle — soil at night
+  var root = document.documentElement;
+  var tg = document.getElementById('themeToggle');
+  try { var saved = localStorage.getItem('tilth-theme'); if (saved) root.setAttribute('data-theme', saved); } catch (e) {}
+  tg && tg.addEventListener('click', function () {
+    var next = root.getAttribute('data-theme') === 'dark' ? 'light' : 'dark';
+    root.setAttribute('data-theme', next);
+    try { localStorage.setItem('tilth-theme', next); } catch (e) {}
+  });
+
+  // copy install command
+  var cb = document.getElementById('copyBtn');
+  cb && cb.addEventListener('click', function () {
+    navigator.clipboard && navigator.clipboard.writeText(document.getElementById('installCmd').textContent);
+    var was = cb.textContent;
+    cb.textContent = 'copied';
+    setTimeout(function () { cb.textContent = was; }, 1400);
+  });
+
+  // entrances — things unfold (reduced-motion handled in CSS + here)
+  var rm = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  if (rm) {
+    document.querySelectorAll('.reveal,.stagger').forEach(function (el) { el.classList.add('revealed'); });
+    return;
+  }
+  var io = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (e.isIntersecting) { e.target.classList.add('revealed'); io.unobserve(e.target); }
+    });
+  }, { threshold: 0.12, rootMargin: '0px 0px -8% 0px' });
+  document.querySelectorAll('.reveal,.stagger').forEach(function (el) { io.observe(el); });
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
Adds the tilth landing page — a self-contained `index.html` (inline CSS/JS, no build step) for `https://jahala.github.io/tilth/`, the URL plotplot.ai and the sibling product footers already link to. Styled to the plotplot brand; passes `/petals check` at **0 errors / 0 warnings**.

## Claims corrected against the released v0.9.0
- **version** 1.0.0 → **0.9.0** (the published crates.io/npm release; Cargo.toml's 1.0.0 is the local-only benchmark label, not a release)
- **languages** 14 → **16** tree-sitter (added Kotlin + Elixir, both shipped in 0.9.0; Bash is post-0.9.0, excluded)
- **benchmark figures** now labeled *measured on v0.5.0* — the version they were actually run on
- fixed 3 broken `…/master/…` repo links → `…/main/…` (AGENTS.md, CONTRIBUTING.md, benchmark)

Verified accurate and left unchanged: install commands (`cargo install tilth`, `npx tilth`), all 19 MCP host chips (real `tilth install` targets in 0.9.0), CLI verbs/flags, and the internals (`grep-regex`, `grep-searcher`, `ignore`, `memmap2`, `DashMap`).

## Note (separate follow-up)
`README.md:313` is also stale — it says "14 languages" while 0.9.0 ships 16. Worth syncing the README separately (out of scope for this page-only PR).

After merge: enable GitHub Pages (Deploy from a branch → `main` / root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
