### PR TITLE
docs: README — 16 tree-sitter languages (add Kotlin, Elixir)

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,7 +310,7 @@ Search, content search, and glob use early termination — time is roughly const
 
 Rust. ~20,000 lines. No runtime dependencies.
 
-- **tree-sitter** — AST parsing for 14 languages (Rust, TypeScript, TSX, JavaScript, Python, Go, Java, Scala, C, C++, Ruby, PHP, C#, Swift). Used for definition detection, callee extraction, callers query, and structural outlines.
+- **tree-sitter** — AST parsing for 16 languages (Rust, TypeScript, TSX, JavaScript, Python, Go, Java, Scala, C, C++, Ruby, PHP, C#, Swift, Kotlin, Elixir). Used for definition detection, callee extraction, callers query, and structural outlines.
 - **ripgrep internals** (`grep-regex`, `grep-searcher`) — fast content search
 - **ignore** crate — parallel directory walking, searches all files including gitignored
 - **memmap2** — memory-mapped file reads (no buffers)


### PR DESCRIPTION
`README.md:313` said "14 languages" but the released v0.9.0 ships **16** tree-sitter languages — it omitted **Kotlin** and **Elixir**, both wired with grammars. This brings the README in line with the [landing page](https://jahala.github.io/tilth/) (#160), which now reflects the same count.

Per the version-sync convention, the benchmark table keeps its `v0.5.0` provenance untouched — only the capability claim is corrected.

Note: Bash (post-0.9.0, currently on an integration branch) will bump this to 17 when 1.0.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
