### PR TITLE
fix(benchmark): grade all assistant turns + corrected ground-truth strings + portability

### DIFF
--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -183,6 +183,8 @@ Each run invokes `claude -p` (Claude Code headless mode) with a code navigation 
 
 All modes use the same system prompt, $1.00 budget cap, and model. The agent explores the codebase and returns a natural-language answer. Correctness is checked against ground-truth strings that must appear in the response.
 
+**Grading semantics**: correctness is a case-insensitive, backtick-stripped substring match — every `required_strings` entry for a task must appear somewhere in the graded text (`benchmark/tasks/base.py`'s `check_correctness`). The graded text is the agent's text output *accumulated across every assistant turn in the run*, not just the final one — a short wrap-up turn at the end of a run adds to, rather than replaces, the substantive answer from an earlier turn (`benchmark/parse.py`'s `parse_stream_json`).
+
 **Repos (pinned commits):**
 
 | Repo | Language | Description |

--- a/benchmark/analyze_exploration.py
+++ b/benchmark/analyze_exploration.py
@@ -178,7 +178,11 @@ def print_detailed_runs(runs: List[Dict], title: str, limit: int = 5):
 
 def main():
     """Main analysis function."""
-    results_dir = Path("/Users/flysikring/conductor/workspaces/tilth/almaty/benchmark/results")
+    # Override with TILTH_BENCH_RESULTS_DIR env var. Default: benchmark/results
+    # relative to this file, so the script works from any clone.
+    results_dir = Path(
+        os.environ.get("TILTH_BENCH_RESULTS_DIR", str(Path(__file__).parent / "results"))
+    )
 
     # Focus on the two newest files
     target_files = [

--- a/benchmark/compare_versions.py
+++ b/benchmark/compare_versions.py
@@ -4,6 +4,7 @@ Compare old tilth (built-in tools) vs new tilth (MCP-only) exploration patterns.
 """
 
 import json
+import os
 from pathlib import Path
 from typing import Dict, List
 
@@ -18,7 +19,11 @@ def parse_jsonl(file_path: str) -> List[Dict]:
     return results
 
 def main():
-    results_dir = Path("/Users/flysikring/conductor/workspaces/tilth/almaty/benchmark/results")
+    # Override with TILTH_BENCH_RESULTS_DIR env var. Default: benchmark/results
+    # relative to this file, so the script works from any clone.
+    results_dir = Path(
+        os.environ.get("TILTH_BENCH_RESULTS_DIR", str(Path(__file__).parent / "results"))
+    )
 
     old_file = results_dir / "benchmark_20260213_131246.jsonl"
     new_file = results_dir / "benchmark_20260213_135039.jsonl"

--- a/benchmark/parse.py
+++ b/benchmark/parse.py
@@ -57,7 +57,7 @@ def parse_stream_json(raw_output: str) -> RunResult:
 
     session_id = ""
     turns: list[Turn] = []
-    result_text = ""
+    result_text_parts: list[str] = []
     final_summary = {}
     turn_index = 0
 
@@ -98,7 +98,7 @@ def parse_stream_json(raw_output: str) -> RunResult:
             turn_index += 1
 
             if text_blocks:
-                result_text = "\n".join(text_blocks)
+                result_text_parts.append("\n".join(text_blocks))
 
         elif event_type == "result":
             final_summary = event
@@ -114,7 +114,7 @@ def parse_stream_json(raw_output: str) -> RunResult:
         total_output_tokens=final_summary.get("usage", {}).get("output_tokens", 0),
         total_cache_creation_tokens=final_summary.get("usage", {}).get("cache_creation_input_tokens", 0),
         total_cache_read_tokens=final_summary.get("usage", {}).get("cache_read_input_tokens", 0),
-        result_text=result_text,
+        result_text="\n".join(result_text_parts),
     )
 
 

--- a/benchmark/tasks/express_tasks.py
+++ b/benchmark/tasks/express_tasks.py
@@ -45,7 +45,7 @@ class ExpressRenderChainTask(Task):
     @property
     def ground_truth(self) -> GroundTruth:
         return GroundTruth(
-            required_strings=["res.render", "app.render", "View", "lookup", "view.js"],
+            required_strings=["res.render", "app.render", "View", "lookup"],
         )
 
     @property
@@ -125,7 +125,7 @@ class ExpressAppRenderTask(Task):
     def ground_truth(self) -> GroundTruth:
         return GroundTruth(
             required_strings=[
-                "app.render", "View", "application.js", "view.js",
+                "app.render", "View", "application.js",
             ],
         )
 

--- a/benchmark/tasks/gin_tasks.py
+++ b/benchmark/tasks/gin_tasks.py
@@ -49,7 +49,7 @@ class GinClientIPTask(Task):
                 "func (c *Context) ClientIP",
                 "RemoteIPHeaders",
                 "X-Forwarded-For",
-                "trustedCIDRs",
+                "isTrustedProxy",
             ],
         )
 

--- a/benchmark/tests/test_parse.py
+++ b/benchmark/tests/test_parse.py
@@ -1,0 +1,69 @@
+"""Tests for benchmark/parse.py — stream-json → RunResult parsing."""
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from parse import parse_stream_json
+
+
+def _assistant_event(text: str) -> dict:
+    """Build a minimal stream-json 'assistant' event carrying one text block."""
+    return {
+        "type": "assistant",
+        "message": {
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 10,
+                "cache_creation_input_tokens": 0,
+                "cache_read_input_tokens": 0,
+            },
+            "content": [{"type": "text", "text": text}],
+        },
+    }
+
+
+def _result_event() -> dict:
+    return {"type": "result", "num_turns": 5, "total_cost_usd": 0.01}
+
+
+def test_result_text_accumulates_across_all_assistant_turns():
+    """A substantive answer in an earlier turn must survive even when a later
+    turn is a short wrap-up — grading reads result_text, so losing the
+    earlier turn silently discards the real answer (docs/research/
+    grading-audit-2026-07.md §5)."""
+    substantive = "The dependency resolution flow starts in get_dependant()."
+    wrapup = "Let me know if you want more detail."
+
+    events = [
+        {"type": "system", "session_id": "abc123"},
+        _assistant_event("Looking into the codebase now."),
+        _assistant_event("Still investigating."),
+        _assistant_event(substantive),
+        _assistant_event("Just a status update, no new info."),
+        _assistant_event(wrapup),
+        _result_event(),
+    ]
+    raw_output = "\n".join(json.dumps(e) for e in events)
+
+    result = parse_stream_json(raw_output)
+
+    assert substantive in result.result_text
+    assert wrapup in result.result_text
+
+
+def test_result_text_single_turn_unchanged():
+    """A single-turn transcript's result_text is just that turn's text —
+    accumulation must not introduce leading separators or duplication."""
+    events = [
+        {"type": "system", "session_id": "abc123"},
+        _assistant_event("The answer is 42."),
+        _result_event(),
+    ]
+    raw_output = "\n".join(json.dumps(e) for e in events)
+
+    result = parse_stream_json(raw_output)
+
+    assert result.result_text == "The answer is 42."


### PR DESCRIPTION
Benchmark-harness integrity fixes from this week's audits. No src/ changes — harness and task definitions only.

1. **parse.py graded only the final assistant message** — `result_text` was overwritten per turn, so any run ending in a short wrap-up was graded against that wrap-up alone (receipt in the audit: a 17-turn run with the correct answer in-body, graded on a 394-char closing note). Now accumulates across all turns. TDD with a red-run proof; new `benchmark/tests/test_parse.py`.
2. **Three ground-truth strings corrected** per the grading audit's verified diff (`gin_client_ip`: `trustedCIDRs` → `isTrustedProxy` — the original lives one call deeper than the function agents correctly cite; two express tasks graded on `view.js` which never appears as literal text in the source). `rg_search_dispatch` deliberately untouched — its failures are genuine navigation misses.
3. **Portability**: two analysis scripts hardcoded a developer home path; now env-overridable with a sane default.
4. **Docs**: grading semantics (substring over ALL assistant text) pinned in the benchmark README.

Offline re-grade of all 2,795 historical result rows under the fixed parser + strings: 90.3% → 91.0%, +18/−0 flips, zero flips on the flagship A/B tasks — no historical conclusion changes. Ten additional rows carry a plausibly-parse-bug-affected flag (reported, not folded into accuracy — stored results don't retain per-turn text, so pre-fix losses can't be reconstructed).

Co-authored-by: Maxime Roy <celestinmax@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)