### PR TITLE
chore: audit hygiene bundle — dup-output fix, dead code, walker policy, ASCII output, doc truth, test coverage

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -323,15 +323,18 @@ opinionated defaults:
 - **Always-skipped directories** (`SKIP_DIRS`): build artifacts,
   dependency caches, VCS internals — `.git`, `node_modules`, `target`,
   `dist`, `build`, `__pycache__`, `vendor`, `.next`, `.venv`,
-  `.mypy_cache`, etc. ~30 entries. Enforced even with
-  `TILTH_NO_IGNORE=1`.
-- **Per-repo `.gitignore`** is honored by default
-  (`apply_ignore_settings`).
-- **`.tilthignore`** — gitignore syntax — is layered on top.
-  `!path` lines re-include files that `.gitignore` would have excluded.
-- **Global gitignore** and `.git/info/exclude` are deliberately
-  **never** consulted; those tend to list per-engineer files (agent
-  state, editor scratch) that grep-style queries should still find.
+  `.mypy_cache`, etc. ~30 entries.
+- **`.gitignore`, global gitignore, `.git/info/exclude`, and custom
+  `.ignore` files are all deliberately never consulted**
+  (`git_ignore(false)`, `git_global(false)`, `git_exclude(false)`,
+  `ignore(false)`). This is not an oversight: grep-style queries need
+  to see gitignored-but-locally-relevant files (docs/, configs,
+  generated code, per-engineer agent state) that a `.gitignore` would
+  hide from a normal directory listing. A per-project `.tilthignore`
+  override was proposed and **rejected 2026-07-03** — it would
+  special-case one tool's walker instead of fixing the underlying
+  need (which is `SKIP_DIRS`-style unconditional exclusion, already
+  covered above).
 - **Symlinks are followed** (`follow_links(true)`). This is the
   upstream `feat: follow symlinks in all file walkers (#46)` change
   and creates a known duplicate-match problem when a path is reachable

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,21 @@ Rust MCP server + CLI for AST-aware code intelligence. Tree-sitter outlines, sym
 src/
   main.rs              CLI entry (clap). Dispatches to MCP, map, or single-query mode.
   lib.rs               Public API: classify query → read/search/glob → formatted output.
-  mcp/mod.rs           MCP server (JSON-RPC on stdio). Embeds SERVER_INSTRUCTIONS + EDIT_MODE_EXTRA via include_str! from prompts/.
+  mcp/
+    mod.rs             MCP server (JSON-RPC on stdio). Embeds SERVER_INSTRUCTIONS + EDIT_MODE_EXTRA via include_str! from prompts/.
+    write.rs           tilth_write overwrite/append primitives — create-only guard, O_NOFOLLOW symlink refusal, atomic parent-dir creation.
+    tools/
+      mod.rs           Tool dispatch hub — path/scope resolution under the absolute-path discipline (anchor_path, resolve_scope), budget application.
+      definitions.rs   JSON schema definitions for every MCP tool (tilth_search/read/files/deps/grok/diff/savings/write).
+      search.rs        tool_search — symbol/content/regex/callers dispatch, multi-symbol support, scope-warning integration.
+      read.rs          tool_read — smart file reads, batch/section/sections slicing, savings tracking.
+      write.rs         tool_write — batch writes in hash/overwrite/append modes; hash mode delegates to edit::apply_batch.
+      deps.rs          tool_deps — file-level dependency analysis (imports + dependents), bloom-filtered.
+      diff.rs          tool_diff — structural diff dispatch (uncommitted/staged/ref/file-pair/patch/log).
+      files.rs         tool_files — glob file listing, pattern/patterns batch, scope resolution.
+      grok.rs          tool_grok — one-call symbol bundle, default vs full caps.
+      savings.rs       tool_savings — session token-savings summary vs a naive-read baseline.
+      session.rs       tool_session — summary/reset actions for grok dedup + savings state.
   classify.rs          Query type detection (file path, glob, symbol, content, fallthrough).
   lang/
     mod.rs             Shared language infrastructure: detect_file_type(), package_root().
@@ -24,9 +38,12 @@ src/
   read/
     mod.rs             File reading with smart view (full vs outline based on token count).
     outline/
+      mod.rs           generate() — dispatches to the right outline backend by file type, appends the truncation note when a cap is hit.
       code.rs          Outline string formatting for code files. Uses lang/outline for extraction.
       markdown.rs      Markdown heading-based outlines.
       structured.rs    JSON/YAML/TOML structured outlines.
+      tabular.rs       CSV/TSV outline: headers + row count + first 5 / last 3 rows via memchr.
+      fallback.rs      head_tail() / log_view() — unknown files and logs with no outline support.
       test_file.rs     Test file detection (suppresses outline noise).
     imports.rs         Import extraction for deps analysis.
   search/
@@ -35,25 +52,32 @@ src/
     content.rs         Literal text / regex search via ripgrep internals.
     callers.rs         Structural call-site detection (tree-sitter + memchr pre-filter).
     callees.rs         Callee extraction and resolution for expanded definitions.
+    callee_query.rs    Per-language tree-sitter call-expression queries + compiled-Query cache, shared by callers.rs and callees.rs.
     siblings.rs        Sibling symbol surfacing in search results.
+    scope.rs           Enclosing-scope lookup: nearest definition at a line, qualified by containing type/module.
     grok.rs            One-call symbol bundle (def + body + callers + callees + siblings + tests).
     deps.rs            File-level dependency analysis (imports + dependents with symbols).
     rank.rs            Result ranking (definition weight, basename boost, context proximity).
     facets.rs          Faceted result grouping (definitions, usages, implementations).
     strip.rs           Cognitive load stripping (comments, blank lines in expanded code).
     truncate.rs        Smart truncation to fit budget constraints.
+    alloc.rs           Value-based budget allocation — keeps the highest-value blocks when output exceeds budget, not just positional tail-cut.
+    bloom_walk.rs      Shared file-prefilter for relational queries (callers/callees/deps): size gate + bloom-filter pre-check before a full parse.
     glob.rs            File glob search.
     blast.rs           Blast radius — find callers of definitions touched by edits.
   index/
-    symbol.rs          In-memory symbol index (built on first search, cached).
     bloom.rs           Bloom filter cache for fast "file contains symbol?" pre-check.
   cache.rs             OutlineCache — DashMap of path → (mtime, outline). Shared across tools.
   session.rs           MCP session state — tracks previously expanded definitions for dedup.
   edit.rs              Hash-anchored editing (tilth_write hash mode). Hashline verification + atomic apply.
+  edit_parse_check.rs  Post-edit tree-sitter parse check — diffs pre/post ERROR/MISSING nodes so tilth_write reports only errors the edit introduced.
   install.rs           `tilth install <host>` — writes MCP config for 6 hosts.
   format.rs            Output formatting helpers.
   budget.rs            Token budget enforcement.
   map.rs               Codebase map generation (CLI only, disabled as MCP tool).
+  overview.rs          Project fingerprint for MCP initialization (manifest, languages, modules, deps, git). Instant orientation without a tool call.
+  timeout.rs           Per-request wall-clock timeout for sync tool calls — worker thread + bounded channel, tracks abandoned threads on expiry.
+  util.rs              atomic_write_bytes() — shared by edit.rs and install.rs.
   types.rs             Shared types (QueryType, Lang, OutlineEntry, etc.).
   error.rs             Error types with exit codes.
 npm/                   npm wrapper — postinstall downloads binary, run.js proxies to it.

--- a/src/diff/matching.rs
+++ b/src/diff/matching.rs
@@ -544,24 +544,6 @@ fn trim_ascii(bytes: &[u8]) -> &[u8] {
 mod tests {
     use super::*;
 
-    fn make_entry(
-        kind: OutlineKind,
-        name: &str,
-        start: u32,
-        end: u32,
-        sig: Option<&str>,
-    ) -> OutlineEntry {
-        OutlineEntry {
-            kind,
-            name: name.to_string(),
-            start_line: start,
-            end_line: end,
-            signature: sig.map(|s| s.to_string()),
-            children: Vec::new(),
-            doc: None,
-        }
-    }
-
     fn make_sym(
         kind: OutlineKind,
         name: &str,

--- a/src/diff/mod.rs
+++ b/src/diff/mod.rs
@@ -509,25 +509,6 @@ fn diff_log(range: &str, scope: Option<&str>, budget: Option<u64>) -> Result<Str
     Ok(format::format_log(&summaries, range, budget))
 }
 
-/// Format a duration as a relative time string.
-#[allow(dead_code)]
-pub(crate) fn relative_time(secs: i64) -> String {
-    let secs = secs.max(0) as u64;
-    if secs < 60 {
-        return format!("{secs}s ago");
-    }
-    let mins = secs / 60;
-    if mins < 60 {
-        return format!("{mins}m ago");
-    }
-    let hours = mins / 60;
-    if hours < 24 {
-        return format!("{hours}h ago");
-    }
-    let days = hours / 24;
-    format!("{days}d ago")
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -315,3 +315,127 @@ pub(crate) fn definition_weight(kind: &str) -> u16 {
         _ => 50,
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::outline::outline_language;
+    use crate::types::Lang;
+
+    #[test]
+    fn definition_weight_covers_every_tier() {
+        // 100 — primary declarations, one per source language shape
+        // (Rust function_item/enum_item, TS class_declaration/interface_declaration, Python decorated_definition).
+        assert_eq!(definition_weight("function_item"), 100);
+        assert_eq!(definition_weight("class_declaration"), 100);
+        assert_eq!(definition_weight("interface_declaration"), 100);
+        assert_eq!(definition_weight("enum_item"), 100);
+        assert_eq!(definition_weight("decorated_definition"), 100);
+        // 90 — impls / object-like declarations (Rust impl_item, Kotlin object_declaration).
+        assert_eq!(definition_weight("impl_item"), 90);
+        assert_eq!(definition_weight("object_declaration"), 90);
+        // 80 — const/static.
+        assert_eq!(definition_weight("const_item"), 80);
+        assert_eq!(definition_weight("static_item"), 80);
+        // 70 — module/namespace/property.
+        assert_eq!(definition_weight("mod_item"), 70);
+        assert_eq!(definition_weight("property_declaration"), 70);
+        // 60 — Bash top-level assignment (special-cased above the 40 tier).
+        assert_eq!(definition_weight("variable_assignment"), 60);
+        // 40 — plain variable declarations (JS/TS lexical_declaration, C#/Kotlin variable_declaration).
+        assert_eq!(definition_weight("lexical_declaration"), 40);
+        assert_eq!(definition_weight("variable_declaration"), 40);
+        // 30 — export wrapper (unwrapped recursively by extract_definition_name).
+        assert_eq!(definition_weight("export_statement"), 30);
+        // 50 — unrecognized kind falls to the default tier, not 0.
+        assert_eq!(definition_weight("comment"), 50);
+    }
+
+    /// Parse `src` with `lang`'s grammar and return the owned tree.
+    fn parse(src: &str, lang: Lang) -> tree_sitter::Tree {
+        let language = outline_language(lang).expect("grammar available for test language");
+        let mut parser = tree_sitter::Parser::new();
+        parser.set_language(&language).expect("grammar loads");
+        parser.parse(src, None).expect("parse succeeds")
+    }
+
+    /// Depth-first search for the first descendant node of the given kind.
+    fn find_by_kind<'a>(root: tree_sitter::Node<'a>, kind: &str) -> tree_sitter::Node<'a> {
+        let mut cursor = root.walk();
+        let mut stack = vec![root];
+        while let Some(node) = stack.pop() {
+            if node.kind() == kind {
+                return node;
+            }
+            stack.extend(node.children(&mut cursor));
+        }
+        panic!("no {kind} node found in parsed tree");
+    }
+
+    #[test]
+    fn extract_definition_name_rust_function_item() {
+        let src = "fn greet(name: &str) -> String { name.to_string() }\n";
+        let tree = parse(src, Lang::Rust);
+        let lines: Vec<&str> = src.lines().collect();
+        let node = find_by_kind(tree.root_node(), "function_item");
+        assert_eq!(
+            extract_definition_name(node, &lines),
+            Some("greet".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_definition_name_python_class_definition() {
+        let src = "class Widget:\n    pass\n";
+        let tree = parse(src, Lang::Python);
+        let lines: Vec<&str> = src.lines().collect();
+        let node = find_by_kind(tree.root_node(), "class_definition");
+        assert_eq!(
+            extract_definition_name(node, &lines),
+            Some("Widget".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_definition_name_unwraps_export_statement() {
+        // export_statement has no "name"/"identifier"/"declarator" field of its
+        // own — extract_definition_name must recurse into the wrapped
+        // function_declaration to find the name (the node.kind() == "export_statement"
+        // branch).
+        let src = "export function handler() {}\n";
+        let tree = parse(src, Lang::TypeScript);
+        let lines: Vec<&str> = src.lines().collect();
+        let node = find_by_kind(tree.root_node(), "export_statement");
+        assert_eq!(
+            extract_definition_name(node, &lines),
+            Some("handler".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_definition_name_walks_lexical_declaration_declarator() {
+        // lexical_declaration stores its identifier inside a child
+        // variable_declarator, not as a direct field on the declaration node —
+        // exercises the dedicated child-walk branch.
+        let src = "const total = 42;\n";
+        let tree = parse(src, Lang::TypeScript);
+        let lines: Vec<&str> = src.lines().collect();
+        let node = find_by_kind(tree.root_node(), "lexical_declaration");
+        assert_eq!(
+            extract_definition_name(node, &lines),
+            Some("total".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_definition_name_returns_none_when_no_name_field_present() {
+        // impl_item has no "name"/"identifier"/"declarator" field and isn't
+        // handled by any of the special-cased branches — must fall through to
+        // None rather than panic or return an empty string.
+        let src = "impl Widget {}\n";
+        let tree = parse(src, Lang::Rust);
+        let lines: Vec<&str> = src.lines().collect();
+        let node = find_by_kind(tree.root_node(), "impl_item");
+        assert_eq!(extract_definition_name(node, &lines), None);
+    }
+}

--- a/src/map.rs
+++ b/src/map.rs
@@ -2,11 +2,10 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 use std::path::{Path, PathBuf};
 
-use ignore::WalkBuilder;
-
 use crate::cache::OutlineCache;
 use crate::lang::detect_file_type;
 use crate::read::outline;
+use crate::search::base_walk_builder;
 use crate::types::{estimate_tokens, FileType};
 
 /// Generate a structural codebase map.
@@ -16,24 +15,7 @@ use crate::types::{estimate_tokens, FileType};
 pub fn generate(scope: &Path, depth: usize, budget: Option<u64>, cache: &OutlineCache) -> String {
     let mut tree: BTreeMap<PathBuf, Vec<FileEntry>> = BTreeMap::new();
 
-    let walker = WalkBuilder::new(scope)
-        .follow_links(true)
-        .hidden(false)
-        .git_ignore(false)
-        .git_global(false)
-        .git_exclude(false)
-        .ignore(false)
-        .parents(false)
-        .filter_entry(|entry| {
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if let Some(name) = entry.file_name().to_str() {
-                    return !crate::search::SKIP_DIRS.contains(&name);
-                }
-            }
-            true
-        })
-        .max_depth(Some(depth + 1))
-        .build();
+    let walker = base_walk_builder(scope).max_depth(Some(depth + 1)).build();
 
     for entry in walker.flatten() {
         if !entry.file_type().is_some_and(|ft| ft.is_file()) {

--- a/src/search/callers.rs
+++ b/src/search/callers.rs
@@ -397,7 +397,7 @@ fn write_caller_bucket(
         );
 
         // Show the call text
-        let _ = writeln!(output, "→ {}", caller.call_text);
+        let _ = writeln!(output, "-> {}", caller.call_text);
 
         // Expand if requested and we have the range
         if i < expand {
@@ -413,11 +413,11 @@ fn write_caller_bucket(
                 for (idx, line) in lines[start_idx..end_idx].iter().enumerate() {
                     let line_num = start_idx + idx + 1;
                     let prefix = if line_num == caller.line as usize {
-                        "► "
+                        "> "
                     } else {
                         "  "
                     };
-                    let _ = writeln!(output, "{prefix}{line_num:4} │ {line}");
+                    let _ = writeln!(output, "{prefix}{line_num:4} | {line}");
                 }
 
                 output.push_str("```\n");
@@ -465,7 +465,7 @@ fn write_second_hop_impact(
         return;
     }
 
-    output.push_str("\n── impact (2nd hop) ──\n");
+    output.push_str("\n-- impact (2nd hop) --\n");
 
     let mut seen: HashSet<(String, PathBuf)> = HashSet::new();
     let mut count = 0;
@@ -481,7 +481,7 @@ fn write_second_hop_impact(
         let rel_path = m.path.strip_prefix(scope).unwrap_or(&m.path).display();
         let _ = writeln!(
             output,
-            "  {:<20} {}:{}  \u{2192} {}",
+            "  {:<20} {}:{}  -> {}",
             m.calling_function, rel_path, m.line, via
         );
         count += 1;

--- a/src/search/glob.rs
+++ b/src/search/glob.rs
@@ -20,7 +20,8 @@ pub struct GlobResult {
     pub available_extensions: Vec<String>,
 }
 
-/// Glob search using `ignore::WalkBuilder` (parallel, .gitignore-aware).
+/// Glob search using `ignore::WalkBuilder` (parallel via `super::walker` —
+/// deliberately NOT .gitignore-aware, see `walker`'s doc comment).
 pub fn search(pattern: &str, scope: &Path) -> Result<GlobResult, TilthError> {
     let glob = Glob::new(pattern).map_err(|e| TilthError::InvalidQuery {
         query: pattern.to_string(),

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -622,27 +622,37 @@ fn format_single_match(
         }
     }
 
+    // Check session dedup for definitions with def_range. The mtime
+    // check ensures a post-edit search re-inlines the body rather than
+    // pointing at stale line numbers.
+    let current_mtime = std::fs::metadata(&m.path)
+        .ok()
+        .and_then(|md| md.modified().ok());
+    let deduped = m.is_definition
+        && m.def_range.is_some()
+        && session
+            .is_some_and(|s| current_mtime.is_some_and(|t| s.is_expanded(&m.path, m.line, t)));
+    // expand_match always prints a range containing m.line (def_range starts
+    // at m.line for definitions; the ±10 fallback for def_range: None / usages
+    // trivially contains it), so the raw "→ [line] text" preview would
+    // reprint m.text byte-for-byte inside the fence below. Only the
+    // structural outline_context (neighboring entries' signatures, not the
+    // matched line's own source) survives alongside an expansion.
+    let fence_will_follow =
+        *expand_remaining > 0 && !deduped && !(multi_file && expanded_files.contains(&m.path));
+
     // Skip outline for small files — the expanded code speaks for itself
     if m.file_lines < 50 {
-        let _ = write!(out, "\n→ [{}]   {}", m.line, m.text);
+        if !fence_will_follow {
+            let _ = write!(out, "\n→ [{}]   {}", m.line, m.text);
+        }
     } else if let Some(context) = outline_context_for_match(&m.path, m.line, cache) {
         out.push_str(&context);
-    } else {
+    } else if !fence_will_follow {
         let _ = write!(out, "\n→ [{}]   {}", m.line, m.text);
     }
 
     if *expand_remaining > 0 {
-        // Check session dedup for definitions with def_range. The mtime
-        // check ensures a post-edit search re-inlines the body rather than
-        // pointing at stale line numbers.
-        let current_mtime = std::fs::metadata(&m.path)
-            .ok()
-            .and_then(|md| md.modified().ok());
-        let deduped = m.is_definition
-            && m.def_range.is_some()
-            && session
-                .is_some_and(|s| current_mtime.is_some_and(|t| s.is_expanded(&m.path, m.line, t)));
-
         if deduped {
             if let Some((start, end)) = m.def_range {
                 let _ = write!(
@@ -2004,6 +2014,59 @@ mod tests {
         assert!(
             out.contains("[usage in function Foo.bar]"),
             "expected scope suffix in output, got: {out}"
+        );
+    }
+
+    #[test]
+    fn format_single_match_does_not_duplicate_expanded_line() {
+        use crate::types::Match;
+
+        // Small file (<50 lines) with no doc comment above the definition —
+        // the outline-context preview at line 627 prints `m.text` verbatim,
+        // and expand_match's whole-file expansion (small files expand fully,
+        // see EXPAND_FULL_FILE_THRESHOLD) includes that same source line
+        // again in the fence right below it.
+        let tmp = tempfile::tempdir().unwrap();
+        let p = tmp.path().join("small.rs");
+        let src = "pub struct Thing;\n\nimpl Thing {\n    pub fn exit_code(&self) -> i32 {\n        0\n    }\n}\n";
+        std::fs::write(&p, src).unwrap();
+
+        let m = Match {
+            path: p.clone(),
+            line: 4,
+            text: "    pub fn exit_code(&self) -> i32 {".to_string(),
+            is_definition: true,
+            exact: true,
+            file_lines: 7,
+            mtime: SystemTime::now(),
+            def_range: Some((4, 6)),
+            def_name: Some("exit_code".to_string()),
+            def_weight: 100,
+            impl_target: None,
+        };
+        let cache = OutlineCache::new();
+        let bloom = crate::index::bloom::BloomFilterCache::new();
+        let mut expand_remaining = 1usize;
+        let mut expanded_files: HashSet<PathBuf> = HashSet::new();
+        let mut out = String::new();
+
+        format_single_match(
+            &m,
+            tmp.path(),
+            &cache,
+            None,
+            &bloom,
+            &mut expand_remaining,
+            &mut expanded_files,
+            false,
+            &mut out,
+        );
+
+        let needle = "pub fn exit_code(&self) -> i32 {";
+        let occurrences = out.matches(needle).count();
+        assert_eq!(
+            occurrences, 1,
+            "expanded line must appear exactly once, got {occurrences} in: {out}"
         );
     }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -644,7 +644,7 @@ fn format_single_match(
             .is_some_and(|s| current_mtime.is_some_and(|t| s.is_expanded(&m.path, m.line, t)));
     // expand_match always prints a range containing m.line (def_range starts
     // at m.line for definitions; the ±10 fallback for def_range: None / usages
-    // trivially contains it), so the raw "→ [line] text" preview would
+    // trivially contains it), so the raw "-> [line] text" preview would
     // reprint m.text byte-for-byte inside the fence below. Only the
     // structural outline_context (neighboring entries' signatures, not the
     // matched line's own source) survives alongside an expansion.
@@ -654,12 +654,12 @@ fn format_single_match(
     // Skip outline for small files — the expanded code speaks for itself
     if m.file_lines < 50 {
         if !fence_will_follow {
-            let _ = write!(out, "\n→ [{}]   {}", m.line, m.text);
+            let _ = write!(out, "\n-> [{}]   {}", m.line, m.text);
         }
     } else if let Some(context) = outline_context_for_match(&m.path, m.line, cache) {
         out.push_str(&context);
     } else if !fence_will_follow {
-        let _ = write!(out, "\n→ [{}]   {}", m.line, m.text);
+        let _ = write!(out, "\n-> [{}]   {}", m.line, m.text);
     }
 
     if *expand_remaining > 0 {
@@ -773,7 +773,7 @@ fn format_single_match(
                                 }
 
                                 if !nodes.is_empty() {
-                                    out.push_str("\n\n\u{2500}\u{2500} calls \u{2500}\u{2500}");
+                                    out.push_str("\n\n-- calls --");
                                     for n in &nodes {
                                         let c = &n.callee;
                                         let _ = write!(
@@ -790,7 +790,7 @@ fn format_single_match(
                                         for child in &n.children {
                                             let _ = write!(
                                                 out,
-                                                "\n    \u{2192} {}  {}:{}-{}",
+                                                "\n    -> {}  {}:{}-{}",
                                                 child.name,
                                                 rel(&child.file, scope),
                                                 child.start_line,
@@ -823,9 +823,7 @@ fn format_single_match(
                                         let resolved =
                                             siblings::resolve_siblings(&filtered, &parent.children);
                                         if !resolved.is_empty() {
-                                            out.push_str(
-                                                "\n\n\u{2500}\u{2500} siblings \u{2500}\u{2500}",
-                                            );
+                                            out.push_str("\n\n-- siblings --");
                                             for s in &resolved {
                                                 let _ = write!(
                                                     out,
@@ -1267,7 +1265,7 @@ fn expand_match(m: &Match, scope: &Path) -> Option<(String, String)> {
                 continue;
             }
 
-            let _ = write!(out, "\n{i:>4} │ {line}");
+            let _ = write!(out, "\n{i:>4} | {line}");
             prev_blank = is_blank;
         }
     }
@@ -1290,9 +1288,9 @@ fn filter_code_lines(code: &str, skip_lines: &HashSet<u32>) -> String {
             continue;
         }
 
-        // Extract line number from formatted line: "  42 │ content"
+        // Extract line number from formatted line: "  42 | content"
         let line_num = segment
-            .find('│')
+            .find('|')
             .and_then(|pos| segment[..pos].trim().parse::<u32>().ok());
 
         if let Some(num) = line_num {
@@ -1373,7 +1371,7 @@ fn outline_context_for_match(
     let mut context = String::new();
     for (i, line) in outline_lines.iter().enumerate().take(end).skip(start) {
         if i == match_idx {
-            let _ = write!(context, "\n→ {line}");
+            let _ = write!(context, "\n-> {line}");
         } else {
             let _ = write!(context, "\n  {line}");
         }

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -78,6 +78,33 @@ const EXPAND_FULL_FILE_THRESHOLD: u64 = 800;
 /// section)" so the user knows to expand for the rest.
 const MARKDOWN_PREVIEW_MAX_LINES: usize = 40;
 
+/// Shared walker policy: searches ALL files except known junk directories.
+/// Does NOT respect .gitignore — ensures gitignored but locally-relevant files
+/// are found. Used by both the parallel search walker (`walker()`) and the
+/// sequential map walker (`crate::map::generate`), which each apply their own
+/// final `.max_depth()`/`.threads()` and `.build()`/`.build_parallel()`.
+pub(crate) fn base_walk_builder(scope: &Path) -> WalkBuilder {
+    let mut builder = WalkBuilder::new(scope);
+    builder
+        .follow_links(true)
+        .same_file_system(true) // Stop at mount boundaries (NFS, external volumes).
+        .hidden(false)
+        .git_ignore(false)
+        .git_global(false)
+        .git_exclude(false)
+        .ignore(false)
+        .parents(false)
+        .filter_entry(|entry| {
+            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
+                if let Some(name) = entry.file_name().to_str() {
+                    return !SKIP_DIRS.contains(&name);
+                }
+            }
+            true
+        });
+    builder
+}
+
 /// Build a parallel directory walker that searches ALL files except known junk directories.
 /// Does NOT respect .gitignore — ensures gitignored but locally-relevant files are found.
 /// When `glob` is Some, applies a file-pattern override (whitelist or negation).
@@ -89,25 +116,8 @@ pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkPar
             std::thread::available_parallelism().map_or(4, |n| (n.get() / 2).clamp(2, 6))
         });
 
-    let mut builder = WalkBuilder::new(scope);
-    builder
-        .follow_links(true)
-        .same_file_system(true) // Stop at mount boundaries (NFS, external volumes).
-        .hidden(false)
-        .git_ignore(false)
-        .git_global(false)
-        .git_exclude(false)
-        .ignore(false)
-        .parents(false)
-        .threads(threads)
-        .filter_entry(|entry| {
-            if entry.file_type().is_some_and(|ft| ft.is_dir()) {
-                if let Some(name) = entry.file_name().to_str() {
-                    return !SKIP_DIRS.contains(&name);
-                }
-            }
-            true
-        });
+    let mut builder = base_walk_builder(scope);
+    builder.threads(threads);
 
     if let Some(pattern) = glob {
         if !pattern.is_empty() {

--- a/src/search/siblings.rs
+++ b/src/search/siblings.rs
@@ -295,3 +295,131 @@ pub fn find_parent_entry(entries: &[OutlineEntry], method_line: u32) -> Option<&
     }
     None
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn child(kind: OutlineKind, name: &str, sig: Option<&str>, line: u32) -> OutlineEntry {
+        OutlineEntry {
+            kind,
+            name: name.to_string(),
+            start_line: line,
+            end_line: line,
+            signature: sig.map(str::to_string),
+            children: Vec::new(),
+            doc: None,
+        }
+    }
+
+    fn parent(name: &str, children: Vec<OutlineEntry>) -> OutlineEntry {
+        OutlineEntry {
+            kind: OutlineKind::Struct,
+            name: name.to_string(),
+            start_line: 1,
+            end_line: 100,
+            signature: None,
+            children,
+            doc: None,
+        }
+    }
+
+    #[test]
+    fn resolve_siblings_copies_matched_child_fields() {
+        let children = vec![child(
+            OutlineKind::Function,
+            "helper",
+            Some("fn helper(&self)"),
+            42,
+        )];
+        let resolved = resolve_siblings(&["helper".to_string()], &children);
+        assert_eq!(resolved.len(), 1);
+        assert_eq!(resolved[0].name, "helper");
+        assert_eq!(resolved[0].kind, OutlineKind::Function);
+        assert_eq!(resolved[0].signature, "fn helper(&self)");
+        assert_eq!(resolved[0].start_line, 42);
+        assert_eq!(resolved[0].end_line, 42);
+    }
+
+    #[test]
+    fn resolve_siblings_falls_back_to_name_when_signature_missing() {
+        let children = vec![child(OutlineKind::Property, "count", None, 10)];
+        let resolved = resolve_siblings(&["count".to_string()], &children);
+        assert_eq!(resolved[0].signature, "count");
+    }
+
+    #[test]
+    fn resolve_siblings_skips_names_with_no_matching_child() {
+        let children = vec![child(OutlineKind::Function, "known", None, 5)];
+        let resolved = resolve_siblings(&["known".to_string(), "unknown".to_string()], &children);
+        assert_eq!(
+            resolved.len(),
+            1,
+            "unmatched name must not appear: {resolved:?}"
+        );
+        assert_eq!(resolved[0].name, "known");
+    }
+
+    #[test]
+    fn resolve_siblings_orders_functions_before_fields() {
+        // Fields listed first in the input; functions must still sort first.
+        let children = vec![
+            child(OutlineKind::Property, "z_field", None, 1),
+            child(OutlineKind::Function, "a_method", None, 2),
+        ];
+        let resolved =
+            resolve_siblings(&["z_field".to_string(), "a_method".to_string()], &children);
+        let names: Vec<&str> = resolved.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["a_method", "z_field"]);
+    }
+
+    #[test]
+    fn resolve_siblings_breaks_ties_alphabetically_within_kind() {
+        let children = vec![
+            child(OutlineKind::Function, "zeta", None, 1),
+            child(OutlineKind::Function, "alpha", None, 2),
+            child(OutlineKind::Function, "mid", None, 3),
+        ];
+        let resolved = resolve_siblings(
+            &["zeta".to_string(), "alpha".to_string(), "mid".to_string()],
+            &children,
+        );
+        let names: Vec<&str> = resolved.iter().map(|s| s.name.as_str()).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
+    }
+
+    #[test]
+    fn resolve_siblings_truncates_at_max_siblings() {
+        let children: Vec<OutlineEntry> = (0..MAX_SIBLINGS + 3)
+            .map(|i| child(OutlineKind::Function, &format!("m{i}"), None, i as u32))
+            .collect();
+        let names: Vec<String> = children.iter().map(|c| c.name.clone()).collect();
+        let resolved = resolve_siblings(&names, &children);
+        assert_eq!(resolved.len(), MAX_SIBLINGS);
+    }
+
+    #[test]
+    fn find_parent_entry_locates_entry_owning_the_line() {
+        let entries = vec![
+            parent(
+                "Other",
+                vec![child(OutlineKind::Function, "unrelated", None, 5)],
+            ),
+            parent(
+                "Target",
+                vec![child(OutlineKind::Function, "method", None, 20)],
+            ),
+        ];
+        let found = find_parent_entry(&entries, 20).expect("parent must be found");
+        assert_eq!(found.name, "Target");
+    }
+
+    #[test]
+    fn find_parent_entry_returns_none_when_no_child_matches() {
+        let entries = vec![parent(
+            "Solo",
+            vec![child(OutlineKind::Function, "method", None, 20)],
+        )];
+        assert!(find_parent_entry(&entries, 999).is_none());
+    }
+}


### PR DESCRIPTION
Six commits from the code-quality audit, each independently gated (full test suite + clippy + fmt green after every commit, 588 → 603 tests):

1. **fix(search)**: the outline preview line duplicated a line the expansion fence was about to reprint (red-run-proven; live receipt: `exit_code` went from printed-twice to printed-once).
2. **chore(diff)**: two dead items deleted — `relative_time` (byte-identical twin of the live `format_age`) and an orphaned test helper.
3. **refactor(map)**: map generation silently missed `same_file_system(true)` that every other walker carries — extracted a shared `base_walk_builder` so the policy has one home.
4. **chore(format)**: box-drawing/arrow glyphs re-encoded to ASCII in search output (3-byte chars → 1-byte; parsing counterpart updated in lockstep; zero test assertions loosened).
5. **docs**: CLAUDE.md module map refreshed to reality (24 undocumented files documented, ghost `index/symbol.rs` entry removed); ARCHITECTURE.md's ignore-layer section rewritten to the real, deliberate policy (search walker ignores .gitignore on purpose; `.tilthignore` feature rejected 2026-07-03).
6. **test**: first direct unit coverage for `definition_weight`/`extract_definition_name` and sibling resolution — mutation-tested to prove teeth.

One audit item was investigated and correctly **declined**: the claim that the diff overview prints unchanged symbols doesn't hold against current code (the filter has been present since the function's introduction; live-verified three ways) — the audit's example was a different, intentional disclosure level.

Reported for separate follow-up, not touched here: a stale `.tilthignore` mention at ARCHITECTURE.md:840 (different claim, needs its own check) and diff/format.rs's Unicode rename-marker vocabulary (a distinct symbol system with its own tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)