### PR TITLE
[codex] add ignore controls and multi-scope CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,17 +279,21 @@ tilth <path> --section 45-89      # exact line range
 tilth <path> --section "## Foo"   # markdown heading
 tilth <path> --full               # force full content
 tilth <symbol> --scope <dir>      # definitions + usages
+tilth <symbol> --scope src --scope tests  # search multiple scopes
 tilth <symbol> --expand=5         # inline source for top 5 matches
 tilth <symbol> --callers          # find call sites (structural)
 tilth <path> --deps               # imports + dependents
 tilth "TODO: fix" --scope <dir>   # content search
 tilth "/<regex>/" --scope <dir>   # regex search
 tilth "*.test.ts" --scope <dir>   # glob files
+tilth --respect-gitignore <symbol> --scope <dir>  # honor .gitignore/.ignore
 tilth diff HEAD~1                 # structural diff (function-level)
 tilth --map --scope <dir>         # codebase skeleton (CLI only)
 ```
 
 `--map` is available in the CLI but not exposed as an MCP tool — benchmarks showed AI agents overused it, hurting accuracy.
+
+Searches always honor `.tilthignore`. `.gitignore`, `.ignore`, git excludes, and global gitignore are opt-in via `--respect-gitignore` or `TILTH_RESPECT_GITIGNORE=1`.
 
 ## Speed
 
@@ -312,7 +316,7 @@ Rust. ~20,000 lines. No runtime dependencies.
 
 - **tree-sitter** — AST parsing for 16 languages (Rust, TypeScript, TSX, JavaScript, Python, Go, Java, Scala, C, C++, Ruby, PHP, C#, Swift, Kotlin, Elixir). Used for definition detection, callee extraction, callers query, and structural outlines.
 - **ripgrep internals** (`grep-regex`, `grep-searcher`) — fast content search
-- **ignore** crate — parallel directory walking, searches all files including gitignored
+- **ignore** crate — parallel directory walking, `.tilthignore` support, optional gitignore handling
 - **memmap2** — memory-mapped file reads (no buffers)
 - **DashMap** — concurrent outline cache, invalidated by mtime
 

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -27,6 +27,7 @@ Outline format: `[<start>-<end>]  <symbol>`. Full/section format: `<line> │ <c
 
 ```bash
 tilth <symbol> --scope <dir>                # definitions + usages
+tilth <symbol> --scope src --scope tests    # search multiple scopes
 tilth "Foo,Bar,Baz" --scope <dir>           # multi-symbol (max 5)
 tilth <symbol> --expand                     # inline source for top 2 matches
 tilth <symbol> --expand=5                   # inline source for top 5
@@ -60,7 +61,8 @@ Output per match:
 ## Files
 
 ```bash
-tilth "*.test.ts" --scope <dir>   # glob (respects .gitignore)
+tilth "*.test.ts" --scope <dir>   # glob files (.tilthignore honored)
+tilth --respect-gitignore <symbol> --scope <dir>  # opt into .gitignore/.ignore
 tilth --map --scope <dir>         # codebase skeleton with directory token rollups
 ```
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,7 +18,11 @@ struct Cli {
 
     /// Directory to search within or resolve relative paths against.
     #[arg(long, default_value = ".")]
-    scope: PathBuf,
+    scope: Vec<PathBuf>,
+
+    /// Respect .gitignore, .ignore, and git exclude files while walking.
+    #[arg(long)]
+    respect_gitignore: bool,
 
     /// Line range or markdown heading (e.g. "45-89" or "## Architecture"). Bypasses smart view.
     #[arg(long)]
@@ -164,6 +168,10 @@ fn main() {
     configure_thread_pools();
     let cli = Cli::parse();
 
+    if cli.respect_gitignore {
+        std::env::set_var("TILTH_RESPECT_GITIGNORE", "1");
+    }
+
     // Shell completions
     if let Some(shell) = cli.completions {
         clap_complete::generate(shell, &mut Cli::command(), "tilth", &mut io::stdout());
@@ -256,14 +264,17 @@ fn main() {
             std::env::set_var("TILTH_NO_OVERVIEW", "1");
         }
         // Pass --scope to MCP if it's not the default "."
-        let mcp_scope = if cli.scope.as_os_str() == "." {
+        let mcp_scope = if scopes_are_default(&cli.scope) {
             None
-        } else {
+        } else if cli.scope.len() == 1 {
             Some(
-                cli.scope
+                cli.scope[0]
                     .canonicalize()
-                    .unwrap_or_else(|_| cli.scope.clone()),
+                    .unwrap_or_else(|_| cli.scope[0].clone()),
             )
+        } else {
+            eprintln!("mcp mode accepts only one --scope");
+            process::exit(2);
         };
         if let Err(e) = tilth::mcp::run(cli.edit, mcp_scope.as_deref()) {
             eprintln!("mcp error: {e}");
@@ -277,8 +288,10 @@ fn main() {
     // Map mode
     if cli.map {
         let cache = tilth::cache::OutlineCache::new();
-        let scope = cli.scope.canonicalize().unwrap_or(cli.scope);
-        let output = tilth::map::generate(&scope, 3, cli.budget, &cache);
+        let scopes = resolve_scopes(&cli.scope);
+        let output = run_for_scopes(&scopes, |scope| {
+            Ok(tilth::map::generate(scope, 3, cli.budget, &cache))
+        });
         emit_output(&output, is_tty);
         return;
     }
@@ -292,7 +305,7 @@ fn main() {
     };
 
     let cache = tilth::cache::OutlineCache::new();
-    let scope = cli.scope.canonicalize().unwrap_or(cli.scope);
+    let scopes = resolve_scopes(&cli.scope);
 
     // When piped (not a TTY), force full output — scripts expect raw content.
     // This promotion exists for FilePath queries (return full file instead of
@@ -314,73 +327,159 @@ fn main() {
 
     // Callers mode
     if cli.callers {
-        let result = tilth::run_callers(
-            &query,
-            &scope,
-            expand,
-            cli.budget,
-            cli.glob.as_deref(),
-            cli.full,
-        );
+        let result = run_query_for_scopes(&scopes, &query, |scope| {
+            tilth::run_callers(
+                &query,
+                scope,
+                expand,
+                cli.budget,
+                cli.glob.as_deref(),
+                cli.full,
+            )
+        });
         emit_result(result, &query, cli.json, is_tty);
         return;
     }
 
     // Deps mode
     if cli.deps {
-        let path = if Path::new(&query).is_absolute() {
-            PathBuf::from(&query)
-        } else {
-            let scope_path = scope.join(&query);
-            if scope_path.exists() {
-                scope_path
-            } else {
-                let cwd_path = std::env::current_dir().unwrap_or_default().join(&query);
-                if cwd_path.exists() {
-                    cwd_path
-                } else {
-                    scope_path // fall back, let analyze_deps report the error
-                }
-            }
-        };
-        let result = tilth::run_deps(&path, &scope, cli.budget);
+        let path = resolve_query_path(&query, &scopes);
+        let result = run_query_for_scopes(&scopes, &query, |scope| {
+            tilth::run_deps(&path, scope, cli.budget)
+        });
         emit_result(result, &query, cli.json, is_tty);
         return;
     }
 
-    let result = if expand > 0 {
-        tilth::run_expanded(
-            &query,
-            &scope,
-            cli.section.as_deref(),
-            cli.budget,
-            full,
-            expand,
-            cli.glob.as_deref(),
-            &cache,
-            cli.full,
-        )
-    } else if full {
-        tilth::run_full(
-            &query,
-            &scope,
-            cli.section.as_deref(),
-            cli.budget,
-            cli.glob.as_deref(),
-            &cache,
-        )
-    } else {
-        tilth::run(
-            &query,
-            &scope,
-            cli.section.as_deref(),
-            cli.budget,
-            cli.glob.as_deref(),
-            &cache,
-        )
-    };
+    let result = run_query_for_scopes(&scopes, &query, |scope| {
+        if expand > 0 {
+            tilth::run_expanded(
+                &query,
+                scope,
+                cli.section.as_deref(),
+                cli.budget,
+                full,
+                expand,
+                cli.glob.as_deref(),
+                &cache,
+                cli.full,
+            )
+        } else if full {
+            tilth::run_full(
+                &query,
+                scope,
+                cli.section.as_deref(),
+                cli.budget,
+                cli.glob.as_deref(),
+                &cache,
+            )
+        } else {
+            tilth::run(
+                &query,
+                scope,
+                cli.section.as_deref(),
+                cli.budget,
+                cli.glob.as_deref(),
+                &cache,
+            )
+        }
+    });
 
     emit_result(result, &query, cli.json, is_tty);
+}
+
+fn scopes_are_default(scopes: &[PathBuf]) -> bool {
+    scopes.len() == 1 && scopes[0].as_os_str() == "."
+}
+
+fn resolve_scopes(scopes: &[PathBuf]) -> Vec<PathBuf> {
+    if scopes.is_empty() {
+        return vec![PathBuf::from(".")
+            .canonicalize()
+            .unwrap_or_else(|_| PathBuf::from("."))];
+    }
+
+    scopes
+        .iter()
+        .map(|scope| scope.canonicalize().unwrap_or_else(|_| scope.clone()))
+        .collect()
+}
+
+fn resolve_query_path(query: &str, scopes: &[PathBuf]) -> PathBuf {
+    if Path::new(query).is_absolute() {
+        return PathBuf::from(query);
+    }
+
+    for scope in scopes {
+        let scoped = scope.join(query);
+        if scoped.exists() {
+            return scoped;
+        }
+    }
+
+    let cwd_path = std::env::current_dir().unwrap_or_default().join(query);
+    if cwd_path.exists() {
+        return cwd_path;
+    }
+
+    scopes
+        .first()
+        .map_or_else(|| PathBuf::from(query), |scope| scope.join(query))
+}
+
+fn run_for_scopes<F>(scopes: &[PathBuf], mut run: F) -> String
+where
+    F: FnMut(&Path) -> Result<String, tilth::error::TilthError>,
+{
+    if scopes.len() == 1 {
+        return run(&scopes[0]).unwrap_or_else(|e| e.to_string());
+    }
+
+    scopes
+        .iter()
+        .map(|scope| {
+            let output = run(scope).unwrap_or_else(|e| e.to_string());
+            format!("# Scope: {}\n\n{output}", scope.display())
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n---\n")
+}
+
+fn run_query_for_scopes<F>(
+    scopes: &[PathBuf],
+    query: &str,
+    mut run: F,
+) -> Result<String, tilth::error::TilthError>
+where
+    F: FnMut(&Path) -> Result<String, tilth::error::TilthError>,
+{
+    if scopes.len() == 1 {
+        return run(&scopes[0]);
+    }
+
+    let mut outputs = Vec::new();
+    let mut first_err = None;
+    for scope in scopes {
+        match run(scope) {
+            Ok(output) => outputs.push(format!("# Scope: {}\n\n{output}", scope.display())),
+            Err(err) => {
+                if first_err.is_none() {
+                    first_err = Some(err);
+                }
+            }
+        }
+    }
+
+    if outputs.is_empty() {
+        Err(
+            first_err.unwrap_or_else(|| tilth::error::TilthError::NotFound {
+                path: PathBuf::from(query),
+                suggestion: None,
+            }),
+        )
+    } else {
+        Ok(outputs.join("\n\n---\n"))
+    }
 }
 
 fn emit_result(
@@ -546,5 +645,15 @@ mod tests {
         // handling, but cli.full stays false. compute_expand must return 0.
         let cli_full = false; // user did NOT pass --full
         assert_eq!(compute_expand(None, cli_full), 0);
+    }
+
+    #[test]
+    fn repeated_scope_flags_accumulate() {
+        let cli = Cli::try_parse_from(["tilth", "foo", "--scope", "src", "--scope", "tests"])
+            .expect("parse repeated scopes");
+        assert_eq!(
+            cli.scope,
+            vec![PathBuf::from("src"), PathBuf::from("tests")]
+        );
     }
 }

--- a/src/search/glob.rs
+++ b/src/search/glob.rs
@@ -20,8 +20,8 @@ pub struct GlobResult {
     pub available_extensions: Vec<String>,
 }
 
-/// Glob search using `ignore::WalkBuilder` (parallel via `super::walker` —
-/// deliberately NOT .gitignore-aware, see `walker`'s doc comment).
+/// Glob search using `ignore::WalkBuilder` (parallel via `super::walker`,
+/// with the same `.tilthignore` and opt-in gitignore policy).
 pub fn search(pattern: &str, scope: &Path) -> Result<GlobResult, TilthError> {
     let glob = Glob::new(pattern).map_err(|e| TilthError::InvalidQuery {
         query: pattern.to_string(),

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -35,8 +35,8 @@ use crate::types::{estimate_tokens, FileType, Match, SearchResult};
 use crate::format::rel;
 
 // Directories that are always skipped — build artifacts, dependencies, VCS internals.
-// We skip these explicitly instead of relying on .gitignore so that locally-relevant
-// gitignored files (docs/, configs, generated code) are still searchable.
+// Keep this list even when ignore files are disabled; it covers common
+// high-volume directories that are rarely useful search targets.
 pub(crate) const SKIP_DIRS: &[&str] = &[
     ".git",
     "node_modules",
@@ -78,22 +78,36 @@ const EXPAND_FULL_FILE_THRESHOLD: u64 = 800;
 /// section)" so the user knows to expand for the rest.
 const MARKDOWN_PREVIEW_MAX_LINES: usize = 40;
 
-/// Shared walker policy: searches ALL files except known junk directories.
-/// Does NOT respect .gitignore — ensures gitignored but locally-relevant files
-/// are found. Used by both the parallel search walker (`walker()`) and the
-/// sequential map walker (`crate::map::generate`), which each apply their own
-/// final `.max_depth()`/`.threads()` and `.build()`/`.build_parallel()`.
+fn respect_gitignore_from_env() -> bool {
+    std::env::var("TILTH_RESPECT_GITIGNORE").is_ok_and(|v| {
+        matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+/// Shared walker policy: searches files except known junk directories and
+/// `.tilthignore` entries. Gitignore-style files are opt-in.
+/// Used by both the parallel search walker (`walker()`) and the sequential map
+/// walker (`crate::map::generate`), which each apply their own final
+/// `.max_depth()`/`.threads()` and `.build()`/`.build_parallel()`.
 pub(crate) fn base_walk_builder(scope: &Path) -> WalkBuilder {
+    base_walk_builder_with_gitignore(scope, respect_gitignore_from_env())
+}
+
+fn base_walk_builder_with_gitignore(scope: &Path, respect_gitignore: bool) -> WalkBuilder {
     let mut builder = WalkBuilder::new(scope);
     builder
         .follow_links(true)
         .same_file_system(true) // Stop at mount boundaries (NFS, external volumes).
         .hidden(false)
-        .git_ignore(false)
-        .git_global(false)
-        .git_exclude(false)
-        .ignore(false)
-        .parents(false)
+        .git_ignore(respect_gitignore)
+        .git_global(respect_gitignore)
+        .git_exclude(respect_gitignore)
+        .ignore(respect_gitignore)
+        .parents(respect_gitignore)
+        .add_custom_ignore_filename(".tilthignore")
         .filter_entry(|entry| {
             if entry.file_type().is_some_and(|ft| ft.is_dir()) {
                 if let Some(name) = entry.file_name().to_str() {
@@ -105,8 +119,8 @@ pub(crate) fn base_walk_builder(scope: &Path) -> WalkBuilder {
     builder
 }
 
-/// Build a parallel directory walker that searches ALL files except known junk directories.
-/// Does NOT respect .gitignore — ensures gitignored but locally-relevant files are found.
+/// Build a parallel directory walker over `.tilthignore`-filtered files except
+/// known junk directories. Gitignore-style files are opt-in.
 /// When `glob` is Some, applies a file-pattern override (whitelist or negation).
 pub(crate) fn walker(scope: &Path, glob: Option<&str>) -> Result<ignore::WalkParallel, TilthError> {
     let threads = std::env::var("TILTH_THREADS")
@@ -1540,6 +1554,15 @@ mod tests {
     /// Collect all file paths from a walker into a sorted Vec.
     fn walk_paths(scope: &Path, glob: Option<&str>) -> Vec<PathBuf> {
         let w = walker(scope, glob).expect("walker failed");
+        collect_walk_paths(w)
+    }
+
+    fn walk_paths_with_gitignore(scope: &Path, respect_gitignore: bool) -> Vec<PathBuf> {
+        let w = base_walk_builder_with_gitignore(scope, respect_gitignore).build_parallel();
+        collect_walk_paths(w)
+    }
+
+    fn collect_walk_paths(w: ignore::WalkParallel) -> Vec<PathBuf> {
         let paths: Mutex<Vec<PathBuf>> = Mutex::new(Vec::new());
         w.run(|| {
             let paths = &paths;
@@ -1574,6 +1597,95 @@ mod tests {
         let exts = extensions(&all);
         assert!(exts.contains("rs"), "expected .rs files, got {exts:?}");
         assert!(!all.is_empty());
+    }
+
+    #[test]
+    fn walker_ignores_gitignore_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::create_dir(tmp.path().join("ignored")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "ignored/\n").unwrap();
+        std::fs::write(tmp.path().join("visible.rs"), "fn visible() {}\n").unwrap();
+        std::fs::write(
+            tmp.path().join("ignored").join("hidden.rs"),
+            "fn hidden() {}\n",
+        )
+        .unwrap();
+
+        let paths = walk_paths_with_gitignore(tmp.path(), false);
+        let rels: HashSet<String> = paths
+            .iter()
+            .filter_map(|p| p.strip_prefix(tmp.path()).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            rels.contains("visible.rs"),
+            "non-ignored file should be walked: {rels:?}"
+        );
+        assert!(
+            rels.contains("ignored/hidden.rs"),
+            "gitignored file should be walked by default: {rels:?}"
+        );
+    }
+
+    #[test]
+    fn walker_respects_tilthignore_by_default() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join("ignored")).unwrap();
+        std::fs::write(tmp.path().join(".tilthignore"), "ignored/\n").unwrap();
+        std::fs::write(tmp.path().join("visible.rs"), "fn visible() {}\n").unwrap();
+        std::fs::write(
+            tmp.path().join("ignored").join("hidden.rs"),
+            "fn hidden() {}\n",
+        )
+        .unwrap();
+
+        let paths = walk_paths_with_gitignore(tmp.path(), false);
+        let rels: HashSet<String> = paths
+            .iter()
+            .filter_map(|p| p.strip_prefix(tmp.path()).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            rels.contains("visible.rs"),
+            "non-ignored file should be walked: {rels:?}"
+        );
+        assert!(
+            !rels.contains("ignored/hidden.rs"),
+            ".tilthignore file should not be walked: {rels:?}"
+        );
+    }
+
+    #[test]
+    fn walker_respects_gitignore_when_enabled() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::create_dir(tmp.path().join(".git")).unwrap();
+        std::fs::create_dir(tmp.path().join("ignored")).unwrap();
+        std::fs::write(tmp.path().join(".gitignore"), "ignored/\n").unwrap();
+        std::fs::write(tmp.path().join("visible.rs"), "fn visible() {}\n").unwrap();
+        std::fs::write(
+            tmp.path().join("ignored").join("hidden.rs"),
+            "fn hidden() {}\n",
+        )
+        .unwrap();
+
+        let paths = walk_paths_with_gitignore(tmp.path(), true);
+        let rels: HashSet<String> = paths
+            .iter()
+            .filter_map(|p| p.strip_prefix(tmp.path()).ok())
+            .map(|p| p.to_string_lossy().to_string())
+            .collect();
+
+        assert!(
+            rels.contains("visible.rs"),
+            "non-ignored file should be walked: {rels:?}"
+        );
+        assert!(
+            !rels.contains("ignored/hidden.rs"),
+            "gitignored file should not be walked when enabled: {rels:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add `.tilthignore` support while preserving the existing default of ignoring `.gitignore` rules
- add `--respect-gitignore` and `TILTH_RESPECT_GITIGNORE=1` opt-in support
- allow repeated top-level `--scope` values for CLI query, callers, deps, and map fanout

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test`
- `cargo build`
- manual: `target/debug/tilth search_symbol --scope src --scope README.md --budget 1800`
- manual: `target/debug/tilth --respect-gitignore outlook --scope ../quant`
