### PR TITLE
refactor(lang): consolidate per-language data into LangSpec table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "tree-sitter-java",
  "tree-sitter-javascript",
  "tree-sitter-kotlin-ng",
+ "tree-sitter-language",
  "tree-sitter-md",
  "tree-sitter-php",
  "tree-sitter-python",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap_complete = "4"
 
 # Tree-sitter (AST outlines)
 tree-sitter = "0.26"
+tree-sitter-language = "0.1"
 streaming-iterator = "0.1"
 tree-sitter-rust = "0.24"
 tree-sitter-javascript = "0.25"

--- a/src/lang/bash.rs
+++ b/src/lang/bash.rs
@@ -1,0 +1,21 @@
+//! Bash language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = "(command name: (command_name) @callee)\n";
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Bash",
+    extensions: &["sh", "bash", "bats"],
+    filenames: &[".bashrc", ".bash_profile", ".bash_aliases", ".profile"],
+    grammar: Some(tree_sitter_bash::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::Bash),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/c.rs
+++ b/src/lang/c.rs
@@ -1,0 +1,25 @@
+//! C language spec. Shares its callee query with C++.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+/// Callee query shared by C and C++.
+pub(crate) const CALLEE_QUERY: &str = concat!(
+    "(call_expression function: (identifier) @callee)\n",
+    "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "C",
+    extensions: &["c", "h"],
+    filenames: &[],
+    grammar: Some(tree_sitter_c::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::CppC),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/cpp.rs
+++ b/src/lang/cpp.rs
@@ -1,0 +1,20 @@
+//! C++ language spec. Shares its callee query with C.
+
+use crate::lang::c::CALLEE_QUERY;
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "C++",
+    extensions: &["cpp", "hpp", "cc", "cxx"],
+    filenames: &[],
+    grammar: Some(tree_sitter_cpp::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::CppC),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/csharp.rs
+++ b/src/lang/csharp.rs
@@ -1,0 +1,29 @@
+//! C# language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(invocation_expression function: (identifier) @callee)\n",
+    "(invocation_expression function: (member_access_expression name: (identifier) @callee))\n",
+);
+
+const SIBLING_QUERY: &str = concat!(
+    "(member_access_expression expression: (this_expression) name: (identifier) @ref)\n",
+    "(invocation_expression function: (member_access_expression expression: (this_expression) name: (identifier) @ref))\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "C#",
+    extensions: &["cs"],
+    filenames: &[],
+    grammar: Some(tree_sitter_c_sharp::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JavaKotlinCSharp),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/dockerfile.rs
+++ b/src/lang/dockerfile.rs
@@ -1,0 +1,19 @@
+//! Dockerfile spec. No tree-sitter grammar shipped — outline returns `None`.
+
+use crate::lang::spec::{LangSpec, StdlibRule, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Docker",
+    extensions: &[],
+    filenames: &["Dockerfile", "Containerfile"],
+    grammar: None,
+    callee_query: None,
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/elixir.rs
+++ b/src/lang/elixir.rs
@@ -1,0 +1,135 @@
+//! Elixir language spec. Diverges on the entire definition cluster: in Elixir
+//! every definition is a `call` node whose `target` identifier is the keyword
+//! (`def`, `defmodule`, …), so the default field-name extractor does not apply.
+//! The definition detection + name extraction + weight live here and are wired
+//! into [`SPEC`] via its `definition_kinds` / `definitions` fields.
+
+use crate::lang::spec::{DefinitionOps, LangSpec, StdlibRule};
+use crate::lang::treesitter::{
+    elixir_arguments, elixir_extract_func_head_name, node_text_simple, NodeTextMode,
+};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call target: (identifier) @callee)\n",
+    "(call target: (dot right: (identifier) @callee))\n",
+);
+
+/// Elixir call-node target identifiers that define named symbols.
+/// This is the complete set used for definition detection in symbol search/index.
+/// See also `ELIXIR_DEF_KEYWORDS` in `outline.rs` which is the subset of
+/// function-like keywords (excludes container keywords like `defmodule`,
+/// `defprotocol`, `defimpl`, `defstruct`, `defexception` that have their own
+/// outline handling).
+pub(crate) const ELIXIR_DEFINITION_TARGETS: &[&str] = &[
+    "defmodule",
+    "def",
+    "defp",
+    "defmacro",
+    "defmacrop",
+    "defguard",
+    "defguardp",
+    "defdelegate",
+    "defstruct",
+    "defexception",
+    "defprotocol",
+    "defimpl",
+];
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Elixir",
+    extensions: &["ex", "exs"],
+    filenames: &[],
+    grammar: Some(tree_sitter_elixir::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &["mix.exs"],
+    definition_kinds: ELIXIR_DEFINITION_TARGETS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DefinitionOps {
+        extract_name: extract_elixir_definition_name,
+        weight: elixir_definition_weight,
+    },
+};
+
+/// Check if a tree-sitter node is an Elixir definition.
+/// In Elixir all definitions are `call` nodes whose `target` identifier
+/// is one of `defmodule`, `def`, `defp`, etc.
+pub(crate) fn is_elixir_definition(node: tree_sitter::Node, lines: &[&str]) -> bool {
+    if node.kind() != "call" {
+        return false;
+    }
+    let Some(target) = node.child_by_field_name("target") else {
+        return false;
+    };
+    let kw = node_text_simple(target, lines, NodeTextMode::Full);
+    ELIXIR_DEFINITION_TARGETS.contains(&kw.as_str())
+}
+
+/// Extract the defined name from an Elixir definition `call` node.
+///
+/// - `defmodule Foo.Bar do...end` → `"Foo.Bar"`
+/// - `def greet(name) do...end`  → `"greet"`
+/// - `defstruct [:a, :b]`       → `"defstruct"`
+pub(crate) fn extract_elixir_definition_name(
+    node: tree_sitter::Node,
+    lines: &[&str],
+) -> Option<String> {
+    let target = node.child_by_field_name("target")?;
+    let kw = node_text_simple(target, lines, NodeTextMode::Full);
+    let args = elixir_arguments(node)?;
+
+    match kw.as_str() {
+        "defmodule" | "defprotocol" | "defimpl" => {
+            // First named child of arguments is the module/protocol alias.
+            // For `defimpl Printable, for: User`, this returns "Printable" (the
+            // protocol name), not "User" (the implementing type). Searching for
+            // the protocol name will find both the protocol and all its impls.
+            let mut cursor = args.walk();
+            for child in args.children(&mut cursor) {
+                if child.is_named() {
+                    return Some(node_text_simple(child, lines, NodeTextMode::Full));
+                }
+            }
+            None
+        }
+        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
+            // First named child is:
+            //   `call`              — normal: `def greet(name)`
+            //   `identifier`        — no-arg: `def bar, do: :ok`
+            //   `binary_operator`   — guard:  `def foo(x) when x > 0`
+            let mut cursor = args.walk();
+            for child in args.children(&mut cursor) {
+                if !child.is_named() {
+                    continue;
+                }
+                return elixir_extract_func_head_name(child, lines);
+            }
+            None
+        }
+        // In Elixir, a struct IS its enclosing module (`%MyModule{}`), and only
+        // one struct per module is allowed. There's no standalone struct name to
+        // extract, so we index the keyword itself. Search for the struct by its
+        // module name instead.
+        "defstruct" | "defexception" => Some(kw.clone()),
+        _ => None,
+    }
+}
+
+/// Semantic weight for Elixir definition keywords. Matches the `DefinitionOps.weight`
+/// signature `(node, lines) -> u16`.
+pub(crate) fn elixir_definition_weight(node: tree_sitter::Node, lines: &[&str]) -> u16 {
+    let Some(target) = node.child_by_field_name("target") else {
+        return 50;
+    };
+    let kw = node_text_simple(target, lines, NodeTextMode::Full);
+    match kw.as_str() {
+        "defmodule" | "defprotocol" | "def" | "defp" | "defmacro" | "defmacrop" | "defguard"
+        | "defguardp" | "defdelegate" => 100,
+        "defimpl" => 90,
+        "defstruct" | "defexception" => 80,
+        _ => 50,
+    }
+}

--- a/src/lang/go.rs
+++ b/src/lang/go.rs
@@ -97,7 +97,7 @@ pub(crate) fn extract_go_receiver_name(
     let bytes = content.as_bytes();
 
     // `with_query` returns `Option<Option<String>>`; flatten to `Option<String>`.
-    crate::search::siblings::with_query(ts_lang, GO_RECV_QUERY, |query| {
+    crate::lang::treesitter::with_query(ts_lang, GO_RECV_QUERY, |query| {
         let recv_idx = query.capture_index_for_name("recv")?;
         let mut cursor = tree_sitter::QueryCursor::new();
         let mut matches = cursor.matches(query, tree.root_node(), bytes);

--- a/src/lang/go.rs
+++ b/src/lang/go.rs
@@ -1,0 +1,116 @@
+//! Go language spec. Diverges on: stdlib rule and method-receiver extraction.
+
+use streaming_iterator::StreamingIterator;
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call_expression function: (identifier) @callee)\n",
+    "(call_expression function: (selector_expression field: (field_identifier) @callee))\n",
+);
+
+const SIBLING_QUERY: &str =
+    "(selector_expression operand: (identifier) @recv field: (field_identifier) @ref)\n";
+
+/// Root (first `/`-segment) of each Go stdlib package. A Go import is stdlib
+/// when its first path segment is one of these — covering both single-segment
+/// (`fmt`) and multi-segment (`net/http`, `encoding/json`) forms. Matching the
+/// root (not the whole path) avoids misclassifying a local package like
+/// `mypackage` while still suppressing the noisy multi-segment stdlib paths.
+const GO_STDLIB_ROOTS: &[&str] = &[
+    "archive",
+    "bufio",
+    "bytes",
+    "cmp",
+    "compress",
+    "container",
+    "context",
+    "crypto",
+    "database",
+    "debug",
+    "embed",
+    "encoding",
+    "errors",
+    "flag",
+    "fmt",
+    "go",
+    "hash",
+    "html",
+    "image",
+    "index",
+    "io",
+    "log",
+    "maps",
+    "math",
+    "mime",
+    "net",
+    "os",
+    "path",
+    "plugin",
+    "reflect",
+    "regexp",
+    "runtime",
+    "slices",
+    "sort",
+    "strconv",
+    "strings",
+    "sync",
+    "syscall",
+    "testing",
+    "text",
+    "time",
+    "unicode",
+    "unsafe",
+    // Go 1.23+ additions
+    "iter",
+    "unique",
+];
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Go",
+    extensions: &["go"],
+    filenames: &[],
+    grammar: Some(tree_sitter_go::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::GoRoots(GO_STDLIB_ROOTS),
+    manifests: &["go.mod"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::Go),
+    extract_receiver: Some(extract_go_receiver_name),
+    definitions: DEFAULT_DEFS,
+};
+
+/// For Go methods, extract the receiver parameter name from the first method
+/// in the file. Go receiver is the first parameter in `func (r *Type) Name()`.
+pub(crate) fn extract_go_receiver_name(
+    content: &str,
+    ts_lang: &tree_sitter::Language,
+) -> Option<String> {
+    // `'static` so its pointer address is a stable cache key.
+    const GO_RECV_QUERY: &str = "(method_declaration receiver: (parameter_list (parameter_declaration name: (identifier) @recv)))";
+
+    let mut parser = tree_sitter::Parser::new();
+    parser.set_language(ts_lang).ok()?;
+    let tree = parser.parse(content, None)?;
+
+    let bytes = content.as_bytes();
+
+    // `with_query` returns `Option<Option<String>>`; flatten to `Option<String>`.
+    crate::search::siblings::with_query(ts_lang, GO_RECV_QUERY, |query| {
+        let recv_idx = query.capture_index_for_name("recv")?;
+        let mut cursor = tree_sitter::QueryCursor::new();
+        let mut matches = cursor.matches(query, tree.root_node(), bytes);
+
+        if let Some(m) = matches.next() {
+            for cap in m.captures {
+                if cap.index == recv_idx {
+                    return cap.node.utf8_text(bytes).ok().map(String::from);
+                }
+            }
+        }
+
+        None
+    })
+    .flatten()
+}

--- a/src/lang/java.rs
+++ b/src/lang/java.rs
@@ -1,0 +1,26 @@
+//! Java language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = "(method_invocation name: (identifier) @callee)\n";
+
+const SIBLING_QUERY: &str = concat!(
+    "(field_access object: (this) field: (identifier) @ref)\n",
+    "(method_invocation object: (this) name: (identifier) @ref)\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Java",
+    extensions: &["java"],
+    filenames: &[],
+    grammar: Some(tree_sitter_java::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &["pom.xml", "build.gradle"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JavaKotlinCSharp),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/javascript.rs
+++ b/src/lang/javascript.rs
@@ -1,0 +1,29 @@
+//! JavaScript language spec. Shares callee/sibling queries with TS/TSX.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+/// Callee query shared by JavaScript, TypeScript, and TSX.
+pub(crate) const CALLEE_QUERY: &str = concat!(
+    "(call_expression function: (identifier) @callee)\n",
+    "(call_expression function: (member_expression property: (property_identifier) @callee))\n",
+);
+
+/// Sibling (`this.x`) query shared by JavaScript, TypeScript, and TSX.
+pub(crate) const SIBLING_QUERY: &str =
+    "(member_expression object: (this) property: (property_identifier) @ref)\n";
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "JavaScript",
+    extensions: &["js", "jsx"],
+    filenames: &[],
+    grammar: Some(tree_sitter_javascript::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &["package.json"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JsTs),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/kotlin.rs
+++ b/src/lang/kotlin.rs
@@ -1,0 +1,24 @@
+//! Kotlin language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call_expression (identifier) @callee)\n",
+    "(call_expression (navigation_expression (identifier) @callee .))\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Kotlin",
+    extensions: &["kt", "kts"],
+    filenames: &[],
+    grammar: Some(tree_sitter_kotlin_ng::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JavaKotlinCSharp),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/make.rs
+++ b/src/lang/make.rs
@@ -1,0 +1,19 @@
+//! Makefile spec. No tree-sitter grammar shipped — outline returns `None`.
+
+use crate::lang::spec::{LangSpec, StdlibRule, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Make",
+    extensions: &[],
+    filenames: &["Makefile", "GNUmakefile"],
+    grammar: None,
+    callee_query: None,
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -2,73 +2,116 @@ pub mod detection;
 pub mod outline;
 pub mod treesitter;
 
+pub(crate) mod spec;
+
+pub(crate) mod bash;
+pub(crate) mod c;
+pub(crate) mod cpp;
+pub(crate) mod csharp;
+pub(crate) mod dockerfile;
+pub(crate) mod elixir;
+pub(crate) mod go;
+pub(crate) mod java;
+pub(crate) mod javascript;
+pub(crate) mod kotlin;
+pub(crate) mod make;
+pub(crate) mod php;
+pub(crate) mod python;
+pub(crate) mod ruby;
+pub(crate) mod rust;
+pub(crate) mod scala;
+pub(crate) mod swift;
+pub(crate) mod tsx;
+pub(crate) mod typescript;
+
 use std::path::Path;
 
 use crate::types::{FileType, Lang};
 
+/// Every `Lang` variant, in declaration order. Used to scan per-language
+/// `spec(lang)` data when building extension / filename / manifest lookups.
+const ALL_LANGS: &[Lang] = &[
+    Lang::Rust,
+    Lang::TypeScript,
+    Lang::Tsx,
+    Lang::JavaScript,
+    Lang::Python,
+    Lang::Go,
+    Lang::Java,
+    Lang::Scala,
+    Lang::C,
+    Lang::Cpp,
+    Lang::Ruby,
+    Lang::Php,
+    Lang::Swift,
+    Lang::Kotlin,
+    Lang::CSharp,
+    Lang::Elixir,
+    Lang::Dockerfile,
+    Lang::Make,
+    Lang::Bash,
+];
+
+/// Test-only accessor for the full `Lang` set, so `spec`'s table-invariant
+/// tests can iterate every variant without making `ALL_LANGS` public.
+#[cfg(test)]
+pub(crate) fn mod_all_langs_for_test() -> &'static [Lang] {
+    ALL_LANGS
+}
+
 /// Detect file type by extension, then by name.
 pub fn detect_file_type(path: &Path) -> FileType {
     match path.extension().and_then(|e| e.to_str()) {
-        Some("ts") => FileType::Code(Lang::TypeScript),
-        Some("tsx") => FileType::Code(Lang::Tsx),
-        Some("js" | "jsx") => FileType::Code(Lang::JavaScript),
-        Some("py" | "pyi") => FileType::Code(Lang::Python),
-        Some("rs") => FileType::Code(Lang::Rust),
-        Some("go") => FileType::Code(Lang::Go),
-        Some("java") => FileType::Code(Lang::Java),
-        Some("scala" | "sc") => FileType::Code(Lang::Scala),
-        Some("c" | "h") => FileType::Code(Lang::C),
-        Some("cpp" | "hpp" | "cc" | "cxx") => FileType::Code(Lang::Cpp),
-        Some("rb") => FileType::Code(Lang::Ruby),
-        Some("php" | "phtml") => FileType::Code(Lang::Php),
-        Some("swift") => FileType::Code(Lang::Swift),
-        Some("kt" | "kts") => FileType::Code(Lang::Kotlin),
-        Some("cs") => FileType::Code(Lang::CSharp),
-        Some("ex" | "exs") => FileType::Code(Lang::Elixir),
-        Some("sh" | "bash" | "bats") => FileType::Code(Lang::Bash),
-
-        Some("md" | "mdx" | "rst") => FileType::Markdown,
-        Some("json" | "yaml" | "yml" | "toml" | "xml" | "ini") => FileType::StructuredData,
-        Some("csv" | "tsv") => FileType::Tabular,
-        Some("log") => FileType::Log,
-
+        Some(ext) => {
+            // Code extensions come from each language's `spec.extensions`.
+            for &lang in ALL_LANGS {
+                if spec::spec(lang).extensions.contains(&ext) {
+                    return FileType::Code(lang);
+                }
+            }
+            // Non-code extensions stay enumerated here.
+            match ext {
+                "md" | "mdx" | "rst" => FileType::Markdown,
+                "json" | "yaml" | "yml" | "toml" | "xml" | "ini" => FileType::StructuredData,
+                "csv" | "tsv" => FileType::Tabular,
+                "log" => FileType::Log,
+                _ => FileType::Other,
+            }
+        }
         None => file_type_from_name(path),
-        _ => FileType::Other,
     }
 }
 
 fn file_type_from_name(path: &Path) -> FileType {
-    match path.file_name().and_then(|n| n.to_str()) {
-        Some("Dockerfile" | "Containerfile") => FileType::Code(Lang::Dockerfile),
-        Some("Makefile" | "GNUmakefile") => FileType::Code(Lang::Make),
-        Some("Vagrantfile" | "Rakefile") => FileType::Code(Lang::Ruby),
-        Some(n) if n.starts_with(".env") => FileType::StructuredData,
-        Some(".bashrc" | ".bash_profile" | ".bash_aliases" | ".profile") => {
-            FileType::Code(Lang::Bash)
+    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+        return FileType::Other;
+    };
+    // Code filenames come from each language's `spec.filenames`.
+    for &lang in ALL_LANGS {
+        if spec::spec(lang).filenames.contains(&name) {
+            return FileType::Code(lang);
         }
-        _ => FileType::Other,
     }
+    if name.starts_with(".env") {
+        return FileType::StructuredData;
+    }
+    FileType::Other
 }
 
 /// Find the nearest package root by looking for manifest files.
+///
+/// The manifest list is aggregated from every language's `spec.manifests`. A
+/// directory is a package root if it contains *any* manifest; order is
+/// irrelevant because the matched directory is returned regardless of which
+/// manifest hit.
 pub(crate) fn package_root(path: &Path) -> Option<&Path> {
-    const MANIFESTS: &[&str] = &[
-        "Cargo.toml",
-        "package.json",
-        "pyproject.toml",
-        "setup.py",
-        "go.mod",
-        "pom.xml",
-        "build.gradle",
-        "build.sbt",
-        "mix.exs",
-        "composer.json", // PHP / Laravel
-    ];
     let mut dir = path;
     loop {
-        for m in MANIFESTS {
-            if dir.join(m).exists() {
-                return Some(dir);
+        for &lang in ALL_LANGS {
+            for m in spec::spec(lang).manifests {
+                if dir.join(m).exists() {
+                    return Some(dir);
+                }
             }
         }
         dir = dir.parent()?;

--- a/src/lang/mod.rs
+++ b/src/lang/mod.rs
@@ -24,7 +24,9 @@ pub(crate) mod swift;
 pub(crate) mod tsx;
 pub(crate) mod typescript;
 
+use std::collections::HashMap;
 use std::path::Path;
+use std::sync::LazyLock;
 
 use crate::types::{FileType, Lang};
 
@@ -59,15 +61,24 @@ pub(crate) fn mod_all_langs_for_test() -> &'static [Lang] {
     ALL_LANGS
 }
 
+/// Extension → language lookup, built once from every `LangSpec.extensions`.
+/// Replaces a per-call linear scan over `ALL_LANGS` with an O(1) hash lookup.
+static EXT_TO_LANG: LazyLock<HashMap<&'static str, Lang>> = LazyLock::new(|| {
+    let mut map = HashMap::new();
+    for &lang in ALL_LANGS {
+        for &ext in spec::spec(lang).extensions {
+            map.entry(ext).or_insert(lang);
+        }
+    }
+    map
+});
+
 /// Detect file type by extension, then by name.
 pub fn detect_file_type(path: &Path) -> FileType {
     match path.extension().and_then(|e| e.to_str()) {
         Some(ext) => {
-            // Code extensions come from each language's `spec.extensions`.
-            for &lang in ALL_LANGS {
-                if spec::spec(lang).extensions.contains(&ext) {
-                    return FileType::Code(lang);
-                }
+            if let Some(&lang) = EXT_TO_LANG.get(ext) {
+                return FileType::Code(lang);
             }
             // Non-code extensions stay enumerated here.
             match ext {

--- a/src/lang/outline.rs
+++ b/src/lang/outline.rs
@@ -1,32 +1,9 @@
-use crate::lang::treesitter::node_text_simple;
+use crate::lang::treesitter::{node_text_simple, NodeTextMode};
 use crate::types::{Lang, OutlineEntry, OutlineKind};
 
 /// Get the tree-sitter Language for a given Lang variant.
 pub fn outline_language(lang: Lang) -> Option<tree_sitter::Language> {
-    let lang = match lang {
-        Lang::Rust => tree_sitter_rust::LANGUAGE,
-        Lang::TypeScript => tree_sitter_typescript::LANGUAGE_TYPESCRIPT,
-        Lang::Tsx => tree_sitter_typescript::LANGUAGE_TSX,
-        Lang::JavaScript => tree_sitter_javascript::LANGUAGE,
-        Lang::Python => tree_sitter_python::LANGUAGE,
-        Lang::Scala => tree_sitter_scala::LANGUAGE,
-        Lang::Go => tree_sitter_go::LANGUAGE,
-        Lang::Java => tree_sitter_java::LANGUAGE,
-        Lang::C => tree_sitter_c::LANGUAGE,
-        Lang::Cpp => tree_sitter_cpp::LANGUAGE,
-        Lang::Ruby => tree_sitter_ruby::LANGUAGE,
-        Lang::Php => tree_sitter_php::LANGUAGE_PHP,
-        // Languages without shipped grammars — fall back
-        Lang::CSharp => tree_sitter_c_sharp::LANGUAGE,
-        Lang::Swift => tree_sitter_swift::LANGUAGE,
-        Lang::Kotlin => tree_sitter_kotlin_ng::LANGUAGE,
-        Lang::Elixir => tree_sitter_elixir::LANGUAGE,
-        Lang::Bash => tree_sitter_bash::LANGUAGE,
-        Lang::Dockerfile | Lang::Make => {
-            return None;
-        }
-    };
-    Some(lang.into())
+    crate::lang::spec::spec(lang).grammar.map(Into::into)
 }
 
 /// Parse markdown content into a tree-sitter block tree.
@@ -90,7 +67,7 @@ pub fn heading_text(node: tree_sitter::Node, lines: &[&str]) -> String {
     let mut cursor = node.walk();
     for child in node.children(&mut cursor) {
         if child.kind() == "inline" {
-            let text = node_text_simple(child, lines);
+            let text = node_text_simple(child, lines, NodeTextMode::Full);
             return text.trim().trim_end_matches('#').trim().to_string();
         }
     }
@@ -432,26 +409,7 @@ fn assignment_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
 
 /// Get the text of a node, truncated to the first line.
 fn node_text(node: tree_sitter::Node, lines: &[&str]) -> String {
-    let row = node.start_position().row;
-    let col_start = node.start_position().column;
-    let end_row = node.end_position().row;
-
-    if row < lines.len() {
-        if row == end_row {
-            let col_end = node.end_position().column.min(lines[row].len());
-            lines[row][col_start..col_end].to_string()
-        } else {
-            // Multi-line — take first line only, truncated
-            let text = &lines[row][col_start..];
-            if text.len() > 80 {
-                format!("{}...", crate::types::truncate_str(text, 77))
-            } else {
-                text.to_string()
-            }
-        }
-    } else {
-        String::new()
-    }
+    node_text_simple(node, lines, NodeTextMode::Truncated)
 }
 
 /// Find the first identifier-like child.
@@ -514,7 +472,7 @@ fn extract_doc(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
 /// This is the subset of definition keywords handled uniformly (extract function
 /// name from arguments). Container keywords (`defmodule`, `defprotocol`, `defimpl`,
 /// `defstruct`, `defexception`) have their own match arms in `elixir_call_to_entry`.
-/// See also `ELIXIR_DEFINITION_TARGETS` in `treesitter.rs` for the complete set.
+/// See also `ELIXIR_DEFINITION_TARGETS` in `elixir.rs` for the complete set.
 const ELIXIR_DEF_KEYWORDS: &[&str] = &[
     "def",
     "defp",

--- a/src/lang/php.rs
+++ b/src/lang/php.rs
@@ -1,0 +1,28 @@
+//! PHP language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(function_call_expression function: (name) @callee)\n",
+    "(function_call_expression function: (qualified_name) @callee)\n",
+    "(function_call_expression function: (relative_name) @callee)\n",
+    "(member_call_expression name: (name) @callee)\n",
+    "(nullsafe_member_call_expression name: (name) @callee)\n",
+    "(scoped_call_expression name: (name) @callee)\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "PHP",
+    extensions: &["php", "phtml"],
+    filenames: &[],
+    grammar: Some(tree_sitter_php::LANGUAGE_PHP),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &["composer.json"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/python.rs
+++ b/src/lang/python.rs
@@ -1,0 +1,53 @@
+//! Python language spec. Diverges on: stdlib first-segment rule (`.` separator).
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call function: (identifier) @callee)\n",
+    "(call function: (attribute attribute: (identifier) @callee))\n",
+);
+
+const SIBLING_QUERY: &str = "(attribute object: (identifier) @obj attribute: (identifier) @ref)\n";
+
+/// Common stdlib modules — not exhaustive, but covers the noisy ones.
+const STDLIB_MODULES: &[&str] = &[
+    "os",
+    "sys",
+    "re",
+    "json",
+    "math",
+    "time",
+    "datetime",
+    "pathlib",
+    "typing",
+    "collections",
+    "functools",
+    "itertools",
+    "abc",
+    "io",
+    "logging",
+    "unittest",
+    "dataclasses",
+    "enum",
+    "copy",
+    "hashlib",
+    "subprocess",
+    "threading",
+    "asyncio",
+];
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Python",
+    extensions: &["py", "pyi"],
+    filenames: &[],
+    grammar: Some(tree_sitter_python::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::PythonSegment(STDLIB_MODULES),
+    manifests: &["pyproject.toml", "setup.py"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::Python),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/ruby.rs
+++ b/src/lang/ruby.rs
@@ -1,0 +1,21 @@
+//! Ruby language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = "(call method: (identifier) @callee)\n";
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Ruby",
+    extensions: &["rb"],
+    filenames: &["Vagrantfile", "Rakefile"],
+    grammar: Some(tree_sitter_ruby::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: None,
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/rust.rs
+++ b/src/lang/rust.rs
@@ -1,0 +1,31 @@
+//! Rust language spec. Diverges on: stdlib prefix rule, lifetime ticks.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call_expression function: (identifier) @callee)\n",
+    "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
+    "(call_expression function: (scoped_identifier name: (identifier) @callee))\n",
+    "(macro_invocation macro: (identifier) @callee)\n",
+);
+
+const SIBLING_QUERY: &str = concat!(
+    "(field_expression value: (self) field: (field_identifier) @ref)\n",
+    "(call_expression function: (field_expression value: (self) field: (field_identifier) @ref))\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Rust",
+    extensions: &["rs"],
+    filenames: &[],
+    grammar: Some(tree_sitter_rust::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::Prefixes(&["std::", "core::", "alloc::"]),
+    manifests: &["Cargo.toml"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: true,
+    strip_family: Some(StripFamily::Rust),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/scala.rs
+++ b/src/lang/scala.rs
@@ -1,0 +1,30 @@
+//! Scala language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call_expression function: (identifier) @callee)\n",
+    "(call_expression function: (field_expression field: (identifier) @callee))\n",
+    "(infix_expression operator: (identifier) @callee)\n",
+);
+
+const SIBLING_QUERY: &str = concat!(
+    "(field_expression (identifier) @obj (identifier) @ref)\n",
+    "(call_expression function: (field_expression (identifier) @obj (identifier) @ref))\n",
+);
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Scala",
+    extensions: &["scala", "sc"],
+    filenames: &[],
+    grammar: Some(tree_sitter_scala::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &["build.sbt"],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JavaKotlinCSharp),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/spec.rs
+++ b/src/lang/spec.rs
@@ -103,11 +103,6 @@ pub(crate) struct DefinitionOps {
 /// Shared default definition kinds — used by every language except Elixir.
 pub(crate) const DEFAULT_DEF_KINDS: &[&str] = DEFINITION_KINDS;
 
-/// Default name extractor adapter (ignores nothing; delegates to the shared fn).
-fn default_defs_extract_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
-    default_extract_definition_name(node, lines)
-}
-
 /// Default weight adapter: weight is keyed on the node kind, so the node's
 /// `lines` argument is unused. Kept in the `(node, lines)` shape so every
 /// `DefinitionOps.weight` has one uniform signature.
@@ -117,7 +112,7 @@ fn default_defs_weight(node: tree_sitter::Node, _lines: &[&str]) -> u16 {
 
 /// Shared default `DefinitionOps` — referenced by every non-Elixir spec.
 pub(crate) const DEFAULT_DEFS: DefinitionOps = DefinitionOps {
-    extract_name: default_defs_extract_name,
+    extract_name: default_extract_definition_name,
     weight: default_defs_weight,
 };
 

--- a/src/lang/spec.rs
+++ b/src/lang/spec.rs
@@ -1,0 +1,317 @@
+//! Per-language data table. One `LangSpec` per `Lang` variant, looked up by the
+//! single `spec(lang)` match — the only surviving full-`Lang` dispatch in the
+//! crate. Every former `match lang` site reads a field on `spec(lang)` instead.
+//!
+//! Shared, language-agnostic behavior (the default definition kinds, default
+//! definition-name extraction and weight) lives once as `DEFAULT_*` items; only
+//! the languages that diverge carry their own values.
+
+use tree_sitter_language::LanguageFn;
+
+use crate::lang::treesitter::{
+    definition_weight as default_definition_weight,
+    extract_definition_name as default_extract_definition_name, DEFINITION_KINDS,
+};
+use crate::types::Lang;
+
+/// All per-language data and behavior in one record. Read via `spec(lang)`.
+pub(crate) struct LangSpec {
+    /// Human-readable language name (`lang_display_name`).
+    pub display: &'static str,
+    /// File extensions that map to this language (`detect_file_type`).
+    pub extensions: &'static [&'static str],
+    /// Bare filenames that map to this language (`file_type_from_name`).
+    pub filenames: &'static [&'static str],
+    /// Tree-sitter grammar, or `None` for languages without a shipped grammar
+    /// (Dockerfile / Make). `outline_language` does `.map(Into::into)`.
+    pub grammar: Option<LanguageFn>,
+    /// Tree-sitter query for callee extraction (`callee_query_str`).
+    pub callee_query: Option<&'static str>,
+    /// Tree-sitter query for self/this sibling references (`sibling_query_str`).
+    pub sibling_query: Option<&'static str>,
+    /// How to recognise a stdlib import for this language (`is_stdlib`).
+    pub stdlib: StdlibRule,
+    /// Build-manifest filenames contributed by this language (`package_root`).
+    pub manifests: &'static [&'static str],
+    /// Definition node kinds for AST definition detection (`DEFINITION_KINDS`).
+    pub definition_kinds: &'static [&'static str],
+    /// Whether `'` denotes a lifetime tick rather than a char delimiter
+    /// (`Lang::has_lifetimes`).
+    pub has_lifetimes: bool,
+    /// Coarse comment-syntax family for cognitive-load stripping (`StripLang`).
+    pub strip_family: Option<StripFamily>,
+    /// Go-only: extract the method receiver name from file content.
+    pub extract_receiver: Option<fn(&str, &tree_sitter::Language) -> Option<String>>,
+    /// Definition-name extraction + weight (Elixir overrides the defaults).
+    pub definitions: DefinitionOps,
+}
+
+/// How an import source is recognised as standard-library (and thus noise that
+/// `tilth_deps` suppresses). Replaces the per-language `is_stdlib` match. Each
+/// variant encodes one language's historical rule byte-for-byte.
+pub(crate) enum StdlibRule {
+    /// Language has no stdlib suppression.
+    None,
+    /// Source matches if it starts with any of these prefixes (Rust:
+    /// `std::` / `core::` / `alloc::`).
+    Prefixes(&'static [&'static str]),
+    /// Source matches if its first `'.'`-delimited segment is in `set` (Python).
+    PythonSegment(&'static [&'static str]),
+    /// Source matches if its first `'/'`-delimited segment is in `set` (Go:
+    /// the import's root path segment is a stdlib package root).
+    GoRoots(&'static [&'static str]),
+}
+
+impl StdlibRule {
+    /// Returns `true` if `source` names a standard-library module under this rule.
+    pub(crate) fn matches(&self, source: &str) -> bool {
+        match self {
+            StdlibRule::None => false,
+            StdlibRule::Prefixes(prefixes) => prefixes.iter().any(|p| source.starts_with(p)),
+            StdlibRule::PythonSegment(set) => {
+                let first = source.split('.').next().unwrap_or("");
+                set.contains(&first)
+            }
+            StdlibRule::GoRoots(set) => set.contains(&source.split('/').next().unwrap_or(source)),
+        }
+    }
+}
+
+/// Coarse 6-way grouping of comment / log syntax for `strip::strip_noise`.
+/// Deliberately *not* a 1:1 sibling of `Lang` (many languages share a family).
+#[derive(Debug, Clone, Copy)]
+pub(crate) enum StripFamily {
+    Rust,
+    Python,
+    Go,
+    JsTs,
+    JavaKotlinCSharp,
+    CppC,
+    Bash,
+}
+
+/// Definition-name extraction + semantic weight for a language. The default
+/// (`DEFAULT_DEFS`) walks standard field names; Elixir overrides both because
+/// its definitions are `call` nodes.
+pub(crate) struct DefinitionOps {
+    /// Extract the defined symbol name from a definition node.
+    pub extract_name: fn(tree_sitter::Node, &[&str]) -> Option<String>,
+    /// Semantic ranking weight for a definition node.
+    pub weight: fn(tree_sitter::Node, &[&str]) -> u16,
+}
+
+/// Shared default definition kinds — used by every language except Elixir.
+pub(crate) const DEFAULT_DEF_KINDS: &[&str] = DEFINITION_KINDS;
+
+/// Default name extractor adapter (ignores nothing; delegates to the shared fn).
+fn default_defs_extract_name(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
+    default_extract_definition_name(node, lines)
+}
+
+/// Default weight adapter: weight is keyed on the node kind, so the node's
+/// `lines` argument is unused. Kept in the `(node, lines)` shape so every
+/// `DefinitionOps.weight` has one uniform signature.
+fn default_defs_weight(node: tree_sitter::Node, _lines: &[&str]) -> u16 {
+    default_definition_weight(node.kind())
+}
+
+/// Shared default `DefinitionOps` — referenced by every non-Elixir spec.
+pub(crate) const DEFAULT_DEFS: DefinitionOps = DefinitionOps {
+    extract_name: default_defs_extract_name,
+    weight: default_defs_weight,
+};
+
+/// The single surviving full-`Lang` dispatch. Every other former `match lang`
+/// reads a field on the returned spec.
+pub(crate) fn spec(lang: Lang) -> &'static LangSpec {
+    use crate::lang;
+    match lang {
+        Lang::Rust => &lang::rust::SPEC,
+        Lang::TypeScript => &lang::typescript::SPEC,
+        Lang::Tsx => &lang::tsx::SPEC,
+        Lang::JavaScript => &lang::javascript::SPEC,
+        Lang::Python => &lang::python::SPEC,
+        Lang::Go => &lang::go::SPEC,
+        Lang::Java => &lang::java::SPEC,
+        Lang::Scala => &lang::scala::SPEC,
+        Lang::C => &lang::c::SPEC,
+        Lang::Cpp => &lang::cpp::SPEC,
+        Lang::Ruby => &lang::ruby::SPEC,
+        Lang::Php => &lang::php::SPEC,
+        Lang::Swift => &lang::swift::SPEC,
+        Lang::Kotlin => &lang::kotlin::SPEC,
+        Lang::CSharp => &lang::csharp::SPEC,
+        Lang::Elixir => &lang::elixir::SPEC,
+        Lang::Dockerfile => &lang::dockerfile::SPEC,
+        Lang::Make => &lang::make::SPEC,
+        Lang::Bash => &lang::bash::SPEC,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lang::mod_all_langs_for_test;
+
+    // ── StdlibRule::matches — locks each variant's historical `is_stdlib` rule ──
+
+    #[test]
+    fn stdlib_none_never_matches() {
+        let rule = StdlibRule::None;
+        assert!(!rule.matches("std"));
+        assert!(!rule.matches(""));
+        assert!(!rule.matches("anything.at.all"));
+    }
+
+    #[test]
+    fn stdlib_prefixes_matches_only_listed_prefixes() {
+        let rule = StdlibRule::Prefixes(&["std::", "core::", "alloc::"]);
+        assert!(rule.matches("std::collections::HashMap"));
+        assert!(rule.matches("core::mem"));
+        assert!(rule.matches("alloc::vec::Vec"));
+        // Bare segment without `::` separator is not a prefix match.
+        assert!(!rule.matches("std"));
+        // A crate that merely starts with the letters but not the prefix.
+        assert!(!rule.matches("standard::thing"));
+        assert!(!rule.matches("serde::Deserialize"));
+    }
+
+    #[test]
+    fn stdlib_python_segment_matches_first_dotted_segment() {
+        let rule = StdlibRule::PythonSegment(&["os", "sys", "json"]);
+        assert!(rule.matches("os"));
+        assert!(rule.matches("os.path"));
+        assert!(rule.matches("json.decoder"));
+        // First segment must match exactly — a longer name sharing a prefix must not.
+        assert!(!rule.matches("ossify"));
+        assert!(!rule.matches("requests"));
+        assert!(!rule.matches("mypackage.os"));
+    }
+
+    // Go's rule (post-PR-71): a GoRoots allowlist keyed on the first `/`-segment.
+    // A multi-segment import (`net/http`) is stdlib when its root (`net`) is in the
+    // set; a bare local package (`mypackage`) is NOT stdlib. These pin that rule.
+    #[test]
+    fn stdlib_go_root_segment_is_stdlib() {
+        let rule = StdlibRule::GoRoots(&["fmt", "net", "encoding"]);
+        assert!(rule.matches("fmt"), "bare stdlib root");
+        assert!(rule.matches("net/http"), "multi-segment stdlib via root");
+        assert!(
+            rule.matches("encoding/json"),
+            "multi-segment stdlib via root"
+        );
+    }
+
+    #[test]
+    fn stdlib_go_non_root_is_not_stdlib() {
+        let rule = StdlibRule::GoRoots(&["fmt", "net"]);
+        // Local/third-party roots are not in the set.
+        assert!(
+            !rule.matches("mypackage"),
+            "bare local package is not stdlib"
+        );
+        assert!(!rule.matches("github.com/gin-gonic/gin"));
+        assert!(!rule.matches("golang.org/x/sync"));
+        // Empty string has no stdlib root.
+        assert!(!rule.matches(""));
+        // A root that merely shares a prefix with a stdlib root must not match.
+        assert!(!rule.matches("fmtlib"));
+    }
+
+    // ── spec() table invariants — every Lang resolves and its data is coherent ──
+
+    #[test]
+    fn spec_resolves_for_every_lang() {
+        // Exercises the single surviving full-`Lang` dispatch over the whole set.
+        for &lang in mod_all_langs_for_test() {
+            let s = spec(lang);
+            assert!(!s.display.is_empty(), "{lang:?} has empty display name");
+        }
+    }
+
+    #[test]
+    fn only_dockerfile_and_make_lack_a_grammar() {
+        for &lang in mod_all_langs_for_test() {
+            let has_grammar = spec(lang).grammar.is_some();
+            let expected = !matches!(lang, Lang::Dockerfile | Lang::Make);
+            assert_eq!(
+                has_grammar, expected,
+                "{lang:?} grammar presence mismatch (Dockerfile/Make have no shipped grammar)"
+            );
+        }
+    }
+
+    #[test]
+    fn only_rust_has_lifetimes() {
+        for &lang in mod_all_langs_for_test() {
+            assert_eq!(
+                spec(lang).has_lifetimes,
+                matches!(lang, Lang::Rust),
+                "{lang:?} lifetime flag mismatch — only Rust uses `'` for lifetime ticks"
+            );
+        }
+    }
+
+    #[test]
+    fn only_go_extracts_a_receiver() {
+        for &lang in mod_all_langs_for_test() {
+            assert_eq!(
+                spec(lang).extract_receiver.is_some(),
+                matches!(lang, Lang::Go),
+                "{lang:?} receiver-extractor presence mismatch — only Go has method receivers"
+            );
+        }
+    }
+
+    #[test]
+    fn extensions_are_unique_across_langs() {
+        // detect_file_type scans ALL_LANGS and returns the first lang whose
+        // `spec.extensions` contains the ext. Overlapping extensions would make
+        // detection order-dependent and silently misroute files.
+        let mut seen: Vec<(&str, Lang)> = Vec::new();
+        for &lang in mod_all_langs_for_test() {
+            for &ext in spec(lang).extensions {
+                if let Some((_, other)) = seen.iter().find(|(e, _)| *e == ext) {
+                    panic!("extension {ext:?} claimed by both {other:?} and {lang:?}");
+                }
+                seen.push((ext, lang));
+            }
+        }
+    }
+
+    #[test]
+    fn elixir_is_the_only_definition_override() {
+        // The refactor's shared-default-plus-override design: every spec points at
+        // DEFAULT_DEF_KINDS except Elixir, whose definitions are `call` nodes.
+        for &lang in mod_all_langs_for_test() {
+            let uses_default = spec(lang).definition_kinds == DEFAULT_DEF_KINDS;
+            assert_eq!(
+                uses_default,
+                !matches!(lang, Lang::Elixir),
+                "{lang:?} definition_kinds override mismatch — only Elixir diverges"
+            );
+        }
+    }
+
+    // ── Pinned per-language data the dispatch sites read ──
+
+    #[test]
+    fn pinned_spec_fields() {
+        assert_eq!(spec(Lang::Rust).display, "Rust");
+        assert_eq!(spec(Lang::Rust).extensions, &["rs"]);
+        assert_eq!(spec(Lang::Rust).manifests, &["Cargo.toml"]);
+
+        assert_eq!(spec(Lang::Go).extensions, &["go"]);
+        assert_eq!(spec(Lang::Go).manifests, &["go.mod"]);
+        assert!(spec(Lang::Go).extract_receiver.is_some());
+
+        assert_eq!(spec(Lang::Python).extensions, &["py", "pyi"]);
+        assert_eq!(
+            spec(Lang::Python).manifests,
+            &["pyproject.toml", "setup.py"]
+        );
+
+        assert_eq!(spec(Lang::Elixir).manifests, &["mix.exs"]);
+        assert!(spec(Lang::Elixir).grammar.is_some());
+    }
+}

--- a/src/lang/swift.rs
+++ b/src/lang/swift.rs
@@ -1,0 +1,27 @@
+//! Swift language spec.
+
+use crate::lang::spec::{LangSpec, StdlibRule, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+const CALLEE_QUERY: &str = concat!(
+    "(call_expression (simple_identifier) @callee)\n",
+    "(call_expression (navigation_expression suffix: (navigation_suffix suffix: (simple_identifier) @callee)))\n",
+);
+
+const SIBLING_QUERY: &str =
+    "(navigation_expression target: (self_expression) suffix: (navigation_suffix suffix: (simple_identifier) @ref))\n";
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "Swift",
+    extensions: &["swift"],
+    filenames: &[],
+    grammar: Some(tree_sitter_swift::LANGUAGE),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: None,
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -50,12 +50,12 @@ pub(crate) fn extract_definition_name(node: tree_sitter::Node, lines: &[&str]) -
     // Try standard field names
     for field in &["name", "identifier", "declarator"] {
         if let Some(child) = node.child_by_field_name(field) {
-            let text = node_text_simple(child, lines);
+            let text = node_text_simple(child, lines, NodeTextMode::Full);
             if !text.is_empty() {
                 // For variable_declarator, get the identifier inside
                 if child.kind().contains("declarator") {
                     if let Some(id) = child.child_by_field_name("name") {
-                        return Some(node_text_simple(id, lines));
+                        return Some(node_text_simple(id, lines, NodeTextMode::Full));
                     }
                 }
                 return Some(text);
@@ -82,7 +82,7 @@ pub(crate) fn extract_definition_name(node: tree_sitter::Node, lines: &[&str]) -
         for child in node.children(&mut cursor) {
             if child.kind() == "variable_declarator" {
                 if let Some(name_node) = child.child_by_field_name("name") {
-                    let text = node_text_simple(name_node, lines);
+                    let text = node_text_simple(name_node, lines, NodeTextMode::Full);
                     if !text.is_empty() {
                         return Some(text);
                     }
@@ -94,11 +94,26 @@ pub(crate) fn extract_definition_name(node: tree_sitter::Node, lines: &[&str]) -
     None
 }
 
-/// Get the text of a single-line node from pre-split source lines.
+/// Controls how [`node_text_simple`] renders a node that spans multiple lines.
+#[derive(Clone, Copy)]
+pub(crate) enum NodeTextMode {
+    /// Return the node's start line untruncated.
+    Full,
+    /// Truncate the node's start line to roughly 80 characters.
+    Truncated,
+}
+
+/// Returns a node's text from pre-split source lines.
 ///
-/// Returns the text slice for single-line nodes, or the text from the start
-/// column to end-of-line for multi-line nodes.
-pub(crate) fn node_text_simple(node: tree_sitter::Node, lines: &[&str]) -> String {
+/// For a single-line node, returns its exact slice. For a multi-line node,
+/// returns only the start line (start column to end-of-line) — never the full
+/// multi-line span; `mode` then decides whether that start line is returned in
+/// full or truncated.
+pub(crate) fn node_text_simple(
+    node: tree_sitter::Node,
+    lines: &[&str],
+    mode: NodeTextMode,
+) -> String {
     let row = node.start_position().row;
     let col_start = node.start_position().column;
     let end_row = node.end_position().row;
@@ -106,7 +121,17 @@ pub(crate) fn node_text_simple(node: tree_sitter::Node, lines: &[&str]) -> Strin
         let col_end = node.end_position().column.min(lines[row].len());
         lines[row][col_start..col_end].to_string()
     } else if row < lines.len() {
-        lines[row][col_start..].to_string()
+        let text = &lines[row][col_start..];
+        match mode {
+            NodeTextMode::Full => text.to_string(),
+            NodeTextMode::Truncated => {
+                if text.len() > 80 {
+                    format!("{}...", crate::types::truncate_str(text, 77))
+                } else {
+                    text.to_string()
+                }
+            }
+        }
     } else {
         String::new()
     }
@@ -116,13 +141,13 @@ pub(crate) fn node_text_simple(node: tree_sitter::Node, lines: &[&str]) -> Strin
 /// Returns None for inherent impls (no trait).
 pub(crate) fn extract_impl_trait(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
     let trait_node = node.child_by_field_name("trait")?;
-    Some(node_text_simple(trait_node, lines))
+    Some(node_text_simple(trait_node, lines, NodeTextMode::Full))
 }
 
 /// Extract implementing type from Rust `impl ... for Type` node.
 pub(crate) fn extract_impl_type(node: tree_sitter::Node, lines: &[&str]) -> Option<String> {
     let type_node = node.child_by_field_name("type")?;
-    Some(node_text_simple(type_node, lines))
+    Some(node_text_simple(type_node, lines, NodeTextMode::Full))
 }
 
 /// Extract implemented interface names from TS/Java class declaration.
@@ -138,7 +163,7 @@ pub(crate) fn extract_implemented_interfaces(
             let mut inner = child.walk();
             for ident in child.children(&mut inner) {
                 if ident.kind().contains("identifier") {
-                    let text = node_text_simple(ident, lines);
+                    let text = node_text_simple(ident, lines, NodeTextMode::Full);
                     if !text.is_empty() {
                         interfaces.push(text);
                     }
@@ -153,27 +178,6 @@ pub(crate) fn extract_implemented_interfaces(
 // Elixir-specific definition helpers
 // ---------------------------------------------------------------------------
 
-/// Elixir call-node target identifiers that define named symbols.
-/// This is the complete set used for definition detection in symbol search/index.
-/// See also `ELIXIR_DEF_KEYWORDS` in `outline.rs` which is the subset of
-/// function-like keywords (excludes container keywords like `defmodule`,
-/// `defprotocol`, `defimpl`, `defstruct`, `defexception` that have their own
-/// outline handling).
-const ELIXIR_DEFINITION_TARGETS: &[&str] = &[
-    "defmodule",
-    "def",
-    "defp",
-    "defmacro",
-    "defmacrop",
-    "defguard",
-    "defguardp",
-    "defdelegate",
-    "defstruct",
-    "defexception",
-    "defprotocol",
-    "defimpl",
-];
-
 /// Find the `arguments` child of an Elixir `call` node.
 /// In tree-sitter-elixir, `arguments` is a node kind, not a named field,
 /// so `child_by_field_name("arguments")` doesn't work.
@@ -182,70 +186,6 @@ pub(crate) fn elixir_arguments(node: tree_sitter::Node) -> Option<tree_sitter::N
     // Node is Copy (arena index) — the returned node survives cursor drop.
     let result = node.children(&mut cursor).find(|c| c.kind() == "arguments");
     result
-}
-
-/// Check if a tree-sitter node is an Elixir definition.
-/// In Elixir all definitions are `call` nodes whose `target` identifier
-/// is one of `defmodule`, `def`, `defp`, etc.
-pub(crate) fn is_elixir_definition(node: tree_sitter::Node, lines: &[&str]) -> bool {
-    if node.kind() != "call" {
-        return false;
-    }
-    let Some(target) = node.child_by_field_name("target") else {
-        return false;
-    };
-    let kw = node_text_simple(target, lines);
-    ELIXIR_DEFINITION_TARGETS.contains(&kw.as_str())
-}
-
-/// Extract the defined name from an Elixir definition `call` node.
-///
-/// - `defmodule Foo.Bar do...end` → `"Foo.Bar"`
-/// - `def greet(name) do...end`  → `"greet"`
-/// - `defstruct [:a, :b]`       → `"defstruct"`
-pub(crate) fn extract_elixir_definition_name(
-    node: tree_sitter::Node,
-    lines: &[&str],
-) -> Option<String> {
-    let target = node.child_by_field_name("target")?;
-    let kw = node_text_simple(target, lines);
-    let args = elixir_arguments(node)?;
-
-    match kw.as_str() {
-        "defmodule" | "defprotocol" | "defimpl" => {
-            // First named child of arguments is the module/protocol alias.
-            // For `defimpl Printable, for: User`, this returns "Printable" (the
-            // protocol name), not "User" (the implementing type). Searching for
-            // the protocol name will find both the protocol and all its impls.
-            let mut cursor = args.walk();
-            for child in args.children(&mut cursor) {
-                if child.is_named() {
-                    return Some(node_text_simple(child, lines));
-                }
-            }
-            None
-        }
-        "def" | "defp" | "defmacro" | "defmacrop" | "defguard" | "defguardp" | "defdelegate" => {
-            // First named child is:
-            //   `call`              — normal: `def greet(name)`
-            //   `identifier`        — no-arg: `def bar, do: :ok`
-            //   `binary_operator`   — guard:  `def foo(x) when x > 0`
-            let mut cursor = args.walk();
-            for child in args.children(&mut cursor) {
-                if !child.is_named() {
-                    continue;
-                }
-                return elixir_extract_func_head_name(child, lines);
-            }
-            None
-        }
-        // In Elixir, a struct IS its enclosing module (`%MyModule{}`), and only
-        // one struct per module is allowed. There's no standalone struct name to
-        // extract, so we index the keyword itself. Search for the struct by its
-        // module name instead.
-        "defstruct" | "defexception" => Some(kw.clone()),
-        _ => None,
-    }
 }
 
 /// Extract function name from the first argument of a `def`/`defp`/`defmacro` call.
@@ -261,29 +201,14 @@ pub(crate) fn elixir_extract_func_head_name(
     match node.kind() {
         "call" => node
             .child_by_field_name("target")
-            .map(|t| node_text_simple(t, lines)),
-        "identifier" => Some(node_text_simple(node, lines)),
+            .map(|t| node_text_simple(t, lines, NodeTextMode::Full)),
+        "identifier" => Some(node_text_simple(node, lines, NodeTextMode::Full)),
         "binary_operator" => {
             // Guard clause: `foo(x) when x > 0` → left is the function head
             let left = node.child_by_field_name("left")?;
             elixir_extract_func_head_name(left, lines)
         }
         _ => None,
-    }
-}
-
-/// Semantic weight for Elixir definition keywords.
-pub(crate) fn elixir_definition_weight(node: tree_sitter::Node, lines: &[&str]) -> u16 {
-    let Some(target) = node.child_by_field_name("target") else {
-        return 50;
-    };
-    let kw = node_text_simple(target, lines);
-    match kw.as_str() {
-        "defmodule" | "defprotocol" | "def" | "defp" | "defmacro" | "defmacrop" | "defguard"
-        | "defguardp" | "defdelegate" => 100,
-        "defimpl" => 90,
-        "defstruct" | "defexception" => 80,
-        _ => 50,
     }
 }
 
@@ -319,6 +244,34 @@ pub(crate) fn definition_weight(kind: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn node_text_mode_controls_multiline_truncation() {
+        let first_line =
+            "pub fn very_long_function_name_with_enough_characters_to_force_truncation_for_outline_test() {";
+        let source = format!("{first_line}\n}}\n");
+        let lines: Vec<&str> = source.lines().collect();
+        let mut parser = tree_sitter::Parser::new();
+        parser
+            .set_language(&tree_sitter_rust::LANGUAGE.into())
+            .expect("rust parser should load");
+        let tree = parser
+            .parse(&source, None)
+            .expect("rust source should parse");
+        let node = tree
+            .root_node()
+            .named_child(0)
+            .expect("source should contain a function node");
+
+        assert_eq!(
+            node_text_simple(node, &lines, NodeTextMode::Full),
+            first_line
+        );
+        assert_eq!(
+            node_text_simple(node, &lines, NodeTextMode::Truncated),
+            format!("{}...", &first_line[..77])
+        );
+    }
     use crate::lang::outline::outline_language;
     use crate::types::Lang;
 

--- a/src/lang/treesitter.rs
+++ b/src/lang/treesitter.rs
@@ -1,5 +1,8 @@
 //! Shared tree-sitter utilities used by symbol search and caller search.
 
+use std::collections::HashMap;
+use std::sync::{LazyLock, Mutex};
+
 /// Definition node kinds across tree-sitter grammars.
 pub(crate) const DEFINITION_KINDS: &[&str] = &[
     // Functions
@@ -391,4 +394,44 @@ mod tests {
         let node = find_by_kind(tree.root_node(), "impl_item");
         assert_eq!(extract_definition_name(node, &lines), None);
     }
+}
+
+/// Global cache of compiled tree-sitter queries, shared by symbol/caller
+/// search (`search::siblings`) and per-language extractors (e.g. Go's
+/// receiver-name lookup). Keyed by `(node_kind_count, field_count,
+/// query_str_ptr)` so that distinct query strings for the same language are
+/// stored under separate keys. We avoid `Language::name()` because ABI < 15
+/// grammars (e.g. tree-sitter-kotlin-ng) return `None`.
+#[allow(clippy::type_complexity)]
+static QUERY_CACHE: LazyLock<Mutex<HashMap<(usize, usize, usize), tree_sitter::Query>>> =
+    LazyLock::new(|| Mutex::new(HashMap::new()));
+
+/// Look up or compile `query_str` for `ts_lang`, then invoke `f` with a
+/// reference to the cached `Query`. Returns `None` if compilation fails.
+///
+/// `query_str` must be `'static` so its pointer address is stable across
+/// calls and can serve as part of the cache key.
+pub(crate) fn with_query<R>(
+    ts_lang: &tree_sitter::Language,
+    query_str: &'static str,
+    f: impl FnOnce(&tree_sitter::Query) -> R,
+) -> Option<R> {
+    use std::collections::hash_map::Entry;
+    // Pointer address distinguishes different queries for the same language.
+    let key = (
+        ts_lang.node_kind_count(),
+        ts_lang.field_count(),
+        query_str.as_ptr() as usize,
+    );
+    let mut cache = QUERY_CACHE
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let query = match cache.entry(key) {
+        Entry::Occupied(e) => e.into_mut(),
+        Entry::Vacant(e) => {
+            let q = tree_sitter::Query::new(ts_lang, query_str).ok()?;
+            e.insert(q)
+        }
+    };
+    Some(f(query))
 }

--- a/src/lang/tsx.rs
+++ b/src/lang/tsx.rs
@@ -1,0 +1,20 @@
+//! TSX language spec. Shares callee/sibling queries with JS/TS.
+
+use crate::lang::javascript::{CALLEE_QUERY, SIBLING_QUERY};
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "TSX",
+    extensions: &["tsx"],
+    filenames: &[],
+    grammar: Some(tree_sitter_typescript::LANGUAGE_TSX),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JsTs),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/lang/typescript.rs
+++ b/src/lang/typescript.rs
@@ -1,0 +1,20 @@
+//! TypeScript language spec. Shares callee/sibling queries with JS/TSX.
+
+use crate::lang::javascript::{CALLEE_QUERY, SIBLING_QUERY};
+use crate::lang::spec::{LangSpec, StdlibRule, StripFamily, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
+
+pub(crate) const SPEC: LangSpec = LangSpec {
+    display: "TypeScript",
+    extensions: &["ts"],
+    filenames: &[],
+    grammar: Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT),
+    callee_query: Some(CALLEE_QUERY),
+    sibling_query: Some(SIBLING_QUERY),
+    stdlib: StdlibRule::None,
+    manifests: &[],
+    definition_kinds: DEFAULT_DEF_KINDS,
+    has_lifetimes: false,
+    strip_family: Some(StripFamily::JsTs),
+    extract_receiver: None,
+    definitions: DEFAULT_DEFS,
+};

--- a/src/mcp/tools/write.rs
+++ b/src/mcp/tools/write.rs
@@ -178,10 +178,8 @@ fn find_git_root(path: &Path) -> Option<PathBuf> {
         if dir.join(".git").exists() {
             return Some(dir);
         }
-        match dir.parent() {
-            Some(p) => dir = p.to_path_buf(),
-            None => return None,
-        }
+        let p = dir.parent()?;
+        dir = p.to_path_buf();
     }
 }
 

--- a/src/overview.rs
+++ b/src/overview.rs
@@ -236,27 +236,7 @@ fn common_dir_prefix(mods: &[(String, usize)]) -> String {
 // ---------------------------------------------------------------------------
 
 fn lang_display_name(lang: Lang) -> &'static str {
-    match lang {
-        Lang::Rust => "Rust",
-        Lang::TypeScript => "TypeScript",
-        Lang::Tsx => "TSX",
-        Lang::JavaScript => "JavaScript",
-        Lang::Python => "Python",
-        Lang::Go => "Go",
-        Lang::Java => "Java",
-        Lang::Scala => "Scala",
-        Lang::C => "C",
-        Lang::Cpp => "C++",
-        Lang::Ruby => "Ruby",
-        Lang::Php => "PHP",
-        Lang::Swift => "Swift",
-        Lang::Kotlin => "Kotlin",
-        Lang::CSharp => "C#",
-        Lang::Elixir => "Elixir",
-        Lang::Bash => "Bash",
-        Lang::Dockerfile => "Docker",
-        Lang::Make => "Make",
-    }
+    crate::lang::spec::spec(lang).display
 }
 
 // ---------------------------------------------------------------------------

--- a/src/search/callee_query.rs
+++ b/src/search/callee_query.rs
@@ -12,67 +12,7 @@ use crate::types::Lang;
 /// Return the tree-sitter query string for extracting callee names in the given language.
 /// Each language has patterns targeting `@callee` captures on call-like expressions.
 pub(super) fn callee_query_str(lang: Lang) -> Option<&'static str> {
-    match lang {
-        Lang::Rust => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
-            "(call_expression function: (scoped_identifier name: (identifier) @callee))\n",
-            "(macro_invocation macro: (identifier) @callee)\n",
-        )),
-        Lang::Go => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (selector_expression field: (field_identifier) @callee))\n",
-        )),
-        Lang::Python => Some(concat!(
-            "(call function: (identifier) @callee)\n",
-            "(call function: (attribute attribute: (identifier) @callee))\n",
-        )),
-        Lang::JavaScript | Lang::TypeScript | Lang::Tsx => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (member_expression property: (property_identifier) @callee))\n",
-        )),
-        Lang::Java => Some(
-            "(method_invocation name: (identifier) @callee)\n",
-        ),
-        Lang::Scala => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (identifier) @callee))\n",
-            "(infix_expression operator: (identifier) @callee)\n",
-        )),
-        Lang::C | Lang::Cpp => Some(concat!(
-            "(call_expression function: (identifier) @callee)\n",
-            "(call_expression function: (field_expression field: (field_identifier) @callee))\n",
-        )),
-        Lang::Ruby => Some(
-            "(call method: (identifier) @callee)\n",
-        ),
-        Lang::Php => Some(concat!(
-            "(function_call_expression function: (name) @callee)\n",
-            "(function_call_expression function: (qualified_name) @callee)\n",
-            "(function_call_expression function: (relative_name) @callee)\n",
-            "(member_call_expression name: (name) @callee)\n",
-            "(nullsafe_member_call_expression name: (name) @callee)\n",
-            "(scoped_call_expression name: (name) @callee)\n",
-        )),
-        Lang::CSharp => Some(concat!(
-            "(invocation_expression function: (identifier) @callee)\n",
-            "(invocation_expression function: (member_access_expression name: (identifier) @callee))\n",
-        )),
-        Lang::Swift => Some(concat!(
-            "(call_expression (simple_identifier) @callee)\n",
-            "(call_expression (navigation_expression suffix: (navigation_suffix suffix: (simple_identifier) @callee)))\n",
-        )),
-        Lang::Kotlin => Some(concat!(
-            "(call_expression (identifier) @callee)\n",
-            "(call_expression (navigation_expression (identifier) @callee .))\n",
-        )),
-        Lang::Elixir => Some(concat!(
-            "(call target: (identifier) @callee)\n",
-            "(call target: (dot right: (identifier) @callee))\n",
-        )),
-        Lang::Bash => Some("(command name: (command_name) @callee)\n"),
-        _ => None,
-    }
+    crate::lang::spec::spec(lang).callee_query
 }
 
 /// Global cache of compiled tree-sitter queries for callee extraction.

--- a/src/search/callees.rs
+++ b/src/search/callees.rs
@@ -106,7 +106,7 @@ pub fn extract_callee_names(
 
 /// Keywords that should not appear as callee names in Elixir.
 /// These are definition and import forms that are syntactically `call` nodes.
-/// Superset of `ELIXIR_DEFINITION_TARGETS` (treesitter.rs) plus import keywords
+/// Superset of `ELIXIR_DEFINITION_TARGETS` (elixir.rs) plus import keywords
 /// (`use`, `import`, `alias`, `require`) and `defoverridable`.
 fn is_elixir_keyword(name: &str) -> bool {
     matches!(

--- a/src/search/deps.rs
+++ b/src/search/deps.rs
@@ -364,101 +364,10 @@ fn is_placeholder_name(name: &str) -> bool {
     false
 }
 
-/// Root (first `/`-segment) of each Go stdlib package. A Go import is stdlib
-/// when its first path segment is one of these — covering both single-segment
-/// (`fmt`) and multi-segment (`net/http`, `encoding/json`) forms. Matching the
-/// root (not the whole path) avoids misclassifying a local package like
-/// `mypackage` while still suppressing the noisy multi-segment stdlib paths.
-const GO_STDLIB_ROOTS: &[&str] = &[
-    "archive",
-    "bufio",
-    "bytes",
-    "cmp",
-    "compress",
-    "container",
-    "context",
-    "crypto",
-    "database",
-    "debug",
-    "embed",
-    "encoding",
-    "errors",
-    "flag",
-    "fmt",
-    "go",
-    "hash",
-    "html",
-    "image",
-    "index",
-    "io",
-    "log",
-    "maps",
-    "math",
-    "mime",
-    "net",
-    "os",
-    "path",
-    "plugin",
-    "reflect",
-    "regexp",
-    "runtime",
-    "slices",
-    "sort",
-    "strconv",
-    "strings",
-    "sync",
-    "syscall",
-    "testing",
-    "text",
-    "time",
-    "unicode",
-    "unsafe",
-    // Go 1.23+ additions
-    "iter",
-    "unique",
-];
-
 /// Returns true if the import source is a standard library module.
 /// Agents can't navigate into stdlib — showing these is noise.
 fn is_stdlib(source: &str, lang: crate::types::Lang) -> bool {
-    use crate::types::Lang;
-    match lang {
-        Lang::Rust => {
-            source.starts_with("std::")
-                || source.starts_with("core::")
-                || source.starts_with("alloc::")
-        }
-        Lang::Python => {
-            // Common stdlib modules — not exhaustive but covers the noisy ones
-            matches!(
-                source.split('.').next().unwrap_or(""),
-                "os" | "sys"
-                    | "re"
-                    | "json"
-                    | "math"
-                    | "time"
-                    | "datetime"
-                    | "pathlib"
-                    | "typing"
-                    | "collections"
-                    | "functools"
-                    | "itertools"
-                    | "abc"
-                    | "io"
-                    | "logging"
-                    | "unittest"
-                    | "dataclasses"
-                    | "enum"
-                    | "copy"
-                    | "hashlib"
-                    | "subprocess"
-                    | "threading"
-                    | "asyncio"
-            )
-        }
-        Lang::Go => GO_STDLIB_ROOTS.contains(&source.split('/').next().unwrap_or(source)),
-        _ => false,
-    }
+    crate::lang::spec::spec(lang).stdlib.matches(source)
 }
 
 /// Returns true if the string looks like a valid module/package path.

--- a/src/search/scope.rs
+++ b/src/search/scope.rs
@@ -7,9 +7,9 @@
 use std::path::Path;
 
 use crate::cache::OutlineCache;
+use crate::lang::elixir::{extract_elixir_definition_name, is_elixir_definition};
 use crate::lang::treesitter::{
-    extract_definition_name, extract_elixir_definition_name, is_elixir_definition,
-    node_text_simple, DEFINITION_KINDS,
+    extract_definition_name, node_text_simple, NodeTextMode, DEFINITION_KINDS,
 };
 
 /// Type-like node kinds that can enclose a function definition.
@@ -161,7 +161,7 @@ fn elixir_kind_label(node: tree_sitter::Node, lines: &[&str]) -> &'static str {
     let Some(target) = node.child_by_field_name("target") else {
         return "definition";
     };
-    match node_text_simple(target, lines).as_str() {
+    match node_text_simple(target, lines, NodeTextMode::Full).as_str() {
         "defmodule" => "module",
         "defprotocol" => "protocol",
         "defimpl" => "impl",

--- a/src/search/siblings.rs
+++ b/src/search/siblings.rs
@@ -20,7 +20,7 @@ static QUERY_CACHE: LazyLock<Mutex<HashMap<(usize, usize, usize), tree_sitter::Q
 ///
 /// `query_str` must be `'static` so its pointer address is stable across
 /// calls and can serve as part of the cache key.
-fn with_query<R>(
+pub(crate) fn with_query<R>(
     ts_lang: &tree_sitter::Language,
     query_str: &'static str,
     f: impl FnOnce(&tree_sitter::Query) -> R,
@@ -61,37 +61,7 @@ const MAX_SIBLINGS: usize = 6;
 /// Tree-sitter query for self/this field and method references by language.
 /// Each pattern captures `@ref` on the accessed member name.
 fn sibling_query_str(lang: Lang) -> Option<&'static str> {
-    match lang {
-        Lang::Rust => Some(concat!(
-            "(field_expression value: (self) field: (field_identifier) @ref)\n",
-            "(call_expression function: (field_expression value: (self) field: (field_identifier) @ref))\n",
-        )),
-        Lang::Python => Some(
-            "(attribute object: (identifier) @obj attribute: (identifier) @ref)\n",
-        ),
-        Lang::TypeScript | Lang::JavaScript | Lang::Tsx => Some(
-            "(member_expression object: (this) property: (property_identifier) @ref)\n",
-        ),
-        Lang::Java => Some(concat!(
-            "(field_access object: (this) field: (identifier) @ref)\n",
-            "(method_invocation object: (this) name: (identifier) @ref)\n",
-        )),
-        Lang::Scala => Some(concat!(
-            "(field_expression (identifier) @obj (identifier) @ref)\n",
-            "(call_expression function: (field_expression (identifier) @obj (identifier) @ref))\n",
-        )),
-        Lang::Go => Some(
-            "(selector_expression operand: (identifier) @recv field: (field_identifier) @ref)\n",
-        ),
-        Lang::CSharp => Some(concat!(
-            "(member_access_expression expression: (this_expression) name: (identifier) @ref)\n",
-            "(invocation_expression function: (member_access_expression expression: (this_expression) name: (identifier) @ref))\n",
-        )),
-        Lang::Swift => Some(
-            "(navigation_expression target: (self_expression) suffix: (navigation_suffix suffix: (simple_identifier) @ref))\n",
-        ),
-        _ => None,
-    }
+    crate::lang::spec::spec(lang).sibling_query
 }
 
 /// Extract self/this member references from within a definition's line range.
@@ -109,12 +79,12 @@ pub fn extract_sibling_references(content: &str, lang: Lang, def_range: (u32, u3
     };
 
     // For Go, resolve the receiver name before entering the query cache lock to
-    // avoid re-entrancy on `QUERY_CACHE` (extract_go_receiver_name also uses it).
-    let go_receiver = if lang == Lang::Go {
-        extract_go_receiver_name(content, &ts_lang)
-    } else {
-        None
-    };
+    // avoid re-entrancy on `QUERY_CACHE` (the receiver extractor also uses it).
+    // The extractor is supplied per-language via `spec(lang).extract_receiver`
+    // (only Go has one).
+    let go_receiver = crate::lang::spec::spec(lang)
+        .extract_receiver
+        .and_then(|extract| extract(content, &ts_lang));
 
     let mut parser = tree_sitter::Parser::new();
     if parser.set_language(&ts_lang).is_err() {
@@ -211,37 +181,6 @@ pub fn extract_sibling_references(content: &str, lang: Lang, def_range: (u32, u3
     names.sort();
     names.dedup();
     names
-}
-
-/// For Go methods, extract the receiver parameter name from the first method
-/// in the file. Go receiver is the first parameter in `func (r *Type) Name()`.
-fn extract_go_receiver_name(content: &str, ts_lang: &tree_sitter::Language) -> Option<String> {
-    // `'static` so its pointer address is a stable cache key.
-    const GO_RECV_QUERY: &str = "(method_declaration receiver: (parameter_list (parameter_declaration name: (identifier) @recv)))";
-
-    let mut parser = tree_sitter::Parser::new();
-    parser.set_language(ts_lang).ok()?;
-    let tree = parser.parse(content, None)?;
-
-    let bytes = content.as_bytes();
-
-    // `with_query` returns `Option<Option<String>>`; flatten to `Option<String>`.
-    with_query(ts_lang, GO_RECV_QUERY, |query| {
-        let recv_idx = query.capture_index_for_name("recv")?;
-        let mut cursor = tree_sitter::QueryCursor::new();
-        let mut matches = cursor.matches(query, tree.root_node(), bytes);
-
-        if let Some(m) = matches.next() {
-            for cap in m.captures {
-                if cap.index == recv_idx {
-                    return cap.node.utf8_text(bytes).ok().map(String::from);
-                }
-            }
-        }
-
-        None
-    })
-    .flatten()
 }
 
 /// Match extracted sibling names against a parent entry's children.

--- a/src/search/siblings.rs
+++ b/src/search/siblings.rs
@@ -1,49 +1,8 @@
-use std::collections::HashMap;
-use std::sync::{LazyLock, Mutex};
-
 use streaming_iterator::StreamingIterator;
 
 use crate::lang::outline::outline_language;
+use crate::lang::treesitter::with_query;
 use crate::types::{Lang, OutlineEntry, OutlineKind};
-
-/// Global cache of compiled tree-sitter queries for sibling extraction.
-/// Keyed by `(node_kind_count, field_count, query_str_ptr)` so that distinct
-/// query strings for the same language (the main sibling query vs the Go
-/// receiver query) are stored under separate keys. We avoid `Language::name()`
-/// because ABI < 15 grammars (e.g. tree-sitter-kotlin-ng) return `None`.
-#[allow(clippy::type_complexity)]
-static QUERY_CACHE: LazyLock<Mutex<HashMap<(usize, usize, usize), tree_sitter::Query>>> =
-    LazyLock::new(|| Mutex::new(HashMap::new()));
-
-/// Look up or compile `query_str` for `ts_lang`, then invoke `f` with a
-/// reference to the cached `Query`.  Returns `None` if compilation fails.
-///
-/// `query_str` must be `'static` so its pointer address is stable across
-/// calls and can serve as part of the cache key.
-pub(crate) fn with_query<R>(
-    ts_lang: &tree_sitter::Language,
-    query_str: &'static str,
-    f: impl FnOnce(&tree_sitter::Query) -> R,
-) -> Option<R> {
-    use std::collections::hash_map::Entry;
-    // Pointer address distinguishes different queries for the same language.
-    let key = (
-        ts_lang.node_kind_count(),
-        ts_lang.field_count(),
-        query_str.as_ptr() as usize,
-    );
-    let mut cache = QUERY_CACHE
-        .lock()
-        .unwrap_or_else(std::sync::PoisonError::into_inner);
-    let query = match cache.entry(key) {
-        Entry::Occupied(e) => e.into_mut(),
-        Entry::Vacant(e) => {
-            let q = tree_sitter::Query::new(ts_lang, query_str).ok()?;
-            e.insert(q)
-        }
-    };
-    Some(f(query))
-}
 
 /// A sibling field or method resolved from the same parent struct/class/impl.
 #[derive(Debug)]

--- a/src/search/strip.rs
+++ b/src/search/strip.rs
@@ -18,9 +18,11 @@ use crate::types::FileType;
 /// non-code), so they are mapped to the JS/TS family here to preserve the
 /// historical strip behavior for those files.
 fn detect_lang(path: &Path) -> Option<StripFamily> {
-    if let FileType::Code(lang) = detect_file_type(path) {
-        if let Some(family) = spec(lang).strip_family {
-            return Some(family);
+    if path.extension().is_some() {
+        if let FileType::Code(lang) = detect_file_type(path) {
+            if let Some(family) = spec(lang).strip_family {
+                return Some(family);
+            }
         }
     }
     match path.extension()?.to_str()? {
@@ -295,6 +297,13 @@ mod tests {
     fn ruby_not_supported() {
         let content = "def foo\n  puts 'hi'\nend\n";
         let skip = strip_noise(content, &path("rb"), Some((1, 3)));
+        assert!(skip.is_empty());
+    }
+
+    #[test]
+    fn extensionless_bash_dotfile_not_stripped() {
+        let content = "# just a comment\necho hi\n";
+        let skip = strip_noise(content, &PathBuf::from(".bashrc"), Some((1, 2)));
         assert!(skip.is_empty());
     }
 

--- a/src/search/strip.rs
+++ b/src/search/strip.rs
@@ -6,28 +6,25 @@
 use std::collections::HashSet;
 use std::path::Path;
 
-/// Language classification for stripping rules.
-#[derive(Debug, Clone, Copy)]
-enum StripLang {
-    Rust,
-    Python,
-    Go,
-    JsTs,
-    JavaKotlinCSharp,
-    CppC,
-    Bash,
-}
+use crate::lang::detect_file_type;
+use crate::lang::spec::{spec, StripFamily};
+use crate::types::FileType;
 
-/// Detect stripping language from file extension.
-fn detect_lang(path: &Path) -> Option<StripLang> {
+/// Detect the stripping comment-syntax family for a file.
+///
+/// Routes through `detect_file_type` → `spec(lang).strip_family` for every
+/// extension the detector recognises. The `.mjs` / `.cjs` extensions are
+/// JavaScript that `detect_file_type` does not classify (it treats them as
+/// non-code), so they are mapped to the JS/TS family here to preserve the
+/// historical strip behavior for those files.
+fn detect_lang(path: &Path) -> Option<StripFamily> {
+    if let FileType::Code(lang) = detect_file_type(path) {
+        if let Some(family) = spec(lang).strip_family {
+            return Some(family);
+        }
+    }
     match path.extension()?.to_str()? {
-        "rs" => Some(StripLang::Rust),
-        "py" | "pyi" => Some(StripLang::Python),
-        "go" => Some(StripLang::Go),
-        "js" | "jsx" | "ts" | "tsx" | "mjs" | "cjs" => Some(StripLang::JsTs),
-        "java" | "kt" | "kts" | "cs" | "scala" | "sc" => Some(StripLang::JavaKotlinCSharp),
-        "c" | "h" | "cpp" | "hpp" | "cc" | "cxx" => Some(StripLang::CppC),
-        "sh" | "bash" | "bats" => Some(StripLang::Bash),
+        "mjs" | "cjs" => Some(StripFamily::JsTs),
         _ => None,
     }
 }
@@ -93,9 +90,9 @@ pub(crate) fn strip_noise(
 /// Returns `true` if the line is a debug/trace logging statement that should
 /// be stripped. Only matches lines that are *only* a log call (not part of a
 /// larger expression).
-fn is_debug_log(trimmed: &str, lang: StripLang) -> bool {
+fn is_debug_log(trimmed: &str, lang: StripFamily) -> bool {
     match lang {
-        StripLang::Rust => {
+        StripFamily::Rust => {
             trimmed.starts_with("log::debug!")
                 || trimmed.starts_with("log::trace!")
                 || trimmed.starts_with("tracing::debug!")
@@ -104,14 +101,14 @@ fn is_debug_log(trimmed: &str, lang: StripLang) -> bool {
                 || trimmed.starts_with("trace!(")
                 || trimmed.starts_with("dbg!(")
         }
-        StripLang::Python => {
+        StripFamily::Python => {
             trimmed.starts_with("logger.debug(")
                 || trimmed.starts_with("logging.debug(")
                 || trimmed.starts_with("print(")
                 || trimmed.starts_with("pprint(")
                 || trimmed.starts_with("pprint.pprint(")
         }
-        StripLang::Go => {
+        StripFamily::Go => {
             trimmed.starts_with("log.Printf(")
                 || trimmed.starts_with("log.Println(")
                 || trimmed.starts_with("log.Print(")
@@ -119,12 +116,12 @@ fn is_debug_log(trimmed: &str, lang: StripLang) -> bool {
                 || trimmed.starts_with("fmt.Println(")
                 || trimmed.starts_with("fmt.Print(")
         }
-        StripLang::JsTs => {
+        StripFamily::JsTs => {
             trimmed.starts_with("console.log(")
                 || trimmed.starts_with("console.debug(")
                 || trimmed.starts_with("console.trace(")
         }
-        StripLang::JavaKotlinCSharp => {
+        StripFamily::JavaKotlinCSharp => {
             // Java: System.out.println, logger.debug, log.debug
             trimmed.starts_with("System.out.print")
                 || trimmed.starts_with("logger.debug(")
@@ -132,14 +129,14 @@ fn is_debug_log(trimmed: &str, lang: StripLang) -> bool {
                 || trimmed.starts_with("Log.d(")
                 || trimmed.starts_with("println(") // Kotlin, Scala
         }
-        StripLang::CppC => {
+        StripFamily::CppC => {
             trimmed.starts_with("printf(")
                 || trimmed.starts_with("std::cout")
                 || trimmed.starts_with("cout ")
                 || trimmed.starts_with("cout<<")
         }
         // Only strip echo lines explicitly labelled DEBUG — plain echo is functional output.
-        StripLang::Bash => {
+        StripFamily::Bash => {
             trimmed.starts_with("echo \"DEBUG") || trimmed.starts_with("echo 'DEBUG")
         }
     }
@@ -155,9 +152,9 @@ const KEEP_MARKERS: &[&str] = &["TODO", "FIXME", "NOTE", "HACK", "SAFETY", "WARN
 /// in any language — matching is per-line on the trimmed prefix, so a block
 /// comment's interior lines have no comment prefix and survive. Stripping them
 /// needs multi-line state tracking across lines, which this pass does not do.
-fn is_strippable_comment(trimmed: &str, lang: StripLang) -> bool {
+fn is_strippable_comment(trimmed: &str, lang: StripFamily) -> bool {
     let is_comment = match lang {
-        StripLang::Rust => {
+        StripFamily::Rust => {
             // Doc comments: `///`, `//!`, `/** */`, `#[doc`
             if trimmed.starts_with("///")
                 || trimmed.starts_with("//!")
@@ -168,29 +165,29 @@ fn is_strippable_comment(trimmed: &str, lang: StripLang) -> bool {
             }
             trimmed.starts_with("//")
         }
-        StripLang::Python => {
+        StripFamily::Python => {
             // Doc strings: `"""`, `'''`
             if trimmed.starts_with("\"\"\"") || trimmed.starts_with("'''") {
                 return false;
             }
             trimmed.starts_with('#')
         }
-        StripLang::Go => trimmed.starts_with("//"),
-        StripLang::JsTs => {
+        StripFamily::Go => trimmed.starts_with("//"),
+        StripFamily::JsTs => {
             // Doc comments: `/**`, `* ` (JSDoc continuation)
             if trimmed.starts_with("/**") || trimmed.starts_with("* ") || trimmed == "*/" {
                 return false;
             }
             trimmed.starts_with("//")
         }
-        StripLang::JavaKotlinCSharp => {
+        StripFamily::JavaKotlinCSharp => {
             // Doc comments: `/**`, `///` (C#)
             if trimmed.starts_with("/**") || trimmed.starts_with("///") {
                 return false;
             }
             trimmed.starts_with("//")
         }
-        StripLang::CppC => {
+        StripFamily::CppC => {
             // Doxygen: `/**`, `///`, `//!`
             if trimmed.starts_with("/**")
                 || trimmed.starts_with("///")
@@ -200,7 +197,7 @@ fn is_strippable_comment(trimmed: &str, lang: StripLang) -> bool {
             }
             trimmed.starts_with("//")
         }
-        StripLang::Bash => {
+        StripFamily::Bash => {
             // Keep shebangs (`#!`) and any line-comment starting with `#!`.
             if trimmed.starts_with("#!") {
                 return false;

--- a/src/search/symbol.rs
+++ b/src/search/symbol.rs
@@ -5,10 +5,10 @@ use std::sync::Mutex;
 use std::time::SystemTime;
 
 use super::file_metadata;
+use crate::lang::elixir::is_elixir_definition;
+use crate::lang::spec::{spec, DefinitionOps, DEFAULT_DEFS, DEFAULT_DEF_KINDS};
 use crate::lang::treesitter::{
-    definition_weight, elixir_definition_weight, extract_definition_name,
-    extract_elixir_definition_name, extract_impl_trait, extract_impl_type,
-    extract_implemented_interfaces, is_elixir_definition, DEFINITION_KINDS,
+    extract_definition_name, extract_impl_trait, extract_impl_type, extract_implemented_interfaces,
 };
 
 use crate::error::TilthError;
@@ -338,9 +338,21 @@ fn walk_for_definitions(
 
     let kind = node.kind();
 
-    if DEFINITION_KINDS.contains(&kind) {
+    // Definition kinds and name/weight ops come from the per-language spec. For
+    // a known language these are `spec(lang).definition_kinds` / `.definitions`
+    // (the shared defaults for every language except Elixir, which carries its
+    // own); when `lang` is unknown we fall back to the shared defaults.
+    let (def_kinds, def_ops): (&[&str], &DefinitionOps) = match lang {
+        Some(l) => {
+            let s = spec(l);
+            (s.definition_kinds, &s.definitions)
+        }
+        None => (DEFAULT_DEF_KINDS, &DEFAULT_DEFS),
+    };
+
+    if def_kinds.contains(&kind) {
         // Check if this node defines the queried symbol
-        if let Some(name) = extract_definition_name(node, lines) {
+        if let Some(name) = (def_ops.extract_name)(node, lines) {
             if name == query {
                 let line_num = node.start_position().row as u32 + 1;
                 let line_text = lines
@@ -360,7 +372,7 @@ fn walk_for_definitions(
                         node.end_position().row as u32 + 1,
                     )),
                     def_name: Some(query.to_string()),
-                    def_weight: definition_weight(node.kind()),
+                    def_weight: (def_ops.weight)(node, lines),
                     impl_target: None,
                 });
             }
@@ -425,8 +437,9 @@ fn walk_for_definitions(
             }
         }
     } else if lang == Some(crate::types::Lang::Elixir) && is_elixir_definition(node, lines) {
-        // Elixir: definitions are `call` nodes — check separately
-        if let Some(name) = extract_elixir_definition_name(node, lines) {
+        // Elixir: definitions are `call` nodes — check separately. Name and
+        // weight come from `spec(Elixir).definitions` via `def_ops`.
+        if let Some(name) = (def_ops.extract_name)(node, lines) {
             if name == query {
                 let line_num = node.start_position().row as u32 + 1;
                 let line_text = lines
@@ -446,7 +459,7 @@ fn walk_for_definitions(
                         node.end_position().row as u32 + 1,
                     )),
                     def_name: Some(query.to_string()),
-                    def_weight: elixir_definition_weight(node, lines),
+                    def_weight: (def_ops.weight)(node, lines),
                     impl_target: None,
                 });
             }

--- a/src/types.rs
+++ b/src/types.rs
@@ -50,27 +50,7 @@ impl Lang {
     /// Lexers that scan `'` must disambiguate a lifetime from a single-quoted
     /// literal; only Rust needs the lifetime branch.
     pub(crate) fn has_lifetimes(self) -> bool {
-        match self {
-            Lang::Rust => true,
-            Lang::TypeScript
-            | Lang::Tsx
-            | Lang::JavaScript
-            | Lang::Python
-            | Lang::Go
-            | Lang::Java
-            | Lang::Scala
-            | Lang::C
-            | Lang::Cpp
-            | Lang::Ruby
-            | Lang::Php
-            | Lang::Swift
-            | Lang::Kotlin
-            | Lang::CSharp
-            | Lang::Elixir
-            | Lang::Bash
-            | Lang::Dockerfile
-            | Lang::Make => false,
-        }
+        crate::lang::spec::spec(self).has_lifetimes
     }
 }
 


### PR DESCRIPTION
Consolidates per-language dispatch and data into a LangSpec table: `src/lang/spec.rs` plus 19 per-language modules, with a `NodeTextMode` parameter and all consumer seams converted. Zero behavior change — verified against the old match arms.

Part of the fork-divergence port (G1). Reviewed via fresh-context taste-test; `cargo test`, clippy `-D warnings`, and fmt all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)