### PR TITLE
fix(search): skip .jj/.hg/.svn VCS internal dirs

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -39,6 +39,9 @@ use crate::format::rel;
 // gitignored files (docs/, configs, generated code) are still searchable.
 pub(crate) const SKIP_DIRS: &[&str] = &[
     ".git",
+    ".jj",
+    ".hg",
+    ".svn",
     "node_modules",
     "target",
     "dist",
@@ -1574,6 +1577,31 @@ mod tests {
         let exts = extensions(&all);
         assert!(exts.contains("rs"), "expected .rs files, got {exts:?}");
         assert!(!all.is_empty());
+    }
+
+    #[test]
+    fn walker_skips_vcs_internal_dirs() {
+        // `.jj`/`.hg`/`.svn` are VCS internals like `.git` — never source.
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join("real.rs"), "fn main() {}").unwrap();
+        for vcs in [".jj", ".hg", ".svn"] {
+            let dir = tmp.path().join(vcs);
+            std::fs::create_dir(&dir).unwrap();
+            std::fs::write(dir.join("store.rs"), "fn buried() {}").unwrap();
+        }
+
+        let names: Vec<String> = walk_paths(tmp.path(), None)
+            .iter()
+            .filter_map(|p| Some(p.file_name()?.to_str()?.to_string()))
+            .collect();
+        assert!(
+            names.contains(&"real.rs".to_string()),
+            "source file must be found: {names:?}"
+        );
+        assert!(
+            !names.contains(&"store.rs".to_string()),
+            "VCS-internal file leaked through the walker: {names:?}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`SKIP_DIRS` skips `.git` but not the other VCS internal directories.
In a jj-colocated repo (`jj` over git), the entire `.jj` object store —
easily thousands of files — gets walked on every search, outline, and
glob. `.hg` (Mercurial) and `.svn` (Subversion) are the same class of
internal store. This adds all three next to `.git`; they're VCS
internals, never source, exactly as the list's own comment frames it.

Repro (before this change):

    mkdir /tmp/jjrepo && cd /tmp/jjrepo
    git init -q && jj git init --colocate -q   # creates a large .jj/ store
    echo 'fn main() {}' > main.rs
    tilth "*" --scope .                        # .jj/**/* is walked and counted

After: the `.jj` tree is skipped, the same as `.git`.

## Test plan

Adds `walker_skips_vcs_internal_dirs`: a tempdir with `.jj`/`.hg`/`.svn`
subdirs, each holding a source file, asserts the walker returns the
top-level source and none of the buried files.

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
