### PR TITLE
fix(search): make glob file selection deterministic

### DIFF
--- a/src/search/glob.rs
+++ b/src/search/glob.rs
@@ -29,16 +29,14 @@ pub fn search(pattern: &str, scope: &Path) -> Result<GlobResult, TilthError> {
     })?;
     let matcher = glob.compile_matcher();
 
-    let files: std::sync::Mutex<Vec<GlobFileEntry>> = std::sync::Mutex::new(Vec::new());
-    let total_found = std::sync::atomic::AtomicUsize::new(0);
+    let matched: std::sync::Mutex<Vec<PathBuf>> = std::sync::Mutex::new(Vec::new());
     let extensions: std::sync::Mutex<HashSet<String>> = std::sync::Mutex::new(HashSet::new());
 
     let walker = super::walker(scope, None)?;
 
     walker.run(|| {
         let matcher = &matcher;
-        let files = &files;
-        let total_found = &total_found;
+        let matched = &matched;
         let extensions = &extensions;
 
         Box::new(move |entry| {
@@ -65,31 +63,36 @@ pub fn search(pattern: &str, scope: &Path) -> Result<GlobResult, TilthError> {
             let rel = path.strip_prefix(scope).unwrap_or(path);
 
             if matcher.is_match(name) || matcher.is_match(rel) {
-                total_found.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                // Compute preview outside the lock, then check-and-push in one acquisition
-                let preview = file_preview(path);
-                let mut locked = files
+                matched
                     .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner);
-                if locked.len() < MAX_FILES {
-                    locked.push(GlobFileEntry {
-                        path: path.to_path_buf(),
-                        preview,
-                    });
-                }
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(path.to_path_buf());
             }
 
             ignore::WalkState::Continue
         })
     });
 
-    let total = total_found.load(std::sync::atomic::Ordering::Relaxed);
-    let files = files
+    let mut matched = matched
         .into_inner()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
     let extensions = extensions
         .into_inner()
         .unwrap_or_else(std::sync::PoisonError::into_inner);
+
+    let total = matched.len();
+
+    // WalkParallel visits files in nondeterministic order; sort before capping
+    // so the selected subset is stable. Previews are computed only for survivors.
+    matched.sort();
+    matched.truncate(MAX_FILES);
+    let files: Vec<GlobFileEntry> = matched
+        .into_iter()
+        .map(|path| {
+            let preview = file_preview(&path);
+            GlobFileEntry { path, preview }
+        })
+        .collect();
 
     let available_extensions: Vec<String> = if files.is_empty() {
         let mut exts: Vec<String> = extensions.into_iter().collect();
@@ -113,4 +116,57 @@ fn file_preview(path: &Path) -> Option<String> {
     let meta = std::fs::metadata(path).ok()?;
     let tokens = estimate_tokens(meta.len());
     Some(format!("~{tokens} tokens"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_selection_is_deterministic_and_sorted() {
+        // More matches than MAX_FILES so the cap engages.
+        let tmp = tempfile::tempdir().unwrap();
+        for i in 0..(MAX_FILES + 15) {
+            std::fs::write(tmp.path().join(format!("f{i:03}.rs")), "fn main() {}").unwrap();
+        }
+
+        let first: Vec<PathBuf> = search("*.rs", tmp.path())
+            .unwrap()
+            .files
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+        let second: Vec<PathBuf> = search("*.rs", tmp.path())
+            .unwrap()
+            .files
+            .into_iter()
+            .map(|f| f.path)
+            .collect();
+
+        // The cap must select the lexicographically smallest matches, sorted —
+        // the same set every run, regardless of parallel walk order.
+        let expected: Vec<PathBuf> = (0..MAX_FILES)
+            .map(|i| tmp.path().join(format!("f{i:03}.rs")))
+            .collect();
+        assert_eq!(
+            first, expected,
+            "capped set must be deterministic and sorted"
+        );
+        assert_eq!(first, second, "two identical runs must return the same set");
+    }
+
+    #[test]
+    fn glob_total_found_counts_every_match() {
+        let tmp = tempfile::tempdir().unwrap();
+        for i in 0..(MAX_FILES + 5) {
+            std::fs::write(tmp.path().join(format!("g{i:03}.rs")), "fn main() {}").unwrap();
+        }
+        let result = search("*.rs", tmp.path()).unwrap();
+        assert_eq!(result.files.len(), MAX_FILES, "file list stays capped");
+        assert_eq!(
+            result.total_found,
+            MAX_FILES + 5,
+            "total_found reports the full match count"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Glob matches are pushed into a `Mutex<Vec>` from `WalkParallel` under an
`if len < MAX_FILES` cap. Because the parallel walk visits files in a
nondeterministic order, two identical glob runs return different 20-file
subsets of the same match set. This collects every match, sorts by path,
then caps — the returned files are now the lexicographically smallest
matches in sorted order, stable across runs.

Output shape is unchanged beyond that determinism: `total_found` still
counts every match, the "… and N more files" tail is unchanged, and
previews are now computed only for the surviving files instead of for
every match before the cap.

Repro (before this change):

    cd a-repo-with-more-than-20-matches
    tilth '*.rs' > a.txt
    tilth '*.rs' > b.txt
    diff a.txt b.txt   # differs run to run

Overlaps with #186 in `glob.rs`; happy to rebase whichever lands second.

## Test plan

- `glob_selection_is_deterministic_and_sorted`: 35 matching files, asserts
  two runs return the identical set and that it's the sorted first-20.
- `glob_total_found_counts_every_match`: asserts the list stays capped at
  `MAX_FILES` while `total_found` reports the full count.

- [x] `cargo fmt --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
