### PR TITLE
chore: issue-tail batch — MCP snippet (#42), release-notes fix (#189), scope guidance (#195)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,10 @@ jobs:
           files: |
             tilth-*.tar.gz
             tilth-*.zip
-          generate_release_notes: true
+          # Notes on ONE leg only: when the release already exists, the action
+          # appends freshly generated notes to the current body, so every extra
+          # matrix leg adds another "What's Changed" copy (#189).
+          generate_release_notes: ${{ matrix.target == 'x86_64-unknown-linux-musl' }}
 
   # After all builds, publish to crates.io
   publish-crate:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- generated from prompts/mcp-base.md + prompts/mcp-edit.md by scripts/regen-agents-md.sh — do not edit directly -->
 tilth — code intelligence MCP server. Replaces grep, cat, find, ls with AST-aware equivalents.
 
-PATHS: DO NOT pass a relative path or scope without also setting root (absolute) — the server cannot see your shell cwd, so bare relative paths are refused. Absolute paths always work; omitting path/scope searches the project the server was launched in.
+PATHS: DO NOT pass a relative path or scope without also setting root (absolute) — the server cannot see your shell cwd, so bare relative paths are refused. Absolute paths always work; omitting path/scope searches the project the server was launched in. DO NOT pass a file as scope — scope is a directory; to search one file, set glob to that file's path.
 
 To explore code, always search first. tilth_search finds definitions, usages, and file locations in one call.
 Usage: tilth_search(query: "handleRequest").

--- a/README.md
+++ b/README.md
@@ -218,6 +218,21 @@ Add `--edit` to enable hash-anchored file editing (see [Edit mode](#edit-mode)):
 tilth install claude-code --edit
 ```
 
+For any MCP client not in the list, the server entry is the same everywhere — only the config file location and top-level key vary (`mcpServers` for most hosts, `amp.mcpServers` for Amp, TOML syntax for Codex):
+
+```json
+{
+  "mcpServers": {
+    "tilth": {
+      "command": "tilth",
+      "args": ["--mcp"]
+    }
+  }
+}
+```
+
+For edit mode, use `"args": ["--mcp", "--edit"]`.
+
 Or call it from bash — see [AGENTS.md](./AGENTS.md) for the MCP agent prompt, or [skills/SKILL.md](./skills/SKILL.md) for a Claude Code skill prompt.
 
 ### Smaller models

--- a/prompts/mcp-base.md
+++ b/prompts/mcp-base.md
@@ -1,6 +1,6 @@
 tilth — code intelligence MCP server. Replaces grep, cat, find, ls with AST-aware equivalents.
 
-PATHS: DO NOT pass a relative path or scope without also setting root (absolute) — the server cannot see your shell cwd, so bare relative paths are refused. Absolute paths always work; omitting path/scope searches the project the server was launched in.
+PATHS: DO NOT pass a relative path or scope without also setting root (absolute) — the server cannot see your shell cwd, so bare relative paths are refused. Absolute paths always work; omitting path/scope searches the project the server was launched in. DO NOT pass a file as scope — scope is a directory; to search one file, set glob to that file's path.
 
 To explore code, always search first. tilth_search finds definitions, usages, and file locations in one call.
 Usage: tilth_search(query: "handleRequest").

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -512,7 +512,7 @@ mod tests {
     fn server_instructions_byte_lock() {
         assert_eq!(
             SERVER_INSTRUCTIONS.len(),
-            1295,
+            1399,
             "SERVER_INSTRUCTIONS byte count drifted from baseline"
         );
         assert!(SERVER_INSTRUCTIONS
@@ -528,6 +528,10 @@ mod tests {
                 "DO NOT pass a relative path or scope without also setting root (absolute)"
             ),
             "require-root path discipline must lead the file-I/O guidance"
+        );
+        assert!(
+            SERVER_INSTRUCTIONS.contains("DO NOT pass a file as scope — scope is a directory"),
+            "file-valued-scope steering (#195) must stay in the PATHS guidance"
         );
         // De-dup (R1) moved per-tool usage into the schemas. Lock that the
         // native-vs-tilth steering for weaker models stays verbatim, and that the

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -69,7 +69,6 @@ pub(crate) const SKIP_DIRS: &[&str] = &[
     ".gradle",
     ".idea",
     ".scala-build",
-    "target",
     ".bloop",
     ".metals",
 ];


### PR DESCRIPTION
Three long-standing issues addressed in one hygiene pass:

- **#42** (March): the reporter-approved generic MCP config snippet lands in the README's MCP server section — the host-key variations and the `--edit` args shape, verbatim as agreed.
- **#189**: release notes appeared 4× because all five platform legs call the release action with `generate_release_notes: true`, and the action *appends* generated notes to an existing release body — every extra leg added another "What's Changed" (4-not-5 is two legs racing). Fixed: one canonical leg generates notes; the rest only upload artifacts. Unprovable without a tag — the next release is the test, and the watch-item is stated in the workflow comment.
- **#195** (partial): "DO NOT pass a file as scope — scope is a directory; to search one file, set glob to that file's path" joins the PATHS guidance (byte-locks updated, AGENTS.md regenerated). This was the one suggestion with a real observed failure and no recovery guidance at any surface. Co-authored-by: Quarrel.
- Plus a two-line dedupe of the duplicate `"target"` entry in SKIP_DIRS.

Full replies with the taken/deferred reasoning follow on each issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)