### PR TITLE
chore(release): bump version to 0.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "tilth"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/index.html
+++ b/index.html
@@ -785,7 +785,7 @@ footer h4 { color: #FAF5E9; font-size: 1.05rem; margin-bottom: 16px; }
         <div class="status-grid">
           <div class="status-cell">
             <div class="label">version</div>
-            <div class="val">0.9.0</div>
+            <div class="val">0.10.0</div>
           </div>
           <div class="status-cell">
             <div class="label">languages</div>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"


### PR DESCRIPTION
Version bump for the 0.10.0 cut — Cargo.toml, npm/package.json, and the landing-page badge, per the release convention. Tag follows the merge.

Highlights riding this release: the per-language spec table, `tilth_files` → `tilth_list` (one-release dispatch alias included), deterministic glob selection, VCS-internal dir skips, binary-file handling in glob previews and grok (with the decode DoS bound), `tilth_diff` root anchoring (closes the wrong-checkout hazard, #201), and the concurrent-write hardening that fixes the SIGBUS server crash and silent lost updates (#202). CI now lints test targets; the whole tree passes the tightened gate.

Note for the release run itself: this is the first tag since the release-notes duplication fix (#189) — expect exactly one "What's Changed" section; if the x86_64-linux leg fails, notes will be missing rather than duplicated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)