### PR TITLE
chore(release): 0.10.1 — fix the npm publish leg

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,10 +134,11 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # ratchet:actions/checkout@v6
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # ratchet:actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           registry-url: https://registry.npmjs.org
-      # Trusted publishing needs npm >= 11.5.1 (node 20 ships npm 10.x).
-      - run: npm install -g npm@latest
+      # Trusted publishing needs npm >= 11.5.1. Major-pinned: `latest` moved to
+      # npm 12, which requires a newer node than the runner guarantees.
+      - run: npm install -g npm@11
       # Primary package: unscoped `tilth`
       - run: npm publish ./npm
       # Anchor the @plotplot org: dual-publish the SAME artifact as `@plotplot/tilth`.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -848,7 +848,7 @@ dependencies = [
 
 [[package]]
 name = "tilth"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tilth"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 description = "Tree-sitter indexed lookups — smart code reading for AI agents"
 license = "MIT"

--- a/index.html
+++ b/index.html
@@ -785,7 +785,7 @@ footer h4 { color: #FAF5E9; font-size: 1.05rem; margin-bottom: 16px; }
         <div class="status-grid">
           <div class="status-cell">
             <div class="label">version</div>
-            <div class="val">0.10.0</div>
+            <div class="val">0.10.1</div>
           </div>
           <div class="status-cell">
             <div class="label">languages</div>

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilth",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Tree-sitter indexed lookups — smart code reading for AI agents",
   "bin": {
     "tilth": "run.js"


### PR DESCRIPTION
v0.10.0's publish-npm leg failed on `npm install -g npm@latest` (npm 12 requires node ≥22; the job pins node 20). All five platform builds and the crates.io publish succeeded, and the release-notes fix verified (exactly one What's Changed). This cut: node 24 + major-pinned npm@11 in the workflow, version bumped to 0.10.1 so npm gets a clean publish. npm jumps 0.9.0 → 0.10.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)